### PR TITLE
Fix breaking up chat strings when newlines are involved.

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
@@ -86,9 +86,9 @@ public class LocalChatPaginator extends ChatPaginator {
             }
         }
 
-        String result = String.join("", lastFormats.stream()
+        String result = lastFormats.stream()
                 .map(ChatColor::toString)
-                .collect(Collectors.toList()));
+                .collect(Collectors.joining(""));
 
         if (lastColor != null) {
             result = lastColor.toString() + result;
@@ -166,8 +166,11 @@ public class LocalChatPaginator extends ChatPaginator {
 
             if (c == '\n') {
                 // NewLine forces a new line
+                line.append(' ');
+                line.append(word);
                 lines.add(line.toString());
                 line = new StringBuilder();
+                word = new StringBuilder();
                 lineWidth = 0;
                 continue;
             }


### PR DESCRIPTION
Previously the presence of a newline would not wrap properly.  

We now add a space, the word we are working on and then cleanly start a new line.

This also doubles as a test of new repository location.