### PR TITLE
Block selector

### DIFF
--- a/documentation/User-Documentation/Reference.md
+++ b/documentation/User-Documentation/Reference.md
@@ -398,9 +398,9 @@ Where:
   It can be a [regex](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285).
   If the regex ends with square brackets you have to add another pair of empty square brackets even if you don't want to 
   use the state argument (`[regex][]`).  
-  Instead of using a regex to match multiple materials you can also define a [Tag](https://minecraft.gamepedia.com/Tag) that matches a logic group of materials.
-  Every tag has a tag group like blocks, items, ... and you write it in the format `:blocks:flowers` or `minecraft:blocks:flowers`.
-  Be aware, that a tag always start with `:` or a namespace. 
+  Instead of using a regex to match multiple materials you can also define a [tag](https://minecraft.gamepedia.com/Tag).
+  Every tag matches a special group of blocks or items that can be grouped together logically. They can be used using this format `:blocks:flowers` or `minecraft:blocks:flowers`.
+  Be aware that a tag always starts with either `:` or a namespace. 
   
   - `state` - (optional) The block states can be provided in a comma separated `key=value` list surrounded by square brackets.
    You can look up states in [this list](https://minecraft.gamepedia.com/1.13/Flattening#Block_states).

--- a/documentation/User-Documentation/Reference.md
+++ b/documentation/User-Documentation/Reference.md
@@ -386,18 +386,21 @@ When specifying a way of matching a block, a `block selector` is used.
 
 ### Format
 
-The format of a block selector is: `prefix:material[state=value,...]`
+The format of a block selector is: `namespace:material[state=value,...]`
 
 Where:
 
-  - `prefix` - (optional) The material prefix. If left out then it will be assumed to be 'minecraft'.
+  - `namespace` - (optional) The material namespace. If left out then it will be assumed to be 'minecraft'.
    Can be a [regex](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285).
   
   - `material` - The material the block is made of. All materials can be found in
   [Spigots Javadocs](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html). 
   It can be a [regex](https://medium.com/factory-mind/regex-tutorial-a-simple-cheatsheet-by-examples-649dc1c3f285).
   If the regex ends with square brackets you have to add another pair of empty square brackets even if you don't want to 
-  use the state argument.
+  use the state argument (`[regex][]`).  
+  Instead of using a regex to match multiple materials you can also define a [Tag](https://minecraft.gamepedia.com/Tag) that matches a logic group of materials.
+  Every tag has a tag group like blocks, items, ... and you write it in the format `:blocks:flowers` or `minecraft:blocks:flowers`.
+  Be aware, that a tag always start with `:` or a namespace. 
   
   - `state` - (optional) The block states can be provided in a comma separated `key=value` list surrounded by square brackets.
    You can look up states in [this list](https://minecraft.gamepedia.com/1.13/Flattening#Block_states).
@@ -419,10 +422,14 @@ Examples:
   - `*` - Matches everything
   
   - `*[waterlogged=true]` - Matches all waterlogged blocks
+  
+  - `minecraft:blocks:flowers` - Matches all flowers
+  
+  - `:blocks:crops[age=0]` - Matches all crops with a age of 0 meaning, not grown or just planted
 
 ###Setting behaviour
 
-A block selector with a regex as it's material name results in a random block out of all blocks that match that regex.
+A block selector with a regex or tag as it's material name results in a random block out of all blocks that match that regex or tag.
 You cannot use a regex in block states when the block selector is used for placing blocks.
 
 ###Matching behaviour

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -6,6 +6,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import pl.betoncraft.betonquest.exceptions.InstructionParseException;
 
 import java.util.*;
@@ -77,17 +78,21 @@ public class BlockSelector {
         return builder.toString();
     }
 
+    public BlockData getBlockData() {
+        if (states == null) {
+            return Bukkit.createBlockData(getRandomMaterial());
+        } else {
+            return Bukkit.createBlockData(getRandomMaterial(), getStateAsString());
+        }
+    }
+
     public void setToBlock(final Block block, final boolean applyPhysics) {
         final BlockState state = block.getState();
 
-        if (states == null) {
-            state.setType(getRandomMaterial());
-        } else {
-            try {
-                state.setBlockData(Bukkit.createBlockData(getRandomMaterial(), getStateAsString()));
-            } catch (final IllegalArgumentException exception) {
-                LogUtils.getLogger().log(Level.SEVERE, "Could not place block '" + toString() + "'! Probably the block has a invalid blockstate: " + exception.getMessage(), exception);
-            }
+        try {
+            state.setBlockData(getBlockData());
+        } catch (final IllegalArgumentException exception) {
+            LogUtils.getLogger().log(Level.SEVERE, "Could not place block '" + toString() + "'! Probably the block has a invalid blockstate: " + exception.getMessage(), exception);
         }
 
         state.update(true, applyPhysics);

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -187,9 +187,9 @@ public class BlockSelector {
         }
 
         if (keyString.contains(":")) {
-            String[] groupParts = keyString.split(":");
-            NamespacedKey namespacedKey = new NamespacedKey(namespaceString, groupParts[1]);
-            Tag<Material> tag = Bukkit.getTag(groupParts[0], namespacedKey, Material.class);
+            final String[] groupParts = keyString.split(":");
+            final NamespacedKey namespacedKey = new NamespacedKey(namespaceString, groupParts[1]);
+            final Tag<Material> tag = Bukkit.getTag(groupParts[0], namespacedKey, Material.class);
             if (tag != null) {
                 materials.addAll(tag.getValues());
             }

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -148,9 +148,9 @@ public class BlockSelector {
         }
 
         if (restSelector.contains(":")) {
-            final String[] parts = restSelector.split(":");
-            selectorParts[0] = parts[0].toLowerCase(Locale.ROOT);
-            selectorParts[1] = parts[1].toLowerCase(Locale.ROOT);
+            final int index = restSelector.indexOf(":");
+            selectorParts[0] = restSelector.substring(0, index).toLowerCase(Locale.ROOT);
+            selectorParts[1] = restSelector.substring(index + 1).toLowerCase(Locale.ROOT);
         } else {
             selectorParts[0] = "minecraft";
             selectorParts[1] = restSelector.toLowerCase(Locale.ROOT);

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -3,6 +3,7 @@ package pl.betoncraft.betonquest.utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import pl.betoncraft.betonquest.exceptions.InstructionParseException;
@@ -111,8 +112,8 @@ public class BlockSelector {
         }
 
         final Map<String, String> blockStates = getStates(getSelectorParts(block.getBlockData().getAsString())[2]);
-        if (states == null && (!exactMatch || blockStates == null)) {
-            return true;
+        if (states == null) {
+            return !exactMatch || blockStates == null;
         }
         if (exactMatch && states.size() != blockStates.size()) {
             return false;
@@ -176,11 +177,22 @@ public class BlockSelector {
         return -1;
     }
 
+    @SuppressWarnings("deprecation")
     private List<Material> getMaterials(final String namespaceString, final String keyString) {
         final List<Material> materials = new ArrayList<>();
         final Material fullMatch = Material.getMaterial(namespaceString + ":" + keyString);
         if (fullMatch != null) {
             materials.add(fullMatch);
+            return materials;
+        }
+
+        if (keyString.contains(":")) {
+            String[] groupParts = keyString.split(":");
+            NamespacedKey namespacedKey = new NamespacedKey(namespaceString, groupParts[1]);
+            Tag<Material> tag = Bukkit.getTag(groupParts[0], namespacedKey, Material.class);
+            if (tag != null) {
+                materials.addAll(tag.getValues());
+            }
             return materials;
         }
 

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -143,17 +143,17 @@ public class BlockSelector {
 
         if (restSelector.endsWith("]")) {
             final int index = getBracketIndex(restSelector, 0);
-            selectorParts[2] = restSelector.substring(index + 1, restSelector.length() - 1).toLowerCase();
+            selectorParts[2] = restSelector.substring(index + 1, restSelector.length() - 1).toLowerCase(Locale.ROOT);
             restSelector = restSelector.substring(0, index);
         }
 
         if (restSelector.contains(":")) {
             final String[] parts = restSelector.split(":");
-            selectorParts[0] = parts[0].toLowerCase();
-            selectorParts[1] = parts[1].toLowerCase();
+            selectorParts[0] = parts[0].toLowerCase(Locale.ROOT);
+            selectorParts[1] = parts[1].toLowerCase(Locale.ROOT);
         } else {
             selectorParts[0] = "minecraft";
-            selectorParts[1] = restSelector.toLowerCase();
+            selectorParts[1] = restSelector.toLowerCase(Locale.ROOT);
         }
 
         return selectorParts;


### PR DESCRIPTION
# Description
https://minecraft.gamepedia.com/Tag
Now its possible to reffer block/item/fluid tags and all future tags that reffer to materials.
The format is
`namespace:tagType:tag`
`minecraft:blocks:flowers`
`:blocks:flowers`
This must be documented

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [X]  ... update the changelog?
- [x]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... clean the commit history?


- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  Did the build pipeline succeed?
