### PR TITLE
Switch over to BetonQuest nexus mirror repository.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Setup JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -218,9 +219,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Setup JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8
           server-id: BetonQuest
           server-username: REPOSITORY_USER
           server-password: REPOSITORY_PASS

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set mirror for http repositories in settings.xml
         uses: whelk-io/maven-settings-xml-action@v15
         with:
-          mirrors: '[{"id": "heroes-repo-http","mirrorOf": "heroes-repo","url": "http://nexus.hc.to/content/repositories/pub_releases/","blocked": false}]'
+          mirrors: '[{"id":"heroes-repo-http","mirrorOf":"heroes-repo","url":"http://nexus.hc.to/content/repositories/pub_releases/","blocked":false}]'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set mirror for http repositories in settings.xml
         uses: whelk-io/maven-settings-xml-action@v15
         with:
-          mirrors: '[{"id": "heroes-repo-http","mirrorOf": "heroes-repo","url": "http://nexus.hc.to/content/repositories/pub_releases/","blocked": false},{"id": "elMakers-https","mirrorOf": "elMakers","url": "https://maven.elmakers.com/repository/"}]'
+          mirrors: '[{"id": "heroes-repo-http","mirrorOf": "heroes-repo","url": "http://nexus.hc.to/content/repositories/pub_releases/","blocked": false}]'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -1,4 +1,4 @@
-name: Test Dependencies
+name: Daily Dependency Check
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn -B package
+          mvn -B -P distributed-repositories,-mirrored-repositories package
 
   documentation:
     name: Build Documentation

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8
 
       - name: Build with Maven
         run: |

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -13,11 +13,17 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
+      - name: Set mirror for http repositories in settings.xml
+        uses: whelk-io/maven-settings-xml-action@v15
+        with:
+          mirrors: '[{"id": "heroes-repo-http","mirrorOf": "heroes-repo","url": "http://nexus.hc.to/content/repositories/pub_releases/","blocked": false},{"id": "elMakers-https","mirrorOf": "elMakers","url": "https://maven.elmakers.com/repository/"}]'
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: 8
+          overwrite-settings: false
 
       - name: Build with Maven
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -1009,7 +1009,7 @@
         <repository>
           <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
           <id>heroes-repo</id>
-          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
+          <url>http://nexus.hc.to/content/repositories/pub_releases/</url> <!-- lgtm [java/maven/non-https-url] -->
         </repository>
         <repository>
           <id>lumine-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1006,10 +1006,10 @@
           <id>enginehub-repo</id>
           <url>https://maven.enginehub.org/repo/</url>
         </repository>
-        <repository>
+        <repository> <!-- lgtm [java/maven/non-https-url] -->
           <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
           <id>heroes-repo</id>
-          <url>http://nexus.hc.to/content/repositories/pub_releases/</url> <!-- lgtm [java/maven/non-https-url] -->
+          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
         </repository>
         <repository>
           <id>lumine-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -390,19 +390,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.github.Shopkeepers.Shopkeepers</groupId>
-      <artifactId>ShopkeepersAPI</artifactId>
-      <version>d05e051348</version>
-      <scope>provided</scope>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.github.Sentropic</groupId>
       <artifactId>SkillAPI-s</artifactId>
       <version>1.96</version>
@@ -510,6 +497,7 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>4.2.2</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- only dependencies from maven central that are for testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,418 +40,456 @@
     </repository>
   </distributionManagement>
 
