### PR TITLE
Fix #1421 - Issues parsing braces in math.calc variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAsyncWorldEdit compatibility
 ### Changed
 ### Deprecated
+- math variable now allows rounding output with the ~ operator
 ### Removed
 ### Fixes
+- parsing of math variable
 - craft objective when item on courser
 - NPC hider for not spawned NPCs
 - Conversation IO Chest load NPC skull async from Citizens instead of sync

--- a/documentation/User-Documentation/Variables-List.md
+++ b/documentation/User-Documentation/Variables-List.md
@@ -59,7 +59,7 @@ the variable will resolve.
     
 ## Calculate mathematical expression: `math.calc`
 
-This variable allows you to perform a calculation based on other variables (for example point or objective variables) and resolves to the result of the specified calculation. The variable always starts with `math.calc:`, followed by the calculation which should be calculated. Supported operations are `+`, `-`, `*`, `/` and  `^`. You can use `( )` and `[ ]` braces and also calculate absolute values with `| |` (but don't use this in the command event as it splits the commands at every `|`). If you want to use variables in the calculation, don't put `%` around them.
+This variable allows you to perform a calculation based on other variables (for example point or objective variables) and resolves to the result of the specified calculation. The variable always starts with `math.calc:`, followed by the calculation which should be calculated. Supported operations are `+`, `-`, `*`, `/` and  `^`. You can use `( )` and `[ ]` braces and also calculate absolute values with `| |` (but don't use this in the command event as it splits the commands at every `|`). If you want to use variables in the calculation, don't put `%` around them. Additionally, you can use the round operator `~` to round everything left of it to the number of decimal digits given on the right. So `4+0.35~1` will produce `4.4` and `4.2~0` will produce `4`.
 
 !!! example
     `%math.calc:100*(15-point.reputation.amount)%`

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/Operator.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/Operator.java
@@ -1,0 +1,142 @@
+package pl.betoncraft.betonquest.utils.math;
+
+import pl.betoncraft.betonquest.exceptions.InstructionParseException;
+
+import java.util.Arrays;
+
+/**
+ * Operators that can be used between two tokens for performing an arithmetic expression
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public enum Operator {
+
+    /**
+     * <b>+</b> Operator, adds two values
+     */
+    PLUS('+', 1) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return val1 + val2;
+        }
+    },
+
+    /**
+     * <b>-</b> Operator, subtracts two values
+     */
+    MINUS('-', 1) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return val1 - val2;
+        }
+    },
+
+    /**
+     * <b>*</b> Operator, multiplies two values
+     */
+    MULTIPLY('*', 2) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return val1 * val2;
+        }
+    },
+    /**
+     * <b>/</b> Operator, divides a value by another
+     */
+    DIVIDE('/', 2) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return val1 / val2;
+        }
+    },
+    /**
+     * <b>%</b> Operator, returns the modulo of two values
+     */
+    MODULO('%', 2) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return val1 % val2;
+        }
+    },
+
+    /**
+     * <b>^</b> Operator, returns the power of a value
+     */
+    POW('^', 3) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            return Math.pow(val1, val2);
+        }
+    };
+
+    /**
+     * Symbol representing the operator
+     */
+    private final char symbol;
+
+    /**
+     * Priority of the operation (power before point before line)
+     */
+    private final int priority;
+
+    Operator(final char symbol, final int priority) {
+        this.symbol = symbol;
+        this.priority = priority;
+    }
+
+    /**
+     * Finds the Operator represented by the given symbol
+     *
+     * @param chr the symbol representing an operator
+     * @return the operator of the symbol
+     * @throws InstructionParseException if no operator exists for the given character
+     */
+    public static Operator valueOf(final char chr) throws InstructionParseException {
+        return Arrays.stream(values()).filter(operator -> operator.symbol == chr).findAny()
+                .orElseThrow(() -> new InstructionParseException(chr + " is not a valid operator"));
+    }
+
+    /**
+     * Checks if the given character represents an Operator
+     *
+     * @param chr character to check
+     * @return true if the character is an operator, false otherwise
+     */
+    public static boolean isOperator(final char chr) {
+        return Arrays.stream(values()).anyMatch(operator -> operator.symbol == chr);
+    }
+
+    /**
+     * Returns the Symbol representing the operator
+     *
+     * @return the symbol character
+     */
+    public char getSymbol() {
+        return symbol;
+    }
+
+    /**
+     * Returns the priority of the operator (power before point before line)
+     *
+     * @return the priority (higher should be calculated first)
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(getSymbol());
+    }
+
+    /**
+     * Performs the operation on two values
+     *
+     * @param val1 first value
+     * @param val2 second value
+     * @return result of the operation
+     */
+    public abstract double calculate(double val1, double val2);
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/Operator.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/Operator.java
@@ -42,6 +42,7 @@ public enum Operator {
             return val1 * val2;
         }
     },
+
     /**
      * <b>/</b> Operator, divides a value by another
      */
@@ -51,6 +52,7 @@ public enum Operator {
             return val1 / val2;
         }
     },
+
     /**
      * <b>%</b> Operator, returns the modulo of two values
      */
