### PR TITLE
Add left, amount and total properties to player kill objective.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added 'notifyall' event to broadcast a notification
 - Added new notification IO 'sound'
 - Added 'jump' objective
+- Added left, amount and total properties to player kill objective
 ### Changed
 - devbuilds always show notifications for new devbuilds, even when the user is not on a _DEV strategy
 - Items for HolographicDisplays are now defines in items.yml

--- a/documentation/User-Documentation/Objectives-List.md
+++ b/documentation/User-Documentation/Objectives-List.md
@@ -140,7 +140,13 @@ optionally with the notification interval after colon and `cancel` if the click 
 
 ## Kill player: `kill`
 
-To complete this objective the player needs to kill another player. The first argument is amount of players to kill. You can also specify additional arguments: `name:` followed by the name will only accept killing players with this name, `required:` followed by a list of conditions separated with commas will only accept killing players meeting these conditions and `notify` will display notifications when a player is killed, optionally with the notification interval after colon.
+To complete this objective the player needs to kill another player. The first argument is amount of players to kill.
+You can also specify additional arguments: `name:` followed by the name will only accept killing players with this name,
+`required:` followed by a list of conditions separated with commas will only accept killing players meeting these conditions
+and `notify` will display notifications when a player is killed, optionally with the notification interval after a colon.
+
+The kill objective has three properties: `left` is the amount of players still left to kill, `amount` is the amount of
+already killed players and `total`is the initially required amount to kill.
 
 !!! example
     ```YAML

--- a/src/main/java/pl/betoncraft/betonquest/objectives/KillPlayerObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/KillPlayerObjective.java
@@ -15,6 +15,7 @@ import pl.betoncraft.betonquest.id.ConditionID;
 import pl.betoncraft.betonquest.utils.LogUtils;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
+import java.util.Locale;
 import java.util.logging.Level;
 
 public class KillPlayerObjective extends Objective implements Listener {
@@ -33,7 +34,7 @@ public class KillPlayerObjective extends Objective implements Listener {
             throw new InstructionParseException("Amount cannot be less than 0");
         }
         name = instruction.getOptional("name");
-        required = instruction.getList(instruction.getOptional("required"), e -> instruction.getCondition(e))
+        required = instruction.getList(instruction.getOptional("required"), instruction::getCondition)
                 .toArray(new ConditionID[0]);
         notifyInterval = instruction.getInt(instruction.getOptional("notify"), 1);
         notify = instruction.hasArgument("notify") || notifyInterval > 0;
@@ -92,7 +93,16 @@ public class KillPlayerObjective extends Objective implements Listener {
 
     @Override
     public String getProperty(final String name, final String playerID) {
-        return "";
+        switch (name.toLowerCase(Locale.ROOT)) {
+            case "left":
+                return Integer.toString(((KillPlayerObjective.KillData) dataMap.get(playerID)).getLeft());
+            case "amount":
+                return Integer.toString(amount - ((KillPlayerObjective.KillData) dataMap.get(playerID)).getLeft());
+            case "total":
+                return Integer.toString(amount);
+            default:
+                return "";
+        }
     }
 
     public static class KillData extends ObjectiveData {


### PR DESCRIPTION
# Description
Make it possible to get the amount of killed and left to killed players as well as a convenience property for the total required amount from a player `kill` objective.

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [x]  ... clean the commit history?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  Did the build pipeline succeed?