-  <profiles>
-    <profile>
-      <id>from-enginehub</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>enginehub-repo</id>
-          <url>https://maven.enginehub.org/repo/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.sk89q.worldguard</groupId>
-          <artifactId>worldguard-bukkit</artifactId>
-          <version>7.0.3</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-          <exclusions>
-            <exclusion>
-              <groupId>org.bukkit</groupId>
-              <artifactId>bukkit</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>com.sk89q.worldedit</groupId>
-          <artifactId>worldedit-bukkit</artifactId>
-          <version>7.1.0</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-          <exclusions>
-            <exclusion>
-              <groupId>org.bukkit</groupId>
-              <artifactId>bukkit</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>com.google.code.findbugs</groupId>
-              <artifactId>annotations</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-heroes</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>heroes-repo</id>
-          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.herocraftonline.heroes</groupId>
-          <artifactId>heroes-stripped</artifactId>
-          <version>4dd3dd85</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-lumine</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>lumine-repo</id>
-          <url>https://mvn.lumine.io/repository/maven-public/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>io.lumine.xikage</groupId>
-          <artifactId>MythicMobs</artifactId>
-          <version>4.11.0-SNAPSHOT</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>io.lumine</groupId>
-          <artifactId>MythicLib</artifactId>
-          <version>1.0.8-SNAPSHOT</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>net.Indyuce</groupId>
-          <artifactId>MMOCore</artifactId>
-          <version>1.7.0</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>net.Indyuce</groupId>
-          <artifactId>MMOItems</artifactId>
-          <version>6.5.2-SNAPSHOT</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-citizensnpcs</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>citizensnpcs-repo</id>
-          <url>https://repo.citizensnpcs.co/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>net.citizensnpcs</groupId>
-          <artifactId>citizens</artifactId>
-          <version>2.0.27-SNAPSHOT</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-          <exclusions>
-            <exclusion>
-              <groupId>junit</groupId>
-              <artifactId>junit</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>com.denizenscript</groupId>
-          <artifactId>denizen</artifactId>
-          <version>1.1.4-SNAPSHOT</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-codemc</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>codemc-repo</id>
-          <url>https://repo.codemc.io/repository/maven-public/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>org.bstats</groupId>
-          <artifactId>bstats-bukkit</artifactId>
-          <version>1.8</version>
-        </dependency>
-        <dependency>
-          <groupId>com.gmail.filoghost.holographicdisplays</groupId>
-          <artifactId>holographicdisplays-api</artifactId>
-          <version>2.4.0</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.gmail.nossr50.mcMMO</groupId>
-          <artifactId>mcMMO</artifactId>
-          <version>2.1.128</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-placeholderapi</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>placeholderapi-repo</id>
-          <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>me.clip</groupId>
-          <artifactId>placeholderapi</artifactId>
-          <version>2.10.9</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-dmulloy2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>dmulloy2-repo</id>
-          <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.comphenix.protocol</groupId>
-          <artifactId>ProtocolLib</artifactId>
-          <version>4.5.1</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.comphenix.packetwrapper</groupId>
-          <artifactId>PacketWrapper</artifactId>
-          <version>1.13-R0.1-20180825.172109-2</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-papermc</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>papermc-repo</id>
-          <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.destroystokyo.paper</groupId>
-          <artifactId>paper-api</artifactId>
-          <version>1.16.5-R0.1-SNAPSHOT</version>
-          <scope>provided</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>junit</groupId>
-              <artifactId>junit</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>io.papermc</groupId>
-          <artifactId>paperlib</artifactId>
-          <version>1.0.6</version>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-sonatype</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>sonatype-releases-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-        <repository>
-          <id>sonatype-snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>net.kyori</groupId>
-          <artifactId>adventure-api</artifactId>
-          <version>4.7.0</version>
-        </dependency>
-        <dependency>
-          <groupId>net.kyori</groupId>
-          <artifactId>adventure-platform-bukkit</artifactId>
-          <version>4.0.0-SNAPSHOT</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>from-jitpack</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>jitpack-repo</id>
-          <url>https://jitpack.io</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.github.MilkBowl</groupId>
-          <artifactId>VaultAPI</artifactId>
-          <version>1.7</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-          <exclusions>
-            <exclusion>
-              <groupId>org.bukkit</groupId>
-              <artifactId>bukkit</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>com.github.SkriptLang</groupId>
-          <artifactId>Skript</artifactId>
-          <version>2.4</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-          <exclusions>
-            <exclusion>
-              <groupId>com.google.code.findbugs</groupId>
-              <artifactId>findbugs</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>com.github.PikaMug</groupId>
-          <artifactId>Quests</artifactId>
-          <version>39a1c3edc7</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.github.Zrips</groupId>
-          <artifactId>Jobs</artifactId>
-          <version>d08dbedb56</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.github.Shopkeepers</groupId>
-          <artifactId>Shopkeepers</artifactId>
-          <version>d05e051348</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.github.Sentropic</groupId>
-          <artifactId>SkillAPI-s</artifactId>
-          <version>1.96</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.github.DieReicheErethons</groupId>
-          <artifactId>Brewery</artifactId>
-          <version>3.0</version>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <dependencies>
-    <!-- only dependencies from maven central that are MC Plugins-->
+    <!-- from papermc repository -->
     <dependency>
