### PR TITLE
rework of ExperienceCondition, ExperienceEvent and ExperienceObjective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option check_interval for holograms in custom.yml andd added GlobalVariable support
 - Added deletepoint event to delete player points
 - Added mythicmobdistance condition that will check if a specific MythicMobs entity is near the player
+- added level argument to 'experience' objective and condition
 ### Changed
 - devbuilds always show notifications for new devbuilds, even when the user is not on a _DEV strategy
 - Items for HolographicDisplays are now defines in items.yml
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AchievementCondition is replaced with AdvancementCondition
 - Renamed objective Potion to Brew
 - Renamed 'monsters' condition to 'entities'
+- Renamed 'xp' event to 'experience'
 - new config option mysql.enabled
     - if you already have an installation, you can add this manually to get rid of the mysql warning during startup
 ### Deprecated

--- a/documentation/User-Documentation/Conditions-List.md
+++ b/documentation/User-Documentation/Conditions-List.md
@@ -112,11 +112,11 @@ with the name of the required entity. Replace all spaces with `_` here. You can 
 
 ## Experience: `experience`
 
-This condition is met when the player has a specified level (default minecraft experience). It is measured by full levels, not experience points. The instruction string must contain an integer argument.
+This condition is met when the player has a specified amount of experience points. If you want to check for whole levels for a player add the `level` argument.
 
 !!! example
     ```YAML
-    experience 30
+    experience 30 level
     ```
 
 ## Facing direction: `facing`

--- a/documentation/User-Documentation/Conditions-List.md
+++ b/documentation/User-Documentation/Conditions-List.md
@@ -112,7 +112,7 @@ with the name of the required entity. Replace all spaces with `_` here. You can 
 
 ## Experience: `experience`
 
-This condition is met when the player has a specified amount of experience points. If you want to check for whole levels for a player add the `level` argument or `l` for short.
+This condition is met when the player has the specified amount of experience points. You can check for whole levels by adding the `level` argument.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Conditions-List.md
+++ b/documentation/User-Documentation/Conditions-List.md
@@ -112,7 +112,7 @@ with the name of the required entity. Replace all spaces with `_` here. You can 
 
 ## Experience: `experience`
 
-This condition is met when the player has a specified amount of experience points. If you want to check for whole levels for a player add the `level` argument.
+This condition is met when the player has a specified amount of experience points. If you want to check for whole levels for a player add the `level` argument or `l` for short.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Events-List.md
+++ b/documentation/User-Documentation/Events-List.md
@@ -518,7 +518,7 @@ Sets weather. The argument is `sun`, `rain` or `storm`.
     
 ## Give experience: `experience`
 
-Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument.
+Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument or `l` for short.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Events-List.md
+++ b/documentation/User-Documentation/Events-List.md
@@ -518,7 +518,7 @@ Sets weather. The argument is `sun`, `rain` or `storm`.
     
 ## Give experience: `experience`
 
-Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument or `l` for short.
+Gives the specified amount of experience points to the player. You can give whole levels by adding the `level` argument.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Events-List.md
+++ b/documentation/User-Documentation/Events-List.md
@@ -516,11 +516,11 @@ Sets weather. The argument is `sun`, `rain` or `storm`.
     weather rain
     ```
     
-## Give experience: `xp`
+## Give experience: `experience`
 
 Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument.
 
 !!! example
     ```YAML
-    xp 4 level
+    experience 4 level
     ```

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -82,7 +82,7 @@ This objectie is completed when the player enchants specified item with specifie
 
 ## Experience: `experience`
 
-This objective can by completed by reaching specified amount of experience points. If you want to check for whole levels for a player add the `level` argument. The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again.
+This objective can by completed by reaching specified amount of experience points. If you want to check for whole levels for a player add the `level` argument or `l` for short. The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -82,7 +82,7 @@ This objectie is completed when the player enchants specified item with specifie
 
 ## Experience: `experience`
 
-This objective can by completed by reaching specified amount of experience points. If you want to check for whole levels for a player add the `level` argument or `l` for short. The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again.
+This objective can by completed by reaching specified amount of experience points. You can check for whole levels by adding the `level` argument. The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again.
 
 !!! example
     ```YAML

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -82,11 +82,11 @@ This objectie is completed when the player enchants specified item with specifie
 
 ## Experience: `experience`
 
