### PR TITLE
fix getAllNumbers() regex to ignore numbers in strings

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/Instruction.java
+++ b/src/main/java/pl/betoncraft/betonquest/Instruction.java
@@ -466,12 +466,12 @@ public class Instruction {
     }
 
     public ArrayList<Integer> getAllNumbers() {
-        final Pattern p = Pattern.compile("-?\\d+");
+        final Pattern p = Pattern.compile("\\b[\\d]+\\b");
         final Matcher m = p.matcher(instruction);
 
         final ArrayList<Integer> result = new ArrayList<>();
         while (m.find()) {
-            result.add(Integer.parseInt(m.group()));
+            result.add(Integer.parseInt(m.group().replaceAll(" ","")));
         }
         return result;
     }


### PR DESCRIPTION
My regex matched numbers in strings before this change. This is fatal as someone could do so in non-number instruction arguments.