### PR TITLE
[1.12] fix PacketInterceptor waiting sync for unregistered listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mmobkill objective notify argument not working correctly
 - `fish` objective didn't count the amount of fish caught in one go (if modified by e.g. mcMMO)
 - fixed smelt objective: only taking out normally did count, shift-extract got canceled
-- empty values in `variable` objective now don't break on player join 
+- empty values in `variable` objective now don't break on player join
+- PacketInterceptor sync wait lag
 ### Security
 - it was possible to put a QuestItem into a chest
 


### PR DESCRIPTION
LL. 96 has an redundant cast, therefore I removed it.
## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [ ] ~~... update the documentation?~~
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ] ~~... solve all TODOs?~~
- [X]  ... remove any commented out code?
- [ ] ~~... add debug messages?~~
- [ ] ~~... clean the commit history?~~ Squash this PR! 🔨 

Check if the build pipeline succeeded for this PR!