-This objective can by completed by reaching specified level (default Minecraft experience, whole levels). The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again. Instruction string consists only from integer - level to reach.
+This objective can by completed by reaching specified amount of experience points. If you want to check for whole levels for a player add the `level` argument. The conditions are checked when the player levels up, so if they are not met the first time, the player will have to meet them and levelup again.
 
 !!! example
     ```YAML
-    experience 25 events:reward
+    experience 25 level events:reward
     ```
 
 ## Delay: `delay`

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -503,7 +503,7 @@ public class BetonQuest extends JavaPlugin {
         registerEvents("language", LanguageEvent.class);
         registerEvents("playsound", PlaysoundEvent.class);
         registerEvents("pickrandom", PickRandomEvent.class);
-        registerEvents("xp", EXPEvent.class);
+        registerEvents("experience", ExperienceEvent.class);
         registerEvents("notify", NotifyEvent.class);
         registerEvents("chat", ChatEvent.class);
 

--- a/src/main/java/pl/betoncraft/betonquest/conditions/ExperienceCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/ExperienceCondition.java
@@ -17,6 +17,7 @@
  */
 package pl.betoncraft.betonquest.conditions;
 
+import org.bukkit.entity.Player;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.api.Condition;
@@ -31,16 +32,24 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
  */
 public class ExperienceCondition extends Condition {
 
-    private final VariableNumber experience;
+    private final VariableNumber amount;
+    private final boolean checkForLevel;
 
     public ExperienceCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
-        experience = instruction.getVarNum();
+        amount = instruction.getVarNum();
+        this.checkForLevel = instruction.hasArgument("level") || instruction.hasArgument("l");
     }
 
     @Override
     protected Boolean execute(final String playerID) throws QuestRuntimeException {
-        return PlayerConverter.getPlayer(playerID).getLevel() >= experience.getInt(playerID);
+        final Player player = PlayerConverter.getPlayer(playerID);
+        final int amount = this.amount.getInt(playerID);
+        if (checkForLevel) {
+            return player.getLevel() >= amount;
+        } else {
+            return player.getTotalExperience() >= amount;
+        }
     }
 
 }

--- a/src/main/java/pl/betoncraft/betonquest/conditions/ExperienceCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/ExperienceCondition.java
@@ -37,8 +37,8 @@ public class ExperienceCondition extends Condition {
 
     public ExperienceCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
-        amount = instruction.getVarNum();
-        this.checkForLevel = instruction.hasArgument("level") || instruction.hasArgument("l");
+        this.amount = instruction.getVarNum();
+        this.checkForLevel = instruction.hasArgument("level");
     }
 
     @Override

