### PR TITLE
Fix UnsupportedOperationException when using /q t <player>.

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -1044,7 +1044,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         }
         // if there are no arguments then list player's tags
         if (args.length < 3 || "list".equalsIgnoreCase(args[2]) || "l".equalsIgnoreCase(args[2])) {
-            final List<String> tags = playerData.getTags();
+            final List<String> tags = new ArrayList<>(playerData.getTags());
             LogUtils.getLogger().log(Level.FINE, "Listing tags");
             sendMessage(sender, "player_tags");
             Collections.sort(tags);


### PR DESCRIPTION
# Description
Fix `UnsupportedOperationException` thrown when using `/q t <player>`.

## Related Issues
Closes #ticket-toeman_ (Discord)

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
