### PR TITLE
Added neutralDeathRadius argument to the mmobkill objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementing 1.15 support for Events and Conditions
 - New Chat event, that write chat messages for a player
 - Added 'pickup' objective
-- Added 'neutralMobDeath' argument to the `mmobkill` objective
 - Added stopnpc event, that will stop the movenpc event
 - Added teleportnpc event, that will stop the movenpc event and teleport the npc to a given location
 - Added option check_interval for holograms in custom.yml andd added GlobalVariable support
@@ -69,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new notification IO 'sound'
 - Added 'jump' objective
 - Added left, amount and total properties to player kill objective
+- Added 'neutralMobDeathAllPlayers' argument to the `mmobkill` objective
 ### Changed
 - devbuilds always show notifications for new devbuilds, even when the user is not on a _DEV strategy
 - Items for HolographicDisplays are now defines in items.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementing 1.15 support for Events and Conditions
 - New Chat event, that write chat messages for a player
 - Added 'pickup' objective
+- Added 'neutralMobDeath' argument to the `mmobkill` objective
 - Added stopnpc event, that will stop the movenpc event
 - Added teleportnpc event, that will stop the movenpc event and teleport the npc to a given location
 - Added option check_interval for holograms in custom.yml andd added GlobalVariable support

--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -649,6 +649,7 @@ You need to kill the specified amount of MythicMobs to complete this objective. 
 the mob's internal name (the one defined in your MythicMobs configuration). You can optionally add the `amount:`
 argument to specify how many of these mobs need to be killed. It's also possible to add the optional arguments
 `minLevel` and `maxLevel` to further customize what mobs need to be killed.
+You can also add an optional `neutralDeathRadius` argument to complete the objective for each nearby player within the defined radius when the mob is killed by any source.
 You can add a "notify" keyword if you want to send a notification to players whenever the objective
 progresses.
 

--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -649,7 +649,7 @@ You need to kill the specified amount of MythicMobs to complete this objective. 
 the mob's internal name (the one defined in your MythicMobs configuration). You can optionally add the `amount:`
 argument to specify how many of these mobs need to be killed. It's also possible to add the optional arguments
 `minLevel` and `maxLevel` to further customize what mobs need to be killed.
-You can also add an optional `neutralDeathRadius` argument to complete the objective for each nearby player within the defined radius when the mob is killed by any source.
+You can also add an optional `neutralDeathRadiusAllPlayers` argument to complete the objective for each nearby player within the defined radius when the mob is killed by any source.
 You can add a "notify" keyword if you want to send a notification to players whenever the objective
 progresses.
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -58,7 +58,6 @@ public class MythicMobKillObjective extends Objective implements Listener {
         maxMobLevel = unsafeMaxMobLevel == null ? new VariableNumber(Double.POSITIVE_INFINITY) : new VariableNumber(packName, unsafeMaxMobLevel);
     }
 