--- a/src/main/java/pl/betoncraft/betonquest/config/ConfigUpdater.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/ConfigUpdater.java
@@ -82,7 +82,7 @@ public class ConfigUpdater {
      * Destination version. At the end of the updating process this will be the
      * current version
      */
-    private final String destination = "v61";
+    private final String destination = "v62";
     /**
      * BetonQuest's instance
      */
@@ -199,6 +199,42 @@ public class ConfigUpdater {
         }
         // update again until destination is reached
         update();
+    }
+
+    private void updateFromV61() {
+        LogUtils.getLogger().log(Level.INFO, "Renaming 'xp' event to 'experience'");
+        LogUtils.getLogger().log(Level.INFO, "Adding 'level' argument to 'experience' condition and objective");
+        for (final ConfigPackage pack : Config.getPackages().values()) {
+            LogUtils.getLogger().log(Level.FINE, "  Replacing in '" + pack.getName() + "' package");
+            for (final String key : pack.getEvents().getConfig().getKeys(false)) {
+                final String instruction = pack.getEvents().getConfig().getString(key);
+                if (instruction.startsWith("xp ")) {
+                    LogUtils.getLogger().log(Level.FINE, "    Replacing xp in '" + key + "' event");
+                    pack.getEvents().getConfig().set(key, instruction.replaceFirst("xp ", "experience "));
+                }
+            }
+            for (final String key : pack.getConditions().getConfig().getKeys(false)) {
+                final String instruction = pack.getConditions().getConfig().getString(key);
+                if (instruction.startsWith("experience ")) {
+                    LogUtils.getLogger().log(Level.FINE, "    Adding level argument in '" + key + "' condition");
+                    pack.getConditions().getConfig().set(key, instruction + " level");
+                }
+            }
+            for (final String key : pack.getObjectives().getConfig().getKeys(false)) {
+                final String instruction = pack.getObjectives().getConfig().getString(key);
+                if (instruction.startsWith("experience ")) {
+                    LogUtils.getLogger().log(Level.FINE, "    Adding level argument in '" + key + "' objectives");
+                    pack.getObjectives().getConfig().set(key, instruction + " level");
+                }
+            }
+            pack.getEvents().saveConfig();
+            pack.getConditions().saveConfig();
+            pack.getObjectives().saveConfig();
+        }
+        LogUtils.getLogger().log(Level.INFO, "Successfully renamed 'xp' event to 'experience'");
+        LogUtils.getLogger().log(Level.INFO, "Successfully added 'level' argument to 'experience' conditions and objectives");
+        config.set("version", "v62");
+        instance.saveConfig();
     }
 
     private void updateFromV60() {

--- a/src/main/java/pl/betoncraft/betonquest/events/ExperienceEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/events/ExperienceEvent.java
@@ -38,7 +38,7 @@ public class ExperienceEvent extends QuestEvent {
     public ExperienceEvent(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         this.amount = instruction.getVarNum();
-        this.checkForLevel = instruction.hasArgument("level") || instruction.hasArgument("l");
+        this.checkForLevel = instruction.hasArgument("level");
     }
 
     @Override

--- a/src/main/java/pl/betoncraft/betonquest/events/ExperienceEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/events/ExperienceEvent.java
@@ -30,22 +30,22 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
  *
  * @author Jonas Blocher
  */
-public class EXPEvent extends QuestEvent {
+public class ExperienceEvent extends QuestEvent {
 
     private final VariableNumber amount;
-    private final boolean level;
+    private final boolean checkForLevel;
 
-    public EXPEvent(final Instruction instruction) throws InstructionParseException {
+    public ExperienceEvent(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         this.amount = instruction.getVarNum();
-        this.level = instruction.hasArgument("level") || instruction.hasArgument("l");
+        this.checkForLevel = instruction.hasArgument("level") || instruction.hasArgument("l");
     }
 
     @Override
     protected Void execute(final String playerID) throws QuestRuntimeException {
         final Player player = PlayerConverter.getPlayer(playerID);
         final int amount = this.amount.getInt(playerID);
-        if (level) {
+        if (checkForLevel) {
             player.giveExpLevels(amount);
         } else {
             player.giveExp(amount);

--- a/src/main/java/pl/betoncraft/betonquest/objectives/ExperienceObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/ExperienceObjective.java
@@ -46,7 +46,7 @@ public class ExperienceObjective extends Objective implements Listener {
         if (amount < 1) {
             throw new InstructionParseException("Amount cannot be less than 1");
         }
-        this.checkForLevel = instruction.hasArgument("level") || instruction.hasArgument("l");
+        this.checkForLevel = instruction.hasArgument("level");
     }
 
     @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
- xp event was renamed to experience
- added level argument for objective and condition

If this is accepted, we need to tell the users that comments and empty lines are deleted again.

```
Manuel update guide:
If you have the 'version: v61' in your config.yml and you dont want to lose your comments and empty lines do the following:
1. Change the version to 'v62'
2. rename every 'xp' event to 'experience'
3. add the 'level' argument to every 'experience' condition and objective
```