### PR TITLE
Only generate default package if BetonQuest folder is empty

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -59,6 +59,8 @@ public class Config {
         root = plugin.getDataFolder();
         lang = plugin.getConfig().getString("language");
 
+        final boolean isVirgin = Optional.ofNullable(root.listFiles(File::isFile)).map(files -> files.length == 0).orElse(true);
+
         // save default config
         plugin.saveDefaultConfig();
         // need to be sure everything is saved
@@ -81,7 +83,7 @@ public class Config {
         defaultPackage = plugin.getConfig().getString("default_package", defaultPackage);
 
         // save example package
-        createDefaultPackage(defaultPackage);
+        if (isVirgin) createDefaultPackage(defaultPackage);
 
         // load packages
         for (final File file : plugin.getDataFolder().listFiles()) {


### PR DESCRIPTION
# Description
![rip](https://cdn.discordapp.com/emojis/496389581923418120.png?v=1&size=16) default package

I think it's about time to ditch this silly issue where the default package can't be deleted as it regenerates every startup.  
The new behaviour is that it only get's generated if the BetonQuest folder contains no files (only log dir).

## Related Issues
#1088

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [ ]  ... update the changelog?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