@@ -68,6 +70,19 @@ public enum Operator {
         @Override
         public double calculate(final double val1, final double val2) {
             return Math.pow(val1, val2);
+        }
+    },
+
+    /**
+     * <b>~</b> Operator, rounds the first value to the number of decimal digits given by the second value
+     */
+    ROUND('~', 0) {
+        @Override
+        public double calculate(final double val1, final double val2) {
+            //Make sure that edge cases (like 0.5) are always rounded up, not down:
+            final double corrected = Double.longBitsToDouble(Double.doubleToLongBits(val1) + 1);
+            final double exp = Math.pow(10, Math.round(val2));
+            return Math.round(corrected * exp) / exp;
         }
     };
 

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/Tokenizer.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/Tokenizer.java
@@ -1,0 +1,216 @@
+package pl.betoncraft.betonquest.utils.math;
+
+import pl.betoncraft.betonquest.VariableNumber;
+import pl.betoncraft.betonquest.exceptions.InstructionParseException;
+import pl.betoncraft.betonquest.utils.math.tokens.AbsoluteValue;
+import pl.betoncraft.betonquest.utils.math.tokens.Number;
+import pl.betoncraft.betonquest.utils.math.tokens.Operation;
+import pl.betoncraft.betonquest.utils.math.tokens.Parenthesis;
+import pl.betoncraft.betonquest.utils.math.tokens.Token;
+import pl.betoncraft.betonquest.utils.math.tokens.Variable;
+import pl.betoncraft.betonquest.variables.MathVariable;
+
+import java.text.DecimalFormat;
+
+/**
+ * Helps the {@link MathVariable} with parsing mathematical expressions.
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+@SuppressWarnings({"PMD.GodClass"})
+public class Tokenizer {
+
+    /**
+     * Decimal separator allowed in numbers
+     */
+    private final char decimalSeparator;
+
+    /**
+     * Name of the package in which the tokenizer is operating
+     */
+    private final String packageName;
+
+    /**
+     * Create a new Tokenizer in given package with given decimal separator
+     *
+     * @param packageName      name of the package
+     * @param decimalSeparator decimal separator char (, or .)
+     */
+    public Tokenizer(final String packageName, final char decimalSeparator) {
+        this.packageName = packageName;
+        this.decimalSeparator = decimalSeparator;
+    }
+
+    /**
+     * Create a new Tokenizer in given package with system default decimal separator
+     *
+     * @param packageName name of the package
+     */
+    public Tokenizer(final String packageName) {
+        this(
+                packageName,
+                ((DecimalFormat) DecimalFormat.getInstance()).getDecimalFormatSymbols().getDecimalSeparator()
+        );
+    }
+
+    /**
+     * Parse the given mathematical expression into a so-called token.
+     * This token can then be used to resolve the expression at runtime for a specific player.
+     *
+     * @param expression the expression that should be parsed
+     * @return expression parsed as token
+     * @throws InstructionParseException if the expression is invalid and therefore couldn't be parsed
+     */
+    public Token tokenize(final String expression) throws InstructionParseException {
+        return tokenize(null, null, expression.replaceAll("\\s", ""));
+    }
+
+    /**
+     * Internal method for recursive token parsing
+     * <p>
+     * The method will walk through the expression from the left side to the right side.
+     * Depending on the first character the type of the left token will be determined.
+     * Between two tokens there must always be an operator.
+     *
+     * @param val1     token left of the given string, or null if {@code val2} will be first token
+     * @param operator operator between the token ({@code val1}) and the string ({@code val2})
+     * @param val2     string containing the rest of the expression that still needs to be parsed
+     * @return parsed token
+     * @throws InstructionParseException if the expression is invalid and therefore couldn't be parsed
+     */
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.AvoidLiteralsInIfCondition",
+            "PMD.NcssCount", "PMD.ExcessiveMethodLength"})
+    private Token tokenize(final Token val1, final Operator operator, final String val2) throws InstructionParseException {
+        if (val2.isEmpty() && operator != null) {
+            throw new InstructionParseException("invalid calculation (operator missing second value)");
+        } else if (val2.isEmpty()) {
+            throw new InstructionParseException("missing calculation");
+        }
+
+        //Parse next token in line (from left to right)
+        Token nextInLine = null;
+        int index = 0;
+        char chr = val2.charAt(index++);
+
+        if (chr == '(' || chr == '[') { //tokenize parenthesis
+            int depth = 1;
+            for (; index < val2.length(); index++) {
+                chr = val2.charAt(index);
+                if (chr == '(' || chr == '[') {
+                    depth++;
+                } else if (chr == ')' || chr == ']') {
+                    depth--;
+                }
+
+                if (depth == 0) {
+                    if (index == 1) {
+                        throw new InstructionParseException("invalid calculation (empty parenthesis)");
+                    }
+
+                    nextInLine = new Parenthesis(tokenize(null, null, val2.substring(1, index)));
+                    break;
+                }
+            }
+            if (nextInLine == null) {
+                throw new InstructionParseException("invalid calculation (unbalanced parenthesis)");
+            }
+
+
+        } else if (chr == '|') { //tokenize absolute values
+            int depth = 0;
+            for (; index < val2.length(); index++) {
+                chr = val2.charAt(index);
+                if (chr == '(' || chr == '[') {
+                    depth++;
+                } else if (chr == ')' || chr == ']') {
+                    depth--;
+                }
+
+                if (depth == 0 && chr == '|') {
+                    if (index == 1) {
+                        throw new InstructionParseException("invalid calculation (empty absolute value)");
+                    }
+
+                    nextInLine = new AbsoluteValue(tokenize(null, null, val2.substring(1, index)));
+                    break;
+                }
+            }
+            if (nextInLine == null) {
+                throw new InstructionParseException("invalid calculation (unbalanced absolute value)");
+            }
+
+        } else if (Character.isDigit(chr) || chr == '-') { //tokenize numbers
+            for (; index < val2.length(); index++) {
+                chr = val2.charAt(index);
+                if (!Character.isDigit(chr) && chr != decimalSeparator) {
+                    break;
+                }
+            }
+            try {
+                nextInLine = new Number(Double.parseDouble(val2.substring(0, index--)));
+            } catch (NumberFormatException e) {
+                throw new InstructionParseException("invalid calculation (invalid number)", e);
+            }
+
+        } else if (Character.isAlphabetic(chr)) { //tokenize variables
+            //FIXME this assumes all variables start with an alphabetic character
+            for (; index < val2.length(); index++) {
+                chr = val2.charAt(index);
+                if (Operator.isOperator(chr) || "([|])".contains(String.valueOf(chr))) {
+                    break;
+                }
+            }
+            try {
+                nextInLine = new Variable(new VariableNumber(packageName, "%" + val2.substring(0, index--) + "%"));
+            } catch (InstructionParseException e) {
+                throw new InstructionParseException("invalid calculation (" + e.getMessage() + ")", e);
+            }
+
+        } else { //error handling
+            if (chr == ')' || chr == ']') {
+                throw new InstructionParseException("invalid calculation (unbalanced parenthesis)");
+            } else if (Operator.isOperator(chr) && operator != null) {
+                throw new InstructionParseException("invalid calculation (doubled operators)");
+            } else if (Operator.isOperator(chr) && operator == null) {
+                throw new InstructionParseException("invalid calculation (operator missing first value)");
+            } else {
+                throw new InstructionParseException("invalid calculation (unknown reason)");
+            }
+        }
+
+        if (index < val2.length() - 1) {
+            try {
+                chr = val2.charAt(++index);
+                if (!Operator.isOperator(chr)) {
+                    throw new InstructionParseException("invalid calculation (missing operator)");
+                }
+                final Operator nextOperator = Operator.valueOf(chr);
+                final String newVal = val2.substring(++index);
+
+                //no token left of this token, parse next
+                if (operator == null) {
+                    return tokenize(nextInLine, nextOperator, newVal);
+                }
+
+                //next operation has higher priority, tokenize it first
+                if (nextOperator.getPriority() > operator.getPriority()) {
+                    return new Operation(val1, operator, tokenize(nextInLine, nextOperator, newVal));
+                }
+
+                //next operation has lower priority, tokenize this first
+                return tokenize(new Operation(val1, operator, nextInLine), nextOperator, newVal);
+
+            } catch (InstructionParseException e) {
+                throw new InstructionParseException(e.getMessage(), e);
+            }
+        } else {
+            if (operator == null) {
+                return nextInLine;
+            } else {
+                return new Operation(val1, operator, nextInLine);
+            }
+        }
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/AbsoluteValue.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/AbsoluteValue.java
@@ -1,0 +1,37 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+
+/**
+ * Returns the absolute value (see {@link Math#abs(double)}) of a token
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public class AbsoluteValue implements Token {
+
+    /**
+     * Token that is inside
+     */
+    private final Token inside;
+
+    /**
+     * Constructs a new absolute value
+     *
+     * @param inside token that is inside
+     */
+    public AbsoluteValue(final Token inside) {
+        this.inside = inside;
+    }
+
+    @Override
+    public double resolve(final String playerID) throws QuestRuntimeException {
+        return Math.abs(inside.resolve(playerID));
+    }
+
+    @Override
+    public String toString() {
+        return '|' + inside.toString() + '|';
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Number.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Number.java
@@ -1,0 +1,35 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+/**
+ * Token that is just any number
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public class Number implements Token {
+
+    /**
+     * The value
+     */
+    private final double value;
+
+    /**
+     * Creates a new number
+     *
+     * @param value value of the number
+     */
+    public Number(final double value) {
+        this.value = value;
+    }
+
+    @Override
+    public double resolve(final String playerID) {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Operation.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Operation.java
@@ -1,0 +1,52 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+import pl.betoncraft.betonquest.utils.math.Operator;
+
+/**
+ * An operation performed on two tokens
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public class Operation implements Token {
+
+    /**
+     * First value, left of the operator
+     */
+    private final Token val1;
+
+    /**
+     * The operator
+     */
+    private final Operator operator;
+
+    /**
+     * Second value, right of the operator
+     */
+    private final Token val2;
+
+    /**
+     * Creates a new operation
+     *
+     * @param val1     left token
+     * @param operator operator
+     * @param val2     right token
+     */
+    public Operation(final Token val1, final Operator operator, final Token val2) {
+        this.val1 = val1;
+        this.operator = operator;
+        this.val2 = val2;
+    }
+
+    @Override
+    public double resolve(final String playerID) throws QuestRuntimeException {
+        return operator.calculate(val1.resolve(playerID), val2.resolve(playerID));
+    }
+
+    @Override
+    public String toString() {
+        return val1.toString() + operator.toString() + val2.toString();
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Parenthesis.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Parenthesis.java
@@ -1,0 +1,37 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+
+/**
+ * Parenthesis around another token
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public class Parenthesis implements Token {
+
+    /**
+     * Token that is inside these parenthesis
+     */
+    private final Token inside;
+
+    /**
+     * Creates new parenthesis around a token
+     *
+     * @param inside token that is inside
+     */
+    public Parenthesis(final Token inside) {
+        this.inside = inside;
+    }
+
+    @Override
+    public double resolve(final String playerID) throws QuestRuntimeException {
+        return inside.resolve(playerID);
+    }
+
+    @Override
+    public String toString() {
+        return '(' + inside.toString() + ')';
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Token.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Token.java
@@ -1,0 +1,24 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+
+/**
+ * Part of a parsed mathematical expression, that can be resolved to a number.
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public interface Token {
+
+    /**
+     * Resolves the tokens expression and returns the result.
+     *
+     * @param playerID player for which this token should be resolved,
+     *                 required for parsing variables
+     * @return the result
+     * @throws QuestRuntimeException if the Token contained variables that could not be resolved
+     *                               due to an Quest Runtime exception
+     */
+    double resolve(final String playerID) throws QuestRuntimeException;
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Variable.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/math/tokens/Variable.java
@@ -1,0 +1,38 @@
+package pl.betoncraft.betonquest.utils.math.tokens;
+
+import pl.betoncraft.betonquest.VariableNumber;
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+
+/**
+ * A token that is a Variable
+ *
+ * @deprecated This should be replaced in BQ 2.0 with a real expression parsing lib like
+ * https://github.com/fasseg/exp4j
+ */
+@Deprecated
+public class Variable implements Token {
+
+    /**
+     * Underlying variable
+     */
+    private final VariableNumber variableNumber;
+
+    /**
+     * Creates a new variable token from a variable number
+     *
+     * @param variableNumber underlying variable
+     */
+    public Variable(final VariableNumber variableNumber) {
+        this.variableNumber = variableNumber;
+    }
+
+    @Override
+    public double resolve(final String playerID) throws QuestRuntimeException {
+        return variableNumber.getDouble(playerID);
+    }
+
+    @Override
+    public String toString() {
+        return variableNumber.toString();
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/variables/MathVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/variables/MathVariable.java
@@ -1,25 +1,23 @@
 package pl.betoncraft.betonquest.variables;
 
 import pl.betoncraft.betonquest.Instruction;
-import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.api.Variable;
-import pl.betoncraft.betonquest.config.ConfigPackage;
 import pl.betoncraft.betonquest.exceptions.InstructionParseException;
 import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
 import pl.betoncraft.betonquest.utils.LogUtils;
+import pl.betoncraft.betonquest.utils.math.Tokenizer;
+import pl.betoncraft.betonquest.utils.math.tokens.Token;
 
 import java.util.Locale;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * This variable evaluates the given calculation and returns the result.
  */
-@SuppressWarnings("PMD.CommentRequired")
+@SuppressWarnings({"PMD.CommentRequired", "deprecation"})
 public class MathVariable extends Variable {
 
-    private final Calculable calculation;
+    private final Token calculation;
 
     public MathVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);
@@ -27,13 +25,14 @@ public class MathVariable extends Variable {
         if (!instructionString.matches("math\\.calc:.+")) {
             throw new InstructionParseException("invalid format");
         }
-        this.calculation = this.parse(instructionString.substring("math.calc:".length()));
+        final String expression = instructionString.substring("math.calc:".length());
+        this.calculation = new Tokenizer(instruction.getPackage().getName(), '.').tokenize(expression);
     }
 
     @Override
     public String getValue(final String playerID) {
         try {
-            final double value = this.calculation.calculate(playerID);
+            final double value = calculation.resolve(playerID);
             if (value % 1 == 0) {
                 return String.format(Locale.US, "%.0f", value);
             }
@@ -42,208 +41,6 @@ public class MathVariable extends Variable {
             LogUtils.getLogger().log(Level.WARNING, "Could not calculate '" + calculation.toString() + "' (" + e.getMessage() + "). Returning 0 instead.");
             LogUtils.logThrowable(e);
             return "0";
-        }
-    }
-
-    /**
-     * Recursively parse a calculable object from the given calculation string which can be calculated in later process
-     *
-     * @param string the string which should be evaluated
-     * @return a calculable object which contains the whole calculation
-     * @throws InstructionParseException if the instruction isn't valid
-     */
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    private Calculable parse(final String string) throws InstructionParseException {
-        //clarify error messages for invalid calculations
-        if (string.matches(".*[+\\-*/^]{2}.*")) {
-            throw new InstructionParseException("invalid calculation (operations doubled)");
-        }
-        if (string.matches(".*(\\([^)]*|\\[[^]]*)")
-                || string.matches("([^(]*\\)|[^\\[]*]).*")) {
-            throw new InstructionParseException("invalid calculation (uneven braces)");
-        }
-        //calculate braces
-        if (string.matches("(\\(.+\\)|\\[.+])")) {
-            return this.parse(string.substring(1, string.length() - 1));
-        }
-        //calculate the absolute value
-        if (string.matches("\\|.+\\|")) {
-            return new AbsoluteValue(this.parse(string.substring(1, string.length() - 1)));
-        }
-        String tempCopy = string;
-        final Matcher matcher = Pattern.compile("(\\(.+\\)|\\[.+]|\\|.+\\|)").matcher(tempCopy);
-        //ignore content of braces for all next operations
-        while (matcher.find()) {
-            final int start = matcher.start();
-            final int end = matcher.end();
-            final int length = end - start;
-            final StringBuilder substring = new StringBuilder(tempCopy.substring(0, start + 1));
-            for (int i = 0; i < length - 2; i++) {
-                substring.append(" ");
-            }
-            substring.append(tempCopy.substring(end - 1));
-            tempCopy = substring.toString();
-        }
-        // ADDITION and SUBTRACTION
-        int indexPlus = tempCopy.lastIndexOf('+');
-        int indexMinus = tempCopy.lastIndexOf('-');
-        if (indexPlus > indexMinus) {
-            if (indexPlus == 0) {
-                return new Calculation(new ClaculableVariable(0), this.parse(string.substring(1)), Operation.ADD);
-            }
-            //'+' comes after '-'
-            return new Calculation(this.parse(string.substring(0, indexPlus)),
-                    this.parse(string.substring(indexPlus + 1)),
-                    Operation.ADD);
-        } else if (indexMinus > indexPlus) {
-            if (indexMinus == 0) {
-                return new Calculation(new ClaculableVariable(0), this.parse(string.substring(1)), Operation.SUBTRACT);
-            }
-            //'-' comes after '+'
-            return new Calculation(this.parse(string.substring(0, indexMinus)),
-                    this.parse(string.substring(indexMinus + 1)),
-                    Operation.SUBTRACT);
-        }
-        //MULTIPLY and DIVIDE
-        indexPlus = tempCopy.lastIndexOf('*');
-        indexMinus = tempCopy.lastIndexOf('/');
-        if (indexPlus > indexMinus) {
-            //'*' comes after '/'
-            return new Calculation(this.parse(string.substring(0, indexPlus)),
-                    this.parse(string.substring(indexPlus + 1)),
-                    Operation.MULTIPLY);
-        } else if (indexMinus > indexPlus) {
-            //'/' comes after '*'
-            return new Calculation(this.parse(string.substring(0, indexMinus)),
-                    this.parse(string.substring(indexMinus + 1)),
-                    Operation.DIVIDE);
-        }
-        //POW
-        indexPlus = tempCopy.lastIndexOf('^');
-        if (indexPlus != -1) {
-            return new Calculation(this.parse(string.substring(0, indexPlus)),
-                    this.parse(string.substring(indexPlus + 1)),
-                    Operation.POW);
-        }
-        //if string matches a number
-        if (string.matches("\\d+(\\.\\d+)?")) {
-            return new ClaculableVariable(Double.parseDouble(string));
-        }
-        //if a variable is specified
-        try {
-            return new ClaculableVariable(super.instruction.getPackage(), "%" + string + "%");
-        } catch (InstructionParseException e) {
-            throw new InstructionParseException(e.getMessage(), e);
-        }
-    }
-
-    private enum Operation {
-        ADD('+'),
-        SUBTRACT('-'),
-        MULTIPLY('*'),
-        DIVIDE('/'),
-        POW('^');
-
-        private final char operator;
-
-        Operation(final char operator) {
-            this.operator = operator;
-        }
-    }
-
-    private interface Calculable {
-
-        double calculate(String playerId) throws QuestRuntimeException;
-    }
-
-    private static class ClaculableVariable implements Calculable {
-
-        private final VariableNumber variable;
-
-        public ClaculableVariable(final VariableNumber variable) {
-            this.variable = variable;
-        }
-
-        public ClaculableVariable(final double number) {
-            this(new VariableNumber(number));
-        }
-
-        public ClaculableVariable(final ConfigPackage pack, final String variable) throws InstructionParseException {
-            this(new VariableNumber(pack.getName(), variable));
-        }
-
-        @Override
-        public double calculate(final String playerId) throws QuestRuntimeException {
-            return variable.getDouble(playerId);
-        }
-
-        @Override
-        public String toString() {
-            return variable.toString().replace("%", "");
-        }
-    }
-
-    private static class AbsoluteValue implements Calculable {
-
-        private final Calculable number;
-
-        public AbsoluteValue(final Calculable number) {
-            this.number = number;
-        }
-
-        @Override
-        public String toString() {
-            return "|" + number + "|";
-        }
-
-        @Override
-        public double calculate(final String playerId) throws QuestRuntimeException {
-            return Math.abs(number.calculate(playerId));
-        }
-    }
-
-    private static class Calculation implements Calculable {
-
-        private final Calculable numberA;
-        private final Calculable numberB;
-        private final Operation operation;
-
-        public Calculation(final Calculable numberA, final Calculable numberB, final Operation operation) {
-            this.numberA = numberA;
-            this.numberB = numberB;
-            this.operation = operation;
-        }
-
-        @Override
-        public double calculate(final String playerId) throws QuestRuntimeException {
-            try {
-                switch (operation) {
-                    case ADD:
-                        return numberA.calculate(playerId) + numberB.calculate(playerId);
-                    case SUBTRACT:
-                        return numberA.calculate(playerId) - numberB.calculate(playerId);
-                    case MULTIPLY:
-                        return numberA.calculate(playerId) * numberB.calculate(playerId);
-                    case DIVIDE:
-                        return numberA.calculate(playerId) / numberB.calculate(playerId);
-                    case POW:
-                        return Math.pow(numberA.calculate(playerId), numberB.calculate(playerId));
-                    default:
-                        throw new QuestRuntimeException("unsupported operation: " + operation);
-                }
-            } catch (ArithmeticException e) {
-                throw new QuestRuntimeException(e.getMessage(), e);
-            }
-        }
-
-        @Override
-        @SuppressWarnings("PMD.SimplifyStartsWith")
-        public String toString() {
-            final String numberA = this.numberA instanceof Calculation || this.numberA.toString().startsWith("-")
-                    ? "(" + this.numberA.toString() + ")" : this.numberA.toString();
-            final String numberB = this.numberB instanceof Calculation || this.numberB.toString().startsWith("-")
-                    ? "(" + this.numberB.toString() + ")" : this.numberB.toString();
-            return numberA + operation.operator + numberB;
         }
     }
 }

--- a/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
+++ b/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
@@ -1,0 +1,585 @@
+package pl.betoncraft.betonquest.utils.math;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.MockedStatic;
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.api.Variable;
+import pl.betoncraft.betonquest.config.Config;
+import pl.betoncraft.betonquest.config.ConfigPackage;
+import pl.betoncraft.betonquest.exceptions.InstructionParseException;
+import pl.betoncraft.betonquest.exceptions.QuestRuntimeException;
+import pl.betoncraft.betonquest.utils.math.tokens.Token;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("deprecation")
+public class TokenizerTest {
+
+    public static final double REQUIRED_DOUBLE_PRECISION = 1E-7;
+    public static final String TEST_PACKAGE = "package";
+    public static final String TEST_PLAYER_ID = "player";
+
+    private static Tokenizer createTokenizer() {
+        return new Tokenizer(TEST_PACKAGE, '.');
+    }
+
+    private static void withVariables(final Executable executable, final ProtoVariable... variables) throws Throwable {
+        try (final MockedStatic<Config> config = mockStatic(Config.class);
+             final MockedStatic<BetonQuest> betonQuest = mockStatic(BetonQuest.class)) {
+            final ConfigPackage configPackage = mock(ConfigPackage.class);
+            final Map<String, ConfigPackage> packageMap = Collections.singletonMap(TEST_PACKAGE, configPackage);
+            //noinspection ResultOfMethodCallIgnored
+            config.when(Config::getPackages).thenReturn(packageMap);
+
+            for (final ProtoVariable variableTemplate : variables) {
+                final Variable var = mock(Variable.class);
+                when(var.getValue(TEST_PLAYER_ID)).thenReturn(variableTemplate.getValue());
+                betonQuest.when(() -> BetonQuest.createVariable(configPackage, "%" + variableTemplate.getKey() + "%")).thenReturn(var);
+            }
+
+            executable.execute();
+        }
+    }
+
+    public TokenizerTest() {
+    }
+
+    @Test
+    public void testTokenizeNull() {
+        final Tokenizer tokenizer = createTokenizer();
+        //noinspection ConstantConditions
+        assertThrows(NullPointerException.class, () -> tokenizer.tokenize(null));
+    }
+
+    @Test
+    public void testTokenizeEmpty() {
+        final Tokenizer tokenizer = createTokenizer();
+        assertThrows(InstructionParseException.class, () -> tokenizer.tokenize(""));
+    }
+
+    @Test
+    public void testTokenizeDigit() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+
+        final Token result = tokenizer.tokenize("1");
+        assertEquals(1, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeInteger() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final double number = 2134671;
+
+        final Token result = tokenizer.tokenize(String.valueOf(number));
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeNegativeInteger() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final double number = -56234;
+
+        final Token result = tokenizer.tokenize(String.valueOf(number));
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDecimal() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final double number = 45213.2345;
+
+        final Token result = tokenizer.tokenize(String.valueOf(number));
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final double number = -7342.634;
+
+        final Token result = tokenizer.tokenize(String.valueOf(number));
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeIntegerAddition() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1+2";
+        final double expectedResult = 3;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeIntegerSubtraction() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1-2";
+        final double expectedResult = -1;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeIntegerMultiplication() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "2*3";
+        final double expectedResult = 6;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeIntegerDivision() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "6/3";
+        final double expectedResult = 2;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDecimalAddition() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1.7+3.5";
+        final double expectedResult = 5.2;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDecimalSubtraction() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "4.6-5.3";
+        final double expectedResult = -0.7;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDecimalMultiplication() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "2.4*5.3";
+        final double expectedResult = 12.72;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDecimalDivision() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "7.8/3.2";
+        final double expectedResult = 2.4375;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeAddNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "18.3+-23.4";
+        final double expectedResult = -5.1;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeSubtractNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "7--5";
+        final double expectedResult = 12;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeMultiplyNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1.3*-2";
+        final double expectedResult = -2.6;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDotRuleAddThenMultiple() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "13+2*4";
+        final double expectedResult = 21;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDotRuleMultipleThenAdd() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "8*3+14";
+        final double expectedResult = 38;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDotRuleMinusThenDivide() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "3.7-12/24";
+        final double expectedResult = 3.2;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDotRuleDivideThenMinus() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "14/4-0.7";
+        final double expectedResult = 2.8;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDotRuleModulo() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "5+13%7-2";
+        final double expectedResult = 9;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizePowerRuleExponentThenMultiply() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "3^4*2";
+        final double expectedResult = 162;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizePowerRuleMultiplyThenExponent() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "0.3*2^5";
+        final double expectedResult = 9.6;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeSimpleParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "(4123)";
+        final double expectedResult = 4123;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeSimpleDoubleParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "((4123))";
+        final double expectedResult = 4123;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeCalculationInParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "(423+543)";
+        final double expectedResult = 966;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeMultipleOfSum() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "2.3*(32+12+65)";
+        final double expectedResult = 250.7;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDeepParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1-(45+((23-5)*4))/6";
+        final double expectedResult = -18.5;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "(14+6)*(4-1)/(8*2)+(12/3)";
+        final double expectedResult = 7.75;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeDeepAndChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "((1-1)*2)/1.5+(3/4)";
+        final double expectedResult = 0.75;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Disabled("negating parenthesis is not a supported feature")
+    @Test
+    public void testTokenizeNegativeParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "-(15.4-32.9)";
+        final double expectedResult = 17.5;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeAbsoluteOfPositive() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "|5|";
+        final double expectedResult = 5;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeAbsoluteOfNegative() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "|-7|";
+        final double expectedResult = 7;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeAbsoluteOfNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "|-32.65|";
+        final double expectedResult = 32.65;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Disabled("negating absolute is not a supported feature")
+    @Test
+    public void testTokenizeNegativeAbsolute() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "-|-23.5|";
+        final double expectedResult = -23.5;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+    }
+
+    @Test
+    public void testTokenizeVariable() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var";
+        final double value = 43;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithNumber() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var2";
+        final double value = 44;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithUnderscore() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var_able";
+        final double value = 45;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithTilde() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var~de";
+        final double value = 46;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithBang() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var!bang";
+        final double value = 47;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithEquals() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var=qu";
+        final double value = 48;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithNumberSign() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var#rav";
+        final double value = 49;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithAmpersand() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var&more";
+        final double value = 50;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithApostrophe() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "variable's";
+        final double value = 51;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithQuestionMark() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var?not";
+        final double value = 52;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithDot() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var.net";
+        final double value = 53;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableWithColon() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var:res";
+        final double value = 54;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    @Test
+    public void testTokenizeVariableEndingWithNumber() throws Throwable {
+        final Tokenizer tokenizer = createTokenizer();
+        final String variable = "var123";
+        final double value = 53;
+
+        withVariables(() -> {
+            final Token result = tokenizer.tokenize(variable);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        }, new ProtoVariable(variable, String.valueOf(value)));
+    }
+
+    private static class ProtoVariable {
+        private final String key;
+        private final String value;
+
+        public ProtoVariable(final String key, final String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
+++ b/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
@@ -305,6 +305,56 @@ public class TokenizerTest {
     }
 
     @Test
+    /* default */ void testTokenizeRoundToInteger() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "2.2~0";
+        final double expectedResult = 2;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "the round operator should round the first value to the given number of decimal digits when tokenized");
+    }
+
+    @Test
+    /* default */ void testTokenizeRoundEdgeCase() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "3.05~1";
+        final double expectedResult = 3.1;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenized round operator should also properly round edge cases like 0.5");
+    }
+
+    @Test
+    /* default */ void testTokenizeRoundResult() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "10-3.03*4~1";
+        final double expectedResult = -2.1;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "round operator should have lowest priority when tokenized");
+    }
+
+    @Test
+    /* default */ void testTokenizeRoundInParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "(4.0345~2)*4";
+        final double expectedResult = 16.12;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "rounding inside parenthesis should work to when tokenized");
+    }
+
+    @Test
+    /* default */ void testTokenizeRoundParenthesis() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "(4.0345*4)~2";
+        final double expectedResult = 16.14;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "rounding the content of a parenthesis should also tokenize");
+    }
+
+    @Test
     /* default */ void testTokenizeSimpleParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "(4123)";
@@ -465,6 +515,7 @@ public class TokenizerTest {
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
+    @Disabled("tilde operator is for rounding numbers")
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     /* default */ void testTokenizeVariableWithTilde() throws Throwable {

--- a/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
+++ b/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
@@ -18,11 +18,25 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@SuppressWarnings("deprecation")
+/**
+ * Test the {@link Tokenizer}.
+ */
+@SuppressWarnings({"deprecation", "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 public class TokenizerTest {
 
+    /**
+     * Precision up to which to check equality of floating point numbers
+     */
     public static final double REQUIRED_DOUBLE_PRECISION = 1E-7;
+
+    /**
+     * The package name of the package we assume to be inside for variable resolution.
+     */
     public static final String TEST_PACKAGE = "package";
+
+    /**
+     * The player name to use for variable resolution.
+     */
     public static final String TEST_PLAYER_ID = "player";
 
     private static Tokenizer createTokenizer() {
@@ -30,8 +44,8 @@ public class TokenizerTest {
     }
 
     private static void withVariables(final Executable executable, final ProtoVariable... variables) throws Throwable {
-        try (final MockedStatic<Config> config = mockStatic(Config.class);
-             final MockedStatic<BetonQuest> betonQuest = mockStatic(BetonQuest.class)) {
+        try (MockedStatic<Config> config = mockStatic(Config.class);
+             MockedStatic<BetonQuest> betonQuest = mockStatic(BetonQuest.class)) {
             final ConfigPackage configPackage = mock(ConfigPackage.class);
             final Map<String, ConfigPackage> packageMap = Collections.singletonMap(TEST_PACKAGE, configPackage);
             //noinspection ResultOfMethodCallIgnored
@@ -47,528 +61,561 @@ public class TokenizerTest {
         }
     }
 
+    /**
+     * Create the TokenizerTest.
+     */
     public TokenizerTest() {
     }
 
     @Test
-    public void testTokenizeNull() {
+    /* default */ void testTokenizeNull() {
         final Tokenizer tokenizer = createTokenizer();
         //noinspection ConstantConditions
-        assertThrows(NullPointerException.class, () -> tokenizer.tokenize(null));
+        assertThrows(NullPointerException.class, () -> tokenizer.tokenize(null), "tokenizing null should fail (NPE)");
     }
 
     @Test
-    public void testTokenizeEmpty() {
+    /* default */ void testTokenizeEmpty() {
         final Tokenizer tokenizer = createTokenizer();
-        assertThrows(InstructionParseException.class, () -> tokenizer.tokenize(""));
+        assertThrows(InstructionParseException.class, () -> tokenizer.tokenize(""), "an empty string should not be parsable");
     }
 
     @Test
-    public void testTokenizeDigit() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDigit() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
 
         final Token result = tokenizer.tokenize("1");
-        assertEquals(1, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(1, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a single letter integer should work");
     }
 
     @Test
-    public void testTokenizeInteger() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeInteger() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
-        final double number = 2134671;
+        final double number = 2_134_671;
 
         final Token result = tokenizer.tokenize(String.valueOf(number));
-        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a multi letter integer should work");
     }
 
     @Test
-    public void testTokenizeNegativeInteger() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeNegativeInteger() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
-        final double number = -56234;
+        final double number = -56_234;
 
         final Token result = tokenizer.tokenize(String.valueOf(number));
-        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a negative integer should work");
     }
 
     @Test
-    public void testTokenizeDecimal() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDecimal() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
-        final double number = 45213.2345;
+        final double number = 45_213.234_5;
 
         final Token result = tokenizer.tokenize(String.valueOf(number));
-        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a decimal should work");
     }
 
     @Test
-    public void testTokenizeNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
-        final double number = -7342.634;
+        final double number = -7_342.634;
 
         final Token result = tokenizer.tokenize(String.valueOf(number));
-        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(number, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a negative decimal should work");
     }
 
     @Test
-    public void testTokenizeIntegerAddition() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeIntegerAddition() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "1+2";
         final double expectedResult = 3;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing addition of two integers should work");
     }
 
     @Test
-    public void testTokenizeIntegerSubtraction() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeIntegerSubtraction() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "1-2";
         final double expectedResult = -1;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing subtraction of two integers should work");
     }
 
     @Test
-    public void testTokenizeIntegerMultiplication() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeIntegerMultiplication() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "2*3";
         final double expectedResult = 6;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing multiplication of two integers should work");
     }
 
     @Test
-    public void testTokenizeIntegerDivision() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeIntegerDivision() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "6/3";
         final double expectedResult = 2;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing division of two integers should work");
     }
 
     @Test
-    public void testTokenizeDecimalAddition() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDecimalAddition() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "1.7+3.5";
         final double expectedResult = 5.2;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing addition of two decimals should work");
     }
 
     @Test
-    public void testTokenizeDecimalSubtraction() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDecimalSubtraction() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "4.6-5.3";
         final double expectedResult = -0.7;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing subtraction of two decimals should work");
     }
 
     @Test
-    public void testTokenizeDecimalMultiplication() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDecimalMultiplication() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "2.4*5.3";
         final double expectedResult = 12.72;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing multiplication of two decimals should work");
     }
 
     @Test
-    public void testTokenizeDecimalDivision() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDecimalDivision() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "7.8/3.2";
         final double expectedResult = 2.4375;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing division of two decimals should work");
     }
 
     @Test
