### PR TITLE
fixed connecting to MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AchievementCondition is replaced with AdvancementCondition
 - Renamed objective Potion to Brew
 - Renamed 'monsters' condition to 'entities'
+- new config option mysql.enabled
+    - if you already have an installation, you can add this manually to get rid of the mysql warning during startup
 ### Deprecated
 ### Removed
 - Removed Deprecated Exceptions

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -354,13 +354,14 @@ public class BetonQuest extends JavaPlugin {
 
         // try to connect to database
         LogUtils.getLogger().log(Level.FINE, "Connecting to MySQL database");
-        this.database = new MySQL(this, getConfig().getString("mysql.host"),
-                getConfig().getString("mysql.port"),
-                getConfig().getString("mysql.base"), getConfig().getString("mysql.user"),
-                getConfig().getString("mysql.pass"));
-
-        // try to connect to MySQL
-        final Connection con = database.getConnection();
+        Connection con = null;
+        if(getConfig().getBoolean("mysql.enabled", true)) {
+            this.database = new MySQL(this, getConfig().getString("mysql.host"),
+                    getConfig().getString("mysql.port"),
+                    getConfig().getString("mysql.base"), getConfig().getString("mysql.user"),
+                    getConfig().getString("mysql.pass"));
+            con = database.getConnection();
+        }
         if (con != null) {
             LogUtils.getLogger().log(Level.INFO, "Using MySQL for storing data!");
             isMySQLUsed = true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 version: v59
 mysql:
+  enabled: false
   host: ''
   port: ''
   user: ''


### PR DESCRIPTION
New config option to disable mysql.
If you already have an installation, you can add `mysql.enabled` manually to get rid of the mysql warning during startup.