### PR TITLE
changed maven repo for Heroes API in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,13 +96,13 @@
     </profile>
 
     <profile>
-      <id>Heroes</id>
+      <id>from-heroes</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <repositories>
         <repository>
-          <id>Heroes-repo</id>
+          <id>heroes-repo</id>
           <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
         </repository>
       </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,21 @@
           <version>3.37</version>
           <scope>provided</scope>
         </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>Heroes</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>Heroes-repo</id>
+          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
+        </repository>
+      </repositories>
+      <dependencies>
         <dependency>
           <groupId>com.herocraftonline.heroes</groupId>
           <artifactId>Heroes</artifactId>


### PR DESCRIPTION
# Description
After a longer discussion on the Heroes discord it seems that the old API is still up to date. I Tried to use it and it works the same way as the dependency from bundabrg's repo. So i think at the moment we use it to get rid of bundabrg's repo.

## Related Issues
Related #1168 

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... clean the commit history?


- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  Did the build pipeline succeed?
