### PR TITLE
add `*` option to mmoclass condition

### DIFF
--- a/documentation/User-Documentation/Compatibility.md
+++ b/documentation/User-Documentation/Compatibility.md
@@ -477,9 +477,13 @@ This event adds experience points in a specified skill. The first argument is th
 ### Conditions
 
 #### MMOCore class: `mmoclass` 
-Checks if a player has the given MMOCore class. If a level has been specified the player needs to be on that level or higher to meet the condition.
+Checks if a player has the given MMOCore class. You can check for any class that is not the default class by writing `*`
+instead of a class name.
+If a level has been specified the player needs to be on that level
+or higher to meet the condition.
 You can disable this behaviour by adding the `equal` argument. 
 ```YAML linenums="1"
+mmoclass * 5
 mmoclass WARRIOR
 mmoclass MAGE 5
 mmoclass MAGE 5 equal

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreClassCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreClassCondition.java
@@ -39,7 +39,7 @@ public class MMOCoreClassCondition extends Condition {
         final String actualClassName = data.getProfess().getName();
         final int actualClassLevel = data.getLevel();
 
-        if (actualClassName.equalsIgnoreCase(targetClassName)) {
+        if (actualClassName.equalsIgnoreCase(targetClassName) || "*".equals(targetClassName) && !"HUMAN".equalsIgnoreCase(actualClassName)) {
             if (targetClassLevel == -1) {
                 return true;
             }


### PR DESCRIPTION
- The `*` now matches any class but the default class (HUMAN)

## Related Issues
Closes #1413 

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
