### PR TITLE
The plugin will no longer loaded before the worlds are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EventHandlers in general updated to ignore cancelled events
 - improved performance for condition checks (Bug where it took seconds to check for conditions)
 - improved performance for conversation checks (Bug where it took seconds to check for conversation options)
-- The plugin will no longer loaded before the worlds are loaded
+- The plugin will no longer be loaded before the worlds are loaded
 ### Deprecated
 - Marked message event for removal in BQ 2.0
 - Marked playsound event for removal in BQ 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EventHandlers in general updated to ignore cancelled events
 - improved performance for condition checks (Bug where it took seconds to check for conditions)
 - improved performance for conversation checks (Bug where it took seconds to check for conversation options)
+- The plugin will no longer loaded before the worlds are loaded
 ### Deprecated
 - Marked message event for removal in BQ 2.0
 - Marked playsound event for removal in BQ 2.0

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/Compatibility.java
@@ -79,8 +79,6 @@ public class Compatibility implements Listener {
             hook(hook);
         }
 
-        Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
-
         // hook into ProtocolLib
         if (Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")
                 && plugin.getConfig().getString("hook.protocollib").equalsIgnoreCase("true")) {
@@ -165,10 +163,4 @@ public class Compatibility implements Listener {
             }
         }
     }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onPluginEnable(final PluginEnableEvent event) {
-        hook(event.getPlugin());
-    }
-
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,6 @@ api-version: 1.13
 description: Advanced role-playing quests and NPC conversations
 authors: [Co0sh]
 website: https://www.spigotmc.org/resources/betonquest.2117/
-load: STARTUP
 softdepend:
   - Skript
   - MMOLib


### PR DESCRIPTION
# Description
There is a problem with plugins(found with HolographicDisplays) that need to be loaded after all worlds are loded. So this change the behavior that BQ is loded before the worlds are loaded.

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... clean the commit history?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  Did the build pipeline succeed?