### PR TITLE
Update Youtube url for Conversation IO: menu 

### DIFF
--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -598,7 +598,7 @@ hide_npcs:
 
 ### Conversation IO: `menu`
 
-A conversation IO that makes use of a chat menu system. A video of it in action can be seen [here](https://www.youtube.com/channel/UCyF806Xfzr4B18dsZ4TEI9w).
+ProtocolLib also enables a conversation IO that makes use of a chat menu system. A video of it in action can be seen [here](https://www.youtube.com/watch?v=Qtn7Dpdf4jw).
 
 Customize how it looks by adding the following lines to custom.yml:
 

--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -598,7 +598,7 @@ hide_npcs:
 
 ### Conversation IO: `menu`
 
-ProtocolLib also enables a conversation IO that makes use of a chat menu system. A video of it in action can be seen [here](https://www.youtube.com/watch?v=Qtn7Dpdf4jw).
+ProtocolLib also enables a conversation IO that makes use of a chat menu system. A video of it in action can be seen [here](../media/content/Home/MenuConvIO.mp4).
 
 Customize how it looks by adding the following lines to custom.yml:
 


### PR DESCRIPTION
Update Youtube url for Conversation IO: menu 

# Description
Update Youtube url for Conversation IO: menu so that it goes to the Youtube video and instead of the channel. Also clarify that ProtocolLib enable this feature.