-    public void testTokenizeAddNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeAddNegativeNumber() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "18.3+-23.4";
         final double expectedResult = -5.1;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing addition of a negative number onto a number should work");
     }
 
     @Test
-    public void testTokenizeSubtractNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeSubtractNegativeNumber() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "7--5";
         final double expectedResult = 12;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing subtraction of a negative number from a number should work");
     }
 
     @Test
-    public void testTokenizeMultiplyNegativeNumber() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeMultiplyNegativeNumber() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "1.3*-2";
         final double expectedResult = -2.6;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing multiplication with a negative number should work");
     }
 
     @Test
-    public void testTokenizeDotRuleAddThenMultiple() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDotRuleAddThenMultiple() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "13+2*4";
         final double expectedResult = 21;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first addition, then multiplication should first multiply, then add");
     }
 
     @Test
-    public void testTokenizeDotRuleMultipleThenAdd() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDotRuleMultipleThenAdd() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "8*3+14";
         final double expectedResult = 38;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first multiplication, then addition should first multiply, then add");
     }
 
     @Test
-    public void testTokenizeDotRuleMinusThenDivide() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDotRuleMinusThenDivide() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "3.7-12/24";
         final double expectedResult = 3.2;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first subtraction, then division should first divide, then subtract");
     }
 
     @Test
