### PR TITLE
fix NullPointerException for walking NPCs with conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed npc teleport and walk operations in unloaded chunks
 - fixed inaccurate location variable decimal rounding
 - fixed NullPointerException for walking NPCs with conversation
+- fixed resuming to path finding when conversation interrupt movement
 ### Security
 
 ## [1.12.0] - 2021-01-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed notify enabled by default for some objectives
 - fixed some grammar mistakes in debug messages
 - fixed npc teleport and walk operations in unloaded chunks
-- fixed inaccurate location variable decimal rounding  
+- fixed inaccurate location variable decimal rounding
+- fixed NullPointerException for walking NPCs with conversation
 ### Security
 
 ## [1.12.0] - 2021-01-10

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensWalkingListener.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensWalkingListener.java
@@ -86,8 +86,8 @@ public class CitizensWalkingListener implements Listener {
                     final CitizensConversation conv = (CitizensConversation) event.getConversation();
                     final NPC npc = conv.getNPC();
                     final Pair<Integer, Location> pair = npcs.get(npc);
-                    final int npcId = pair.getKey() - 1;
-                    if (npcId == 0) {
+                    final int conversationsAmount = pair.getKey() - 1;
+                    if (conversationsAmount == 0) {
                         npcs.remove(npc);
                         if (npc.isSpawned()) {
                             final Navigator nav = npc.getNavigator();
@@ -97,7 +97,7 @@ public class CitizensWalkingListener implements Listener {
                             npc.spawn(pair.getValue(), SpawnReason.PLUGIN);
                         }
                     } else {
-                        npcs.put(npc, Pair.of(npcId, pair.getValue()));
+                        npcs.put(npc, Pair.of(conversationsAmount, pair.getValue()));
                     }
                 }
             }.runTask(BetonQuest.getInstance());

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensWalkingListener.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensWalkingListener.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.citizensnpcs.api.ai.Navigator;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
@@ -25,8 +26,7 @@ public class CitizensWalkingListener implements Listener {
 
     private static CitizensWalkingListener instance;
 
-    private final Map<NPC, Integer> npcs = new HashMap<>();
-    private final Map<NPC, Location> locs = new HashMap<>();
+    private final Map<NPC, Pair<Integer, Location>> npcs = new HashMap<>();
 
     /**
      * Creates new listener which prevents Citizens NPCs from walking around
@@ -60,11 +60,11 @@ public class CitizensWalkingListener implements Listener {
                     final CitizensConversation conv = (CitizensConversation) event.getConversation();
                     final NPC npc = conv.getNPC();
                     if (npcs.containsKey(npc)) {
-                        npcs.put(npc, npcs.get(npc) + 1);
+                        final Pair<Integer, Location> pair = npcs.get(npc);
+                        npcs.put(npc, Pair.of(pair.getKey() + 1, pair.getValue()));
                     } else {
                         final Navigator nav = npc.getNavigator();
-                        npcs.put(npc, 1);
-                        locs.put(npc, nav.getTargetAsLocation());
+                        npcs.put(npc, Pair.of(1, nav.getTargetAsLocation()));
                         nav.setPaused(true);
                         nav.cancelNavigation();
                         nav.setTarget(conv.getNPC().getEntity().getLocation());
@@ -85,18 +85,19 @@ public class CitizensWalkingListener implements Listener {
                 public void run() {
                     final CitizensConversation conv = (CitizensConversation) event.getConversation();
                     final NPC npc = conv.getNPC();
-                    final int npcId = npcs.get(npc) - 1;
+                    final Pair<Integer, Location> pair = npcs.get(npc);
+                    final int npcId = pair.getKey() - 1;
                     if (npcId == 0) {
                         npcs.remove(npc);
                         if (npc.isSpawned()) {
                             final Navigator nav = npc.getNavigator();
                             nav.setPaused(false);
-                            nav.setTarget(locs.remove(npc));
+                            nav.setTarget(pair.getValue());
                         } else {
-                            npc.spawn(locs.remove(npc), SpawnReason.PLUGIN);
+                            npc.spawn(pair.getValue(), SpawnReason.PLUGIN);
                         }
                     } else {
-                        npcs.put(npc, npcId);
+                        npcs.put(npc, Pair.of(npcId, pair.getValue()));
                     }
                 }
             }.runTask(BetonQuest.getInstance());
@@ -120,7 +121,8 @@ public class CitizensWalkingListener implements Listener {
      * @param location the location to which the npc should move
      */
     public void setNewTargetLocation(final NPC npc, final Location location) {
-        locs.put(npc, location);
+        final Pair<Integer, Location> pair = npcs.get(npc);
+        npcs.put(npc, Pair.of(pair.getKey(), location));
     }
 
 }

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/NPCMoveEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/NPCMoveEvent.java
@@ -111,6 +111,7 @@ public class NPCMoveEvent extends QuestEvent implements Listener {
         }
         locationsIterator = locations.listIterator(0);
         final Location firstLocation = locationsIterator.next().getLocation(playerID);
+        stopNPCMoving(npc);
         if (npc.isSpawned()) {
             if (CitizensWalkingListener.getInstance().isMovementPaused(npc)) {
                 CitizensWalkingListener.getInstance().setNewTargetLocation(npc, firstLocation);
@@ -146,7 +147,7 @@ public class NPCMoveEvent extends QuestEvent implements Listener {
         if (npc.getId() != npcId) {
             return;
         }
-        if (currentPlayer == null || locationsIterator == null) {
+        if (currentPlayer == null || locationsIterator == null || CitizensWalkingListener.getInstance().isMovementPaused(npc)) {
             return;
         }
         if (event instanceof NavigationStuckEvent || event instanceof NavigationCancelEvent) {
@@ -156,11 +157,7 @@ public class NPCMoveEvent extends QuestEvent implements Listener {
         if (locationsIterator.hasNext()) {
             try {
                 final Location next = locationsIterator.next().getLocation(currentPlayer);
-                if (CitizensWalkingListener.getInstance().isMovementPaused(npc)) {
-                    CitizensWalkingListener.getInstance().setNewTargetLocation(npc, next);
-                } else {
-                    npc.getNavigator().setTarget(next);
-                }
+                npc.getNavigator().setTarget(next);
             } catch (final QuestRuntimeException e) {
                 LogUtils.getLogger().log(Level.WARNING, "Error while NPC " + npc.getId() + " navigation: " + e.getMessage());
                 LogUtils.logThrowable(e);


### PR DESCRIPTION
# Description
```
 [21:38:29 WARN]: [BetonQuest] Task #539570 for BetonQuest v1.12.1-DEV-22 generated an exception
java.lang.NullPointerException: null
        at net.citizensnpcs.npc.ai.CitizensNavigator.setTarget(CitizensNavigator.java:278) ~[?:?]
        at pl.betoncraft.betonquest.compatibility.citizens.CitizensWalkingListener$2.run(CitizensWalkingListener.java:94) ~[?:?]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:99) ~[patched_1.16.5.jar:git-Paper-444]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.5.jar:git-Paper-444]
        at net.minecraft.server.v1_16_R3.MinecraftServer.b(MinecraftServer.java:1293) ~[patched_1.16.5.jar:git-Paper-444]
        at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:377) ~[patched_1.16.5.jar:git-Paper-444]
        at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1208) ~[patched_1.16.5.jar:git-Paper-444]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:996) ~[patched_1.16.5.jar:git-Paper-444]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:173) ~[patched_1.16.5.jar:git-Paper-444]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275] 
```

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  ... add debug messages?
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
