### PR TITLE
#1305: Fix bug that didn't allow : in variables used in notify events.

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/events/NotifyEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/events/NotifyEvent.java
@@ -42,7 +42,6 @@ public class NotifyEvent extends QuestEvent {
             keyValueMatcher.reset();
 
             final String langMessages = rawInstruction.substring(indexStart, indexEnd);
-            checkVariables(langMessages);
 
             final Matcher languageMatcher = LANGUAGE_PATTERN.matcher(langMessages);
             while (languageMatcher.find()) {
@@ -50,10 +49,15 @@ public class NotifyEvent extends QuestEvent {
                 final String message = languageMatcher.group("message")
                         .replace("\\{", "{")
                         .replace("\\:", ":");
+                checkVariables(message);
                 messages.put(lang, message);
             }
             if (messages.isEmpty()) {
-                messages.put(Config.getLanguage(), langMessages);
+                final String message = langMessages
+                        .replace("\\{", "{")
+                        .replace("\\:", ":");
+                checkVariables(message);
+                messages.put(Config.getLanguage(), message);
             }
             if (!messages.containsKey(Config.getLanguage())) {
                 throw new InstructionParseException("No message defined for default language '" + Config.getLanguage() + "'!");


### PR DESCRIPTION
# Description
Move variable parsing after applying escaping.

## Related Issues
Closes #1305

## Checklists
### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [x]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... clean the commit history?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [x]  Did the build pipeline succeed?