-      <groupId>com.elmakers.mine.bukkit</groupId>
-      <artifactId>EffectLib</artifactId>
-      <version>8.0</version>
+      <groupId>com.destroystokyo.paper</groupId>
+      <artifactId>paper-api</artifactId>
+      <version>1.16.5-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.md-5</groupId>
+      <artifactId>bungeecord-chat</artifactId>
+      <version>1.16-R0.4</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.papermc</groupId>
+      <artifactId>paperlib</artifactId>
+      <version>1.0.6</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- from enginehub repository -->
+    <dependency>
+      <groupId>com.sk89q.worldguard</groupId>
+      <artifactId>worldguard-bukkit</artifactId>
+      <version>7.0.4</version>
       <scope>provided</scope>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.sk89q.worldguard</groupId>
+      <artifactId>worldguard-core</artifactId>
+      <version>7.0.4</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sk89q.worldedit</groupId>
+      <artifactId>worldedit-bukkit</artifactId>
+      <version>7.2.5</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sk89q.worldedit</groupId>
+      <artifactId>worldedit-core</artifactId>
+      <version>7.2.5</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from heroes repository -->
+    <dependency>
+      <groupId>com.herocraftonline.heroes</groupId>
+      <artifactId>heroes-stripped</artifactId>
+      <version>4dd3dd85</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from lumine repository -->
+    <dependency>
+      <groupId>io.lumine.xikage</groupId>
+      <artifactId>MythicMobs</artifactId>
+      <version>4.11.2</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.lumine</groupId>
+      <artifactId>MythicLib</artifactId>
+      <version>1.0.19</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.Indyuce</groupId>
+      <artifactId>MMOCore</artifactId>
+      <version>1.7.1</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.Indyuce</groupId>
+      <artifactId>MMOItems</artifactId>
+      <version>6.5.7</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from citizensnpcs repository -->
+    <dependency>
+      <groupId>net.citizensnpcs</groupId>
+      <artifactId>citizens</artifactId>
+      <version>2.0.27-SNAPSHOT</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.denizenscript</groupId>
+      <artifactId>denizen</artifactId>
+      <version>1.1.9-SNAPSHOT</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from codemc repository -->
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+      <version>1.8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.gmail.filoghost.holographicdisplays</groupId>
+      <artifactId>holographicdisplays-api</artifactId>
+      <version>2.4.6</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.gmail.nossr50.mcMMO</groupId>
+      <artifactId>mcMMO</artifactId>
+      <version>2.1.196</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from placeholderapi repository -->
+    <dependency>
+      <groupId>me.clip</groupId>
+      <artifactId>placeholderapi</artifactId>
+      <version>2.10.9</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from dmulloy2 repository -->
+    <dependency>
+      <groupId>com.comphenix.protocol</groupId>
+      <artifactId>ProtocolLib</artifactId>
+      <version>4.6.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.comphenix.packetwrapper</groupId>
+      <artifactId>PacketWrapper</artifactId>
+      <version>1.13-R0.1-SNAPSHOT</version>
+    </dependency>
+
+    <!-- from lichtspiele repository -->
+    <dependency>
+      <groupId>com.nisovin.shopkeepers</groupId>
+      <artifactId>ShopkeepersAPI</artifactId>
+      <version>2.12.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from elmakers repository -->
     <dependency>
       <groupId>com.elmakers.mine.bukkit</groupId>
       <artifactId>MagicAPI</artifactId>
-      <version>8.2</version>
+      <version>8.5.2</version>
       <scope>provided</scope>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    <!-- only dependencies from maven central that are no MC Plugins-->
