### PR TITLE
ChatNotify ConversationIO bypass the conversation interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed smelt objective: only taking out normally did count, shift-extract got canceled
 - empty values in `variable` objective now don't break on player join
 - PacketInterceptor sync wait lag
-- ChatNotify ConversationIO bypass the conversation interceptor
+- notifications using the chatIO were catched by the conversation interceptor
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed smelt objective: only taking out normally did count, shift-extract got canceled
 - empty values in `variable` objective now don't break on player join
 - PacketInterceptor sync wait lag
+- ChatNotify ConversationIO bypass the conversation interceptor
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/pl/betoncraft/betonquest/notify/ChatNotifyIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/notify/ChatNotifyIO.java
@@ -1,7 +1,9 @@
 package pl.betoncraft.betonquest.notify;
 
 import org.bukkit.entity.Player;
+import pl.betoncraft.betonquest.conversation.Conversation;
 import pl.betoncraft.betonquest.exceptions.InstructionParseException;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 import java.util.Map;
 
@@ -14,6 +16,11 @@ public class ChatNotifyIO extends NotifyIO {
 
     @Override
     protected void notifyPlayer(final String message, final Player player) {
-        player.sendMessage(message);
+        final Conversation conversation = Conversation.getConversation(PlayerConverter.getID(player));
+        if (conversation == null || conversation.getInterceptor() == null) {
+            player.sendMessage(message);
+        } else {
+            conversation.getInterceptor().sendMessage(message);
+        }
     }
 }


### PR DESCRIPTION
## Related Issues
The Interceptor bypass is not used in the new Notify API

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  ... add debug messages?
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
