### PR TITLE
ChatNotify ConversationIO bypass the conversation interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PacketInterceptor sync wait lag
 - the `left` and `amount` variables of some objectives were swapped and have been corrected: `left` is the amount left, `amount` is the amount done
 - brew objective now counts newly brewed potions even if there were already some potions of the desired type in other slots present
-- ChatNotify ConversationIO bypass the conversation interceptor
+- notifications using the chatIO were catched by the conversation interceptor
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PacketInterceptor sync wait lag
 - the `left` and `amount` variables of some objectives were swapped and have been corrected: `left` is the amount left, `amount` is the amount done
 - brew objective now counts newly brewed potions even if there were already some potions of the desired type in other slots present
+- ChatNotify ConversationIO bypass the conversation interceptor
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/org/betonquest/betonquest/notify/ChatNotifyIO.java
+++ b/src/main/java/org/betonquest/betonquest/notify/ChatNotifyIO.java
@@ -1,6 +1,8 @@
 package org.betonquest.betonquest.notify;
 
+import org.betonquest.betonquest.conversation.Conversation;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.entity.Player;
 
 import java.util.Map;
@@ -14,6 +16,11 @@ public class ChatNotifyIO extends NotifyIO {
 
     @Override
     protected void notifyPlayer(final String message, final Player player) {
-        player.sendMessage(message);
+        final Conversation conversation = Conversation.getConversation(PlayerConverter.getID(player));
+        if (conversation == null || conversation.getInterceptor() == null) {
+            player.sendMessage(message);
+        } else {
+            conversation.getInterceptor().sendMessage(message);
+        }
     }
 }


### PR DESCRIPTION
## Related Issues
The Interceptor bypass is not used in the new Notify API

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  ... add debug messages?
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