+
+
+    <!-- from jitpack repository -->
+    <dependency>
+      <groupId>com.github.MilkBowl</groupId>
+      <artifactId>VaultAPI</artifactId>
+      <version>1.7</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.SkriptLang</groupId>
+      <artifactId>Skript</artifactId>
+      <version>2.5.3</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.PikaMug</groupId>
+      <artifactId>Quests</artifactId>
+      <version>39a1c3edc7</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.PikaMug.Quests</groupId>
+      <artifactId>quests-main</artifactId>
+      <version>39a1c3edc7</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.Zrips</groupId>
+      <artifactId>Jobs</artifactId>
+      <version>4.17.1</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.Shopkeepers.Shopkeepers</groupId>
+      <artifactId>ShopkeepersAPI</artifactId>
+      <version>d05e051348</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.Sentropic</groupId>
+      <artifactId>SkillAPI-s</artifactId>
+      <version>1.96</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.DieReicheErethons</groupId>
+      <artifactId>Brewery</artifactId>
+      <version>3.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- from sonatype repository -->
+    <dependency>
+      <groupId>net.kyori</groupId>
+      <artifactId>adventure-api</artifactId>
+      <version>4.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>net.kyori</groupId>
+      <artifactId>adventure-platform-bukkit</artifactId>
+      <version>4.0.0-SNAPSHOT</version>
+    </dependency>
+
+    <!-- only dependencies from maven central that are MC Plugins -->
+    <dependency>
+      <groupId>com.elmakers.mine.bukkit</groupId>
+      <artifactId>EffectLib</artifactId>
+      <version>9.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- only dependencies from maven central that are no MC Plugins -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.16</version>
+      <version>1.18.20</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.6.3</version>
+      <version>3.8.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.1-jre</version>
+      <version>30.1.1-jre</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -466,30 +504,31 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20160212</version>
+      <version>20210307</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>4.2.2</version>
     </dependency>
-    <!-- only dependencies from maven central that are for testing-->
+
+    <!-- only dependencies from maven central that are for testing -->
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.6.2</version>
+      <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.2</version>
+      <version>5.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.7.0</version>
+      <version>3.9.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -525,7 +564,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-banned-dependencies</id>
@@ -572,7 +610,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -761,9 +798,14 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M3</version>
+        </plugin>
+        <plugin>
           <groupId>org.projectlombok</groupId>
           <artifactId>lombok-maven-plugin</artifactId>
-          <version>1.18.16.0</version>
+          <version>1.18.20.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -789,7 +831,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.1.3</version>
+          <version>4.2.2</version>
           <configuration>
             <effort>max</effort>
             <threshold>low</threshold>
@@ -798,7 +840,14 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.42</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <configLocation>config/checkstyle.xml</configLocation>
             <propertyExpansion>checkstyle.config.path=${basedir}/config</propertyExpansion>
@@ -807,7 +856,7 @@
         <plugin>
           <groupId>com.coderplus.maven.plugins</groupId>
           <artifactId>copy-rename-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -817,7 +866,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -862,17 +911,17 @@
         <plugin>
           <groupId>org.ec4j.maven</groupId>
           <artifactId>editorconfig-maven-plugin</artifactId>
-          <version>0.1.0</version>
+          <version>0.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -892,7 +941,7 @@
         <plugin>
           <groupId>org.pitest</groupId>
           <artifactId>pitest-maven</artifactId>
-          <version>1.6.4</version>
+          <version>1.6.6</version>
           <dependencies>
             <dependency>
               <groupId>org.pitest</groupId>
