### PR TITLE
Improve chestput waring for invalid locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - events in conversation options are now executed before npc or player responses are printed
 - message event now ignores chat interceptors during conversation
 - tame objective now works with all tamable mobs, including possible future ones
+- improved chestput waring for locations without a chest
 ### Deprecated
 ### Removed
 - Removed Deprecated Exceptions

--- a/src/main/java/pl/betoncraft/betonquest/objectives/ChestPutObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/ChestPutObjective.java
@@ -18,6 +18,8 @@
 package pl.betoncraft.betonquest.objectives;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -39,6 +41,7 @@ import pl.betoncraft.betonquest.id.NoID;
 import pl.betoncraft.betonquest.utils.LocationData;
 import pl.betoncraft.betonquest.utils.LogUtils;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
+import pl.betoncraft.betonquest.utils.Utils;
 
 import java.util.logging.Level;
 
@@ -88,19 +91,22 @@ public class ChestPutObjective extends Objective implements Listener {
             return;
         }
         try {
-            final Block block = loc.getLocation(playerID).getBlock();
-            final InventoryHolder chest;
-            try {
-                chest = (InventoryHolder) block.getState();
-            } catch (ClassCastException e) {
-                LogUtils.getLogger().log(Level.WARNING, "Could not cast the chest inventory: " + e.getMessage());
-                LogUtils.logThrowable(e);
+            final Location targetChestLocation = loc.getLocation(playerID);
+            final Block block = targetChestLocation.getBlock();
+            if (!(block instanceof InventoryHolder)) {
+                final World world = targetChestLocation.getWorld();
+                final String worldName = world == null ? "null" : world.getName();
+                LogUtils.getLogger().log(Level.WARNING,
+                        String.format("Error in '%s' chestput objective: Block at location x:%d y:%d z:%d in world '%s' isn't a chest!",
+                                instruction.getID().getFullID(),
+                                targetChestLocation.getBlockX(),
+                                targetChestLocation.getBlockY(),
+                                targetChestLocation.getBlockZ(),
+                                worldName));
                 return;
             }
-            if (event.getInventory() == null || event.getInventory().getHolder() == null) {
-                return;
-            }
-            if (!event.getInventory().getHolder().equals(chest)) {
+            final InventoryHolder chest = (InventoryHolder) block.getState();
+            if (!chest.equals(event.getInventory().getHolder())) {
                 return;
             }
             if (chestItemCondition.handle(playerID) && checkConditions(playerID)) {

--- a/src/main/java/pl/betoncraft/betonquest/objectives/ChestPutObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/ChestPutObjective.java
@@ -41,7 +41,6 @@ import pl.betoncraft.betonquest.id.NoID;
 import pl.betoncraft.betonquest.utils.LocationData;
 import pl.betoncraft.betonquest.utils.LogUtils;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
-import pl.betoncraft.betonquest.utils.Utils;
 
 import java.util.logging.Level;
 
@@ -95,14 +94,13 @@ public class ChestPutObjective extends Objective implements Listener {
             final Block block = targetChestLocation.getBlock();
             if (!(block instanceof InventoryHolder)) {
                 final World world = targetChestLocation.getWorld();
-                final String worldName = world == null ? "null" : world.getName();
                 LogUtils.getLogger().log(Level.WARNING,
                         String.format("Error in '%s' chestput objective: Block at location x:%d y:%d z:%d in world '%s' isn't a chest!",
                                 instruction.getID().getFullID(),
                                 targetChestLocation.getBlockX(),
                                 targetChestLocation.getBlockY(),
                                 targetChestLocation.getBlockZ(),
-                                worldName));
+                                world == null ? "null" : world.getName()));
                 return;
             }
             final InventoryHolder chest = (InventoryHolder) block.getState();


### PR DESCRIPTION
# Description
Opening any chest generates a useless warning if you have an active `chestput` objective pointing to a location that is not a chest.

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... clean the commit history?


- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [x]  Did the build pipeline succeed?