-    public void testTokenizeDotRuleDivideThenMinus() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDotRuleDivideThenMinus() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "14/4-0.7";
         final double expectedResult = 2.8;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first division, then subtraction should first divide, then subtract");
     }
 
     @Test
-    public void testTokenizeDotRuleModulo() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDotRuleModulo() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "5+13%7-2";
         final double expectedResult = 9;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with addition, modulo and subtraction, then modulo should be done before adding and subtracting");
     }
 
     @Test
-    public void testTokenizePowerRuleExponentThenMultiply() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizePowerRuleExponentThenMultiply() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "3^4*2";
         final double expectedResult = 162;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first the power operator, then multiplication the power should be calculated before doing the multiplication");
     }
 
     @Test
-    public void testTokenizePowerRuleMultiplyThenExponent() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizePowerRuleMultiplyThenExponent() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "0.3*2^5";
         final double expectedResult = 9.6;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with first multiplication, then the power operator the power should be calculated before doing the multiplication");
     }
 
     @Test
-    public void testTokenizeSimpleParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeSimpleParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "(4123)";
         final double expectedResult = 4123;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with a number inside a parenthesis should work");
     }
 
     @Test
-    public void testTokenizeSimpleDoubleParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeSimpleDoubleParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "((4123))";
         final double expectedResult = 4123;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with a number inside multiple parenthesis should work");
     }
 
     @Test