@@ -944,4 +993,77 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>mirrored-repositories</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>betonquest-repo</id>
+          <url>https://betonquest.org/nexus/repository/default/</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>distributed-repositories</id>
+      <repositories>
+        <repository>
+          <id>papermc-repo</id>
+          <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
+        <repository>
+          <id>enginehub-repo</id>
+          <url>https://maven.enginehub.org/repo/</url>
+        </repository>
+        <repository>
+          <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
+          <id>heroes-repo</id>
+          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
+        </repository>
+        <repository>
+          <id>lumine-repo</id>
+          <url>https://mvn.lumine.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+          <id>citizensnpcs-repo</id>
+          <url>https://repo.citizensnpcs.co/</url>
+        </repository>
+        <repository>
+          <id>codemc-repo</id>
+          <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+          <id>placeholderapi-repo</id>
+          <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+        <repository>
+          <id>dmulloy2-repo</id>
+          <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+        </repository>
+        <repository>
+          <id>lichtspiele-repo</id>
+          <url>https://nexus.lichtspiele.org/repository/maven-public/</url>
+        </repository>
+        <repository>
+          <id>elmakers-repo</id>
+          <url>https://maven.elmakers.com/repository/</url>
+        </repository>
+        <repository>
+          <id>jitpack-repo</id>
+          <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+          <id>sonatype-releases-repo</id>
+          <url>https://oss.sonatype.org/content/repositories/releases/</url>
+        </repository>
+        <repository>
+          <id>sonatype-snapshots-repo</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -5,7 +5,6 @@ import lombok.CustomLog;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
-import org.apache.commons.lang3.StringUtils;
 import org.betonquest.betonquest.*;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.compatibility.Compatibility;
@@ -61,8 +60,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
     private String defaultPack = Config.getString("config.default_package");
 
     /**
-     * Registers a new executor and a new tab completer of the /betonquest
-     * command
+     * Registers a new executor and a new tab completer of the /betonquest command.
      */
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public QuestCommand() {
@@ -1812,7 +1810,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             }
             final UUID uuid = ((Player) sender).getUniqueId();
             if (args.length < 3) {
-                sender.sendMessage("§2Active Filters: " + StringUtils.joinWith(", ", logWatcher.getFilters(uuid)));
+                sender.sendMessage("§2Active Filters: " + String.join(", ", logWatcher.getFilters(uuid)));
                 return;
             }
             final String filter = args[2];

