### PR TITLE
add "acceptNPCLeftClick" config option for CitizensNPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added period argument to folder event
 - Added variable support to the Notify system
 - Added variable support to the PickRandomEvent
+- Added "acceptNPCLeftClick: true / false" config option
 ### Changed
 - devbuilds always show notifications for new devbuilds, even when the user is not on a _DEV strategy
 - Items for HolographicDisplays are now defines in items.yml

--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -63,8 +63,11 @@ takebrew MY_OTHER_BREW 2
 If you have this plugin you can use it's NPCs for conversations. I highly recommend you installing it,
 it's NPCs are way more immersive. Having Citizens also allows you to use NPCKill objective and to have moving NPC's.
 
+A Citizen NPC will only react to right clicks by default. This can be changed by 
+setting `acceptNPCLeftClick` in the config.yml to `true`.
+
 !!! notice
-    When you use Citizens, in main.yml you need to specify the ID of the NPC instead of the name!
+      You need to specify the ID of the NPC instead of it's name in the main.yml when using Citizens!
 
 ### Conditions
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -13,13 +13,15 @@ public class CitizensIntegrator implements Integrator {
 
     private final BetonQuest plugin;
 
+    private CitizensListener citizensListener;
+
     public CitizensIntegrator() {
         plugin = BetonQuest.getInstance();
     }
 
     @Override
     public void hook() {
-        new CitizensListener();
+        citizensListener = new CitizensListener();
         new CitizensWalkingListener();
         if (Compatibility.getHooked().contains("EffectLib")) {
             new CitizensParticle();
@@ -59,6 +61,9 @@ public class CitizensIntegrator implements Integrator {
 
         if (Compatibility.getHooked().containsAll(Arrays.asList("Citizens", "HolographicDisplays"))) {
             CitizensHologram.reload();
+        }
+        if (Compatibility.getHooked().contains("Citizens")) {
+            citizensListener.reload();
         }
     }
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensListener.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensListener.java
@@ -1,10 +1,12 @@
 package pl.betoncraft.betonquest.compatibility.citizens;
 
 import net.citizensnpcs.api.event.CitizensReloadEvent;
+import net.citizensnpcs.api.event.NPCClickEvent;
+import net.citizensnpcs.api.event.NPCLeftClickEvent;
 import net.citizensnpcs.api.event.NPCRightClickEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.config.Config;
@@ -16,15 +18,59 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
  */
 public class CitizensListener implements Listener {
 
+    private RightClickListener rightClick;
+    private LeftClickListener leftClick;
+
     /**
      * Initializes the listener
      */
     public CitizensListener() {
-        Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
+        reload();
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onNPCClick(final NPCRightClickEvent event) {
+    public void reload() {
+        if (rightClick != null) {
+            HandlerList.unregisterAll(rightClick);
+        }
+        if (leftClick != null) {
+            HandlerList.unregisterAll(leftClick);
+        }
+
+
+        final BetonQuest plugin = BetonQuest.getInstance();
+
+        rightClick = new RightClickListener();
+        Bukkit.getPluginManager().registerEvents(rightClick, plugin);
+
+        if (plugin.getConfig().getBoolean("acceptNPCLeftClick")) {
+            leftClick = new LeftClickListener();
+            Bukkit.getPluginManager().registerEvents(leftClick, plugin);
+        }
+    }
+
+    private class RightClickListener implements Listener {
+
+        public RightClickListener() {
+        }
+
+        @EventHandler
+        public void onNPCClick(final NPCRightClickEvent event) {
+            interactLogic(event);
+        }
+    }
+
+    private class LeftClickListener implements Listener {
+
+        public LeftClickListener() {
+        }
+
+        @EventHandler
+        public void onNPCClick(final NPCLeftClickEvent event) {
+            interactLogic(event);
+        }
+    }
+
+    public void interactLogic(final NPCClickEvent event) {
         if (!event.getClicker().hasPermission("betonquest.conversation")) {
             return;
         }

--- a/src/main/java/pl/betoncraft/betonquest/config/ConfigUpdater.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/ConfigUpdater.java
@@ -51,7 +51,7 @@ public class ConfigUpdater {
      * Destination version. At the end of the updating process this will be the
      * current version
      */
-    private final String destination = "v62";
+    private final String destination = "v63";
     /**
      * BetonQuest's instance
      */
@@ -168,6 +168,14 @@ public class ConfigUpdater {
         }
         // update again until destination is reached
         update();
+    }
+
+    private void updateFromV62() {
+        LogUtils.getLogger().log(Level.INFO, "Adding 'acceptNPCLeftClick' to config.yml");
+        config.set("acceptNPCLeftClick", false);
+        config.set("version", "v63");
+        instance.saveConfig();
+        LogUtils.getLogger().log(Level.INFO, "Successfully added 'acceptNPCLeftClick' to config.yml");
     }
 
     private void updateFromV61() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,7 @@ update:
 default_journal_slot: '-1'
 max_npc_distance: '5'
 citizens_npcs_by_name: 'false'
+acceptNPCLeftClick: 'false'
 default_conversation_IO: menu,chest
 default_interceptor: packet,simple
 display_chat_after_conversation: 'true'


### PR DESCRIPTION
# Description
This adds the new config option "acceptNPCLeftClick". Citzen NPCs will also react to left click if that option is set to true.
/q reload does not work with this for some reason 


## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?                         
- [X]  ... clean the commit history?


- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [x]  Did the build pipeline succeed?
