### PR TITLE
removed ignoreCancelled in ActionObjective event

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/objectives/ActionObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/ActionObjective.java
@@ -21,6 +21,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -37,6 +38,7 @@ import pl.betoncraft.betonquest.utils.LocationData;
 import pl.betoncraft.betonquest.utils.LogUtils;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
+import javax.management.monitor.Monitor;
 import java.util.logging.Level;
 
 /**
@@ -72,7 +74,7 @@ public class ActionObjective extends Objective implements Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onInteract(final PlayerInteractEvent event) {
         // Only fire the event for the main hand to avoid that the event is triggered two times.
         if (event.getHand() == EquipmentSlot.OFF_HAND && event.getHand() != null) {


### PR DESCRIPTION
As part of fixing interaction with QuestItems, it is a new behavior that clicking on blocks with a quest item is ignored. With that PR this is changed back