--- a/src/main/java/org/betonquest/betonquest/conditions/RandomCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/RandomCondition.java
@@ -9,11 +9,12 @@ import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import java.util.Random;
 
 /**
- * The condition that is met randomly
+ * The condition that is met randomly.
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class RandomCondition extends Condition {
 
+    private final Random random = new Random();
     private final VariableNumber valueMax;
     private final VariableNumber rangeOfRandom;
 
@@ -37,8 +38,7 @@ public class RandomCondition extends Condition {
 
     @Override
     protected Boolean execute(final String playerID) throws QuestRuntimeException {
-        final Random generator = new Random();
-        final int temp = generator.nextInt(rangeOfRandom.getInt(playerID)) + 1;
+        final int temp = random.nextInt(rangeOfRandom.getInt(playerID)) + 1;
         return temp <= valueMax.getInt(playerID);
     }
 

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationResumer.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationResumer.java
@@ -16,7 +16,7 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 /**
- * Resumes the conversation for the player
+ * Resumes the conversation for the player.
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class ConversationResumer implements Listener {

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationResumer.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationResumer.java
@@ -44,7 +44,7 @@ public class ConversationResumer implements Listener {
         final String[] locParts = parts[2].split(";");
         this.loc = new Location(Bukkit.getWorld(locParts[3]), Double.parseDouble(locParts[0]),
                 Double.parseDouble(locParts[1]), Double.parseDouble(locParts[2]));
-        this.distance = Double.valueOf(Config.getString("config.max_npc_distance"));
+        this.distance = Double.parseDouble(Config.getString("config.max_npc_distance"));
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
     }
 
@@ -57,7 +57,7 @@ public class ConversationResumer implements Listener {
         if (event.getTo().getWorld().equals(loc.getWorld()) && event.getTo().distanceSquared(loc) < distance * distance) {
             HandlerList.unregisterAll(this);
             BetonQuest.getInstance().getSaver()
-                    .add(new Record(UpdateType.UPDATE_CONVERSATION, new String[]{"null", playerID}));
+                    .add(new Record(UpdateType.UPDATE_CONVERSATION, "null", playerID));
             new Conversation(playerID, conversationID, loc, option);
         }
     }
@@ -69,6 +69,6 @@ public class ConversationResumer implements Listener {
         }
         HandlerList.unregisterAll(this);
         BetonQuest.getInstance().getSaver()
-                .add(new Record(UpdateType.UPDATE_CONVERSATION, new String[]{original, playerID}));
+                .add(new Record(UpdateType.UPDATE_CONVERSATION, original, playerID));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
@@ -20,6 +20,7 @@ import java.util.Random;
 @SuppressWarnings("PMD.CommentRequired")
 public class FolderEvent extends QuestEvent {
 
+    private final Random randomGenerator = new Random();
     private final VariableNumber delay;
     private final VariableNumber period;
     private final VariableNumber random;
@@ -51,7 +52,7 @@ public class FolderEvent extends QuestEvent {
             // remove chosen events from that ArrayList and place them in a new
             // list
             for (int i = randomInt; i > 0; i--) {
-                final int chosen = new Random().nextInt(eventsList.size());
+                final int chosen = randomGenerator.nextInt(eventsList.size());
                 chosenList.add(eventsList.remove(chosen));
             }
         } else {

--- a/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 import java.util.Random;
 
 /**
- * Folder event is a collection of other events, that can be run after a delay
- * and the events can be randomly chosen to run or not
+ * Folder event is a collection of other events, that can be run after a delay and the events can be randomly chosen to
+ * run or not.
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class FolderEvent extends QuestEvent {

--- a/src/main/java/org/betonquest/betonquest/utils/BlockSelector.java
+++ b/src/main/java/org/betonquest/betonquest/utils/BlockSelector.java
@@ -32,9 +32,10 @@ import java.util.regex.PatternSyntaxException;
 public class BlockSelector {
     private final List<Material> materials;
     private final Map<String, String> states;
+    private final Random random = new Random();
 
     /**
-     * Create a {@link BlockSelector} from a {@link String}
+     * Create a {@link BlockSelector} from a {@link String}.
      *
      * @param block The {@link String} of the {@link BlockSelector} in the format of {@link BlockData#getAsString()}
      * @throws InstructionParseException Is thrown, if no material match that selector string
@@ -50,7 +51,7 @@ public class BlockSelector {
     }
 
     /**
-     * Create a {@link BlockSelector} from a {@link Block}
+     * Create a {@link BlockSelector} from a {@link Block}.
      *
      * @param block The {@link Block} of the {@link BlockSelector}
      * @throws InstructionParseException Is thrown, if no material match that selector string
@@ -66,7 +67,7 @@ public class BlockSelector {
      */
     @Override
     public String toString() {
-        return materials.toString() + (states == null ? "" : "[" + states.toString() + "]");
+        return materials.toString() + (states == null ? "" : "[" + states + "]");
     }
 
     /**
@@ -75,7 +76,6 @@ public class BlockSelector {
      * @return A {@link Material}
      */
     public Material getRandomMaterial() {
-        final Random random = new Random();
         return materials.get(random.nextInt(materials.size()));
     }
 
@@ -120,7 +120,7 @@ public class BlockSelector {
         try {
             state.setBlockData(getBlockData());
         } catch (final IllegalArgumentException exception) {
-            LOG.error(null, "Could not place block '" + toString() + "'! Probably the block has a invalid blockstate: " + exception.getMessage(), exception);
+            LOG.error(null, "Could not place block '" + this + "'! Probably the block has a invalid blockstate: " + exception.getMessage(), exception);
         }
 
         state.update(true, applyPhysics);


### PR DESCRIPTION
# Description
Switch to using our own maven repository mirror. Also reduce load of provided dependencies, we usually do not have access to their dependencies anyways. Also updated any versions where nothing breaks. (Quests -> 4.0.2 breaks stuff, SkillAPI-s -> 1.96 doesn't download properly from jitpack, SpotBugs -> 2.2.3 has false positives)

Also had to fix some new findings of bugs and a somehow not working `StringUtils.joinWith(String, String...)` call that I fixed.

## Related Issues
Closes #1475 partially. It is only relevant when building with `distributed-repositories` profile enabled.

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