-    public void testTokenizeCalculationInParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeCalculationInParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "(423+543)";
         final double expectedResult = 966;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string with a calculation inside a parenthesis should work");
     }
 
     @Test
-    public void testTokenizeMultipleOfSum() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeMultipleOfSum() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "2.3*(32+12+65)";
         final double expectedResult = 250.7;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a string multiplying the result of a calculation inside a parenthesis should work");
     }
 
     @Test
-    public void testTokenizeDeepParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDeepParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "1-(45+((23-5)*4))/6";
         final double expectedResult = -18.5;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a calculation with multiple layers of calculations inside parenthesis should work");
     }
 
     @Test
-    public void testTokenizeChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "(14+6)*(4-1)/(8*2)+(12/3)";
         final double expectedResult = 7.75;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a series of calculations in parenthesis should work");
     }
 
     @Test
-    public void testTokenizeDeepAndChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeDeepAndChainedParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "((1-1)*2)/1.5+(3/4)";
         final double expectedResult = 0.75;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a mix of parenthesis inside and sequential should work; issue #1421");
     }
 
     @Disabled("negating parenthesis is not a supported feature")
     @Test
-    public void testTokenizeNegativeParenthesis() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeNegativeParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "-(15.4-32.9)";
         final double expectedResult = 17.5;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing the negation of the result of a calculation inside parenthesis should work");
     }
 
     @Test
