### PR TITLE
fix password docs style

### DIFF
--- a/config/docs-requirements.txt
+++ b/config/docs-requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.1.2
 mkdocs-exclude==1.0.2
-mkdocs-material==5.5.3
+mkdocs-material==5.5.7
 mkdocs-git-revision-date-localized-plugin==0.5.0
 mkdocs-awesome-pages-plugin==2.2.1
 

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -162,31 +162,37 @@ To complete this objective the player simply needs to leave the server. Keep in 
 
 This objective requires the player to write a certain password in chat. All attempts of a player will be hidden from public chat.
 The password consists of a prefix followed by the actual secret word:
-<pre>
+```
 Solution: The Cake is a lie!     
 ^prefix   ^secret word(s)
-</pre>
+```
 
 The objective's instruction string is defined as follows:
-1. The first argument is the password, use underscore characters (`_`) instead of spaces. The password is a [regular expression](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285). They are a little complicated but worth the effort if you want more control over what exactly matches. You can try it on pages like [regex101.com](https://regex101.com/).
-2. The prefix can be changed:
-   The default (when no prefix is set) is the translated prefix from the *messages.yml* config in the user's language.
+
+1. The first argument is the password, use underscore characters (`_`) instead of spaces.
+   The password is a [regular expression](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285).
+   They are a little complicated but worth the effort if you want more control over what exactly matches. 
+   You can try it on pages like [regex101.com](https://regex101.com/).
+   Documentation for regular expression in Java [here](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/regex/Pattern.html#sum).
+
+2. The prefix can be changed: The default (when no prefix is set) is the translated prefix from the *messages.yml* config in the user's language.             
+   Note that every custom prefix is suffixed with `: `, so `prefix:Library_password` will require the user to enter `Library password: myfancypassword`.     
+   To disable the prefix use an empty `prefix:` declaration, e.g. `password myfancypassword prefix: events:success`.
+   Be aware of these side effects that come with disabling the prefix:
+    
+    * Nothing will be hidden on failure, so tries will be visible in chat and commands will get executed!
+    * If a command was used to enter the password, the command will not be canceled on success and thus still be executed!    
+    * This ensures that even if your password is `quest` you can still execute the `/quest` command. 
    
-   Note that every custom prefix is suffixed with `: `, so `prefix:Library_password` will require the user to enter `Library password: myfancypassword`.
-   
-   To disable the prefix use an empty `prefix:` declaration, e.g. `password myfancypassword prefix: events:success`. Be aware of the side effects that come with disabling the prefix:
-   - Nothing will be hidden on failure, so tries will be visible in chat and commands will get executed!
-   - If a command was used to enter the password, the command will not be canceled on success and thus still be executed!
-   - This ensures that even if your password is `quest` you can still execute the `/quest` command. 
 3. You can also add the `ignoreCase` argument if you want a password's capitalization to be ignored. This is especially important for regex matching.
-4. If you want to trigger one or more events when the player failed to guess the password you can use the argument `fail` with a list of events (comma separated). With disabled prefix every command or chat message will trigger these events!
+
+4. If you want to trigger one or more events when the player failed to guess the password you can use the argument `fail` with a list of events (comma separated).
+   With disabled prefix every command or chat message will trigger these events!
 
 !!! example
     ```YAML
     password beton ignoreCase prefix:secret fail:failEvent1,failEvent2 events:message,reward
     ```
-
-[Java's regular expression documentation](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/regex/Pattern.html#sum)
 
 ## Pickup item: `pickup`
 

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -172,8 +172,10 @@ The objective's instruction string is defined as follows:
 1. The first argument is the password, use underscore characters (`_`) instead of spaces.
    The password is a [regular expression](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285).
    They are a little complicated but worth the effort if you want more control over what exactly matches. 
-   You can try it on pages like [regex101.com](https://regex101.com/).
-   Documentation for regular expression in Java [here](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/regex/Pattern.html#sum).
+   Websites like [regex101.com](https://regex101.com/) help with that complexity though.
+   The offical [documentation](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/regex/Pattern.html#sum) for regular expressions
+   in Java might also help you.
+   If you don't want to get into them just write down the password but keep in mind that the players answer needs to be an exact match! 
 
 2. The prefix can be changed: The default (when no prefix is set) is the translated prefix from the *messages.yml* config in the user's language.             
    Note that every custom prefix is suffixed with `:⠀`, so `prefix:Library_password` will require the user to enter `Library password: myfancypassword`.     

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -176,7 +176,7 @@ The objective's instruction string is defined as follows:
    Documentation for regular expression in Java [here](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/regex/Pattern.html#sum).
 
 2. The prefix can be changed: The default (when no prefix is set) is the translated prefix from the *messages.yml* config in the user's language.             
-   Note that every custom prefix is suffixed with `: `, so `prefix:Library_password` will require the user to enter `Library password: myfancypassword`.     
+   Note that every custom prefix is suffixed with `:⠀`, so `prefix:Library_password` will require the user to enter `Library password: myfancypassword`.     
    To disable the prefix use an empty `prefix:` declaration, e.g. `password myfancypassword prefix: events:success`.
    Be aware of these side effects that come with disabling the prefix:
     


### PR DESCRIPTION
# Description
The style of the passwords objective docs was broken. This PR fixes the style.

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... clean the commit history?


- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  Did the build pipeline succeed?
