### PR TITLE
[BQ 1.12] Fix BlockSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - craft objective variables `left` and `amount` were swapped
 - NPC hider for not spawned NPCs
 - Conversation IO Chest load NPC skull async from Citizens instead of sync
+- block selector didn't respect regex boundary
+- block selector regex errors are now properly handled
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/resources/default/main.yml
+++ b/src/main/resources/default/main.yml
@@ -1,5 +1,5 @@
 variables:
-  block: '*_LOG'
+  block: '.*_LOG'
 npcs:
   '0': innkeeper
 cancel:


### PR DESCRIPTION
# Description
Fix block selector:
- regex pattern now are actually exact matches as intended
- regex errors are now properly reported
- fixed the invalid block selector regex inside the default package (example quest)

## Related Issues
Solves supermem's DC ticket.

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