-    public void testTokenizeAbsoluteOfPositive() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeAbsoluteOfPositive() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "|5|";
         final double expectedResult = 5;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing the calculation of the absolute of a positive number should work");
     }
 
     @Test
-    public void testTokenizeAbsoluteOfNegative() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeAbsoluteOfNegative() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "|-7|";
         final double expectedResult = 7;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing the calculation of the absolute of a negative number should work");
     }
 
     @Test
-    public void testTokenizeAbsoluteOfNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeAbsoluteOfNegativeDecimal() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "|-32.65|";
         final double expectedResult = 32.65;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing the calculation of the absolute of a negative decimal should work");
     }
 
     @Disabled("negating absolute is not a supported feature")
     @Test
-    public void testTokenizeNegativeAbsolute() throws InstructionParseException, QuestRuntimeException {
+    /* default */ void testTokenizeNegativeAbsolute() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "-|-23.5|";
         final double expectedResult = -23.5;
 
         final Token result = tokenizer.tokenize(calculation);
-        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing the negation of the result of the absolute should work");
     }
 
     @Test
-    public void testTokenizeVariable() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariable() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var";
         final double value = 43;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithNumber() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithNumber() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var2";
         final double value = 44;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a number should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithUnderscore() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithUnderscore() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var_able";
         final double value = 45;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an underscore should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithTilde() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithTilde() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var~de";
         final double value = 46;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a tilde should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithBang() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithBang() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var!bang";
         final double value = 47;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an exclamation mark should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithEquals() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithEquals() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var=qu";
         final double value = 48;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an equals sign should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithNumberSign() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithNumberSign() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var#rav";
         final double value = 49;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a number sign should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithAmpersand() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithAmpersand() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var&more";
         final double value = 50;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an ampersand should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithApostrophe() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithApostrophe() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "variable's";
         final double value = 51;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an apostrophe should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithQuestionMark() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithQuestionMark() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var?not";
         final double value = 52;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a question mark should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithDot() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithDot() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var.net";
         final double value = 53;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a dot should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableWithColon() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableWithColon() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var:res";
         final double value = 54;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a colon should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
     @Test