-    @SuppressWarnings("PMD.PreserveStackTrace")
     @EventHandler(ignoreCancelled = true)
     public void onBossKill(final MythicMobDeathEvent event) {
         if (!names.contains(event.getMobType().getInternalName())) {
@@ -67,8 +66,8 @@ public class MythicMobKillObjective extends Objective implements Listener {
 
         if (!(event.getKiller() instanceof Player)) {
             if (neutralDeathRadius > 0D) {
-                Location center = BukkitAdapter.adapt(event.getMob().getLocation());
-                for (Player player : center.getWorld().getPlayers()) {
+                final Location center = BukkitAdapter.adapt(event.getMob().getLocation());
+                for (final Player player : center.getWorld().getPlayers()) {
                     if (!isValidPlayer(player)) {
                         continue;
                     }
@@ -99,6 +98,7 @@ public class MythicMobKillObjective extends Objective implements Listener {
         return player.isValid();
     }
 
+    @SuppressWarnings("PMD.PreserveStackTrace")
     private void handlePlayerKill(final Player player, final ActiveMob mob) {
         final String playerID = PlayerConverter.getID(player);
         if (!containsPlayer(playerID)) {

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -1,25 +1,30 @@
 package pl.betoncraft.betonquest.compatibility.mythicmobs;
 
-import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicMobDeathEvent;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
+import java.util.logging.Level;
+
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.EventHandler;
+
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
-import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.api.Objective;
 import pl.betoncraft.betonquest.config.Config;
-import pl.betoncraft.betonquest.exceptions.InstructionParseException;
-import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
 import pl.betoncraft.betonquest.utils.LogUtils;
+import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+import pl.betoncraft.betonquest.exceptions.InstructionParseException;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.logging.Level;
+import io.lumine.xikage.mythicmobs.mobs.ActiveMob;
+import io.lumine.xikage.mythicmobs.adapters.bukkit.BukkitAdapter;
+import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicMobDeathEvent;
 
 /**
  * Player has to kill MythicMobs monster
@@ -29,6 +34,8 @@ public class MythicMobKillObjective extends Objective implements Listener {
     private final Set<String> names = new HashSet<>();
     private final int amount;
     private final boolean notify;
+    private final double neutralDeathRadius;
+    private final double neutralDeathRadiusSquared;
     private final VariableNumber minMobLevel;
     private final VariableNumber maxMobLevel;
 
@@ -39,6 +46,9 @@ public class MythicMobKillObjective extends Objective implements Listener {
 
         Collections.addAll(names, instruction.getArray());
         amount = instruction.getInt(instruction.getOptional("amount"), 1);
+
+        neutralDeathRadius = instruction.getDouble(instruction.getOptional("neutralDeathRadius"), 0);
+        neutralDeathRadiusSquared = neutralDeathRadius * neutralDeathRadius;
 
         final String unsafeMinMobLevel = instruction.getOptional("minLevel");
         final String unsafeMaxMobLevel = instruction.getOptional("maxLevel");
@@ -54,16 +64,48 @@ public class MythicMobKillObjective extends Objective implements Listener {
         if (!names.contains(event.getMobType().getInternalName())) {
             return;
         }
+
         if (!(event.getKiller() instanceof Player)) {
+            if (neutralDeathRadius > 0D) {
+                Location center = BukkitAdapter.adapt(event.getMob().getLocation());
+                for (Player player : center.getWorld().getPlayers()) {
+                    if (!isValidPlayer(player)) {
+                        continue;
+                    }
+
+                    if (player.getLocation().distanceSquared(center) > neutralDeathRadiusSquared) {
+                        continue;
+                    }
+
+                    handlePlayerKill(player, event.getMob());
+                }
+            }
             return;
         }
 
-        final String playerID = PlayerConverter.getID((Player) event.getKiller());
+        handlePlayerKill((Player) event.getKiller(), event.getMob());
+    }
+
+
+    private boolean isValidPlayer(final Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        if (!player.isOnline()) {
+            return false;
+        }
+
+        return player.isValid();
+    }
+
+    private void handlePlayerKill(final Player player, final ActiveMob mob) {
+        final String playerID = PlayerConverter.getID(player);
         if (!containsPlayer(playerID)) {
             return;
         }
 
-        final double actualMobLevel = event.getMobLevel();
+        final double actualMobLevel = mob.getLevel();
         try {
             if (minMobLevel.getDouble(playerID) > actualMobLevel || maxMobLevel.getDouble(playerID) < actualMobLevel) {
                 return;

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -34,8 +34,8 @@ public class MythicMobKillObjective extends Objective implements Listener {
     private final Set<String> names = new HashSet<>();
     private final int amount;
     private final boolean notify;
-    private final double neutralDeathRadius;
-    private final double neutralDeathRadiusSquared;
+    private final double neutralDeathRadiusAllPlayers;
+    private final double neutralDeathRadiusAllPlayersSquared;
     private final VariableNumber minMobLevel;
     private final VariableNumber maxMobLevel;
 
@@ -47,8 +47,8 @@ public class MythicMobKillObjective extends Objective implements Listener {
         Collections.addAll(names, instruction.getArray());
         amount = instruction.getInt(instruction.getOptional("amount"), 1);
 
-        neutralDeathRadius = instruction.getDouble(instruction.getOptional("neutralDeathRadius"), 0);
-        neutralDeathRadiusSquared = neutralDeathRadius * neutralDeathRadius;
+        neutralDeathRadiusAllPlayers = instruction.getDouble(instruction.getOptional("neutralDeathRadiusAllPlayers"), 0);
+        neutralDeathRadiusAllPlayersSquared = neutralDeathRadiusAllPlayers * neutralDeathRadiusAllPlayers;
 
         final String unsafeMinMobLevel = instruction.getOptional("minLevel");
         final String unsafeMaxMobLevel = instruction.getOptional("maxLevel");
@@ -64,27 +64,25 @@ public class MythicMobKillObjective extends Objective implements Listener {
             return;
         }
 
-        if (!(event.getKiller() instanceof Player)) {
-            if (neutralDeathRadius > 0D) {
+        if (event.getKiller() instanceof Player) {
+            handlePlayerKill((Player) event.getKiller(), event.getMob());
+        } else {
+            if (neutralDeathRadiusAllPlayers > 0D) {
                 final Location center = BukkitAdapter.adapt(event.getMob().getLocation());
                 for (final Player player : center.getWorld().getPlayers()) {
                     if (!isValidPlayer(player)) {
                         continue;
                     }
 
-                    if (player.getLocation().distanceSquared(center) > neutralDeathRadiusSquared) {
+                    if (player.getLocation().distanceSquared(center) > neutralDeathRadiusAllPlayersSquared) {
                         continue;
                     }
 
                     handlePlayerKill(player, event.getMob());
                 }
             }
-            return;
         }
-
-        handlePlayerKill((Player) event.getKiller(), event.getMob());
     }
-
 
     private boolean isValidPlayer(final Player player) {
         if (player == null) {


### PR DESCRIPTION
# Description
`neutralDeathRadius` triggers the `mmobkill` objective for every player within the defined radius, even if the player didn't kill the mob directly, it's useful when you have non player damage sources to kill mobs, such as summons, fire or lava.

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [ ]  ... clean the commit history?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [X]  Did the build pipeline succeed?