-    public void testTokenizeVariableEndingWithNumber() throws Throwable {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    /* default */ void testTokenizeVariableEndingWithNumber() throws Throwable {
         final Tokenizer tokenizer = createTokenizer();
         final String variable = "var123";
         final double value = 53;
 
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION);
+            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable ending with a digit should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 
+    /**
+     * Array-safe container for variable-name to variable-value pairs.
+     */
     private static class ProtoVariable {
+
+        /**
+         * The variable key.
+         */
         private final String key;
+
+        /**
+         * The variable value.
+         */
         private final String value;
 
+        /**
+         * Create a variable prototype used by {@link #withVariables(Executable, ProtoVariable...)}
+         *
+         * @param key variable name
+         * @param value variable content
+         */
         public ProtoVariable(final String key, final String value) {
             this.key = key;
             this.value = value;

--- a/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
+++ b/src/test/java/pl/betoncraft/betonquest/utils/math/TokenizerTest.java
@@ -355,6 +355,36 @@ public class TokenizerTest {
     }
 
     @Test
+        /* default */ void testTokenizeRoundPower() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "2.5^3~2";
+        final double expectedResult = 15.63;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "round operator should have lower priority then power operator");
+    }
+
+    @Test
+        /* default */ void testTokenizeRoundNegativeDigits() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "1234~-2";
+        final double expectedResult = 1200;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "round operator should work with negative number of decimal digits");
+    }
+
+    @Test
+        /* default */ void testTokenizeRoundMinus() throws InstructionParseException, QuestRuntimeException {
+        final Tokenizer tokenizer = createTokenizer();
+        final String calculation = "13.243~7-5";
+        final double expectedResult = 13.24;
+
+        final Token result = tokenizer.tokenize(calculation);
+        assertEquals(expectedResult, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "round operator should work if a mathematical expression is given as number of decimal digits");
+    }
+
+    @Test
     /* default */ void testTokenizeSimpleParenthesis() throws InstructionParseException, QuestRuntimeException {
         final Tokenizer tokenizer = createTokenizer();
         final String calculation = "(4123)";
@@ -512,20 +542,6 @@ public class TokenizerTest {
         withVariables(() -> {
             final Token result = tokenizer.tokenize(variable);
             assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing an underscore should work");
-        }, new ProtoVariable(variable, String.valueOf(value)));
-    }
-
-    @Disabled("tilde operator is for rounding numbers")
-    @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    /* default */ void testTokenizeVariableWithTilde() throws Throwable {
-        final Tokenizer tokenizer = createTokenizer();
-        final String variable = "var~de";
-        final double value = 46;
-
-        withVariables(() -> {
-            final Token result = tokenizer.tokenize(variable);
-            assertEquals(value, result.resolve(TEST_PLAYER_ID), REQUIRED_DOUBLE_PRECISION, "tokenizing a variable containing a tilde should work");
         }, new ProtoVariable(variable, String.valueOf(value)));
     }
 


### PR DESCRIPTION
Closes #1421

I'm currently looking into adapting this tokenizer I created in Dezember to BetonQuest to have a relatively quick fix for the math variable.

## Progress:
* [X] Move over code and refactor package names
* [X] Add support for `[ ]` braces
* [X] Add support for abstract values
* [x] Add support for variables
* [x] Remove unneeded parts.
* [x] Code cleanup and adding a bit more comments
* [x] Extensive testing of the tokenizer
* [x] Adapt math variable to use the tokenizer
* [x] Testing of the variable 