### PR TITLE
Fix case insensitive password objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - the `left` and `amount` variables of some objectives were swapped and have been corrected: `left` is the amount left, `amount` is the amount done
 - brew objective now counts newly brewed potions even if there were already some potions of the desired type in other slots present
 - notifications using the chatIO were catched by the conversation interceptor
+- case insensitive `password` objective did not work if the password contained upper case letters
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/org/betonquest/betonquest/objectives/PasswordObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/PasswordObjective.java
@@ -15,9 +15,9 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Requires the player to type a password in chat.
@@ -25,16 +25,16 @@ import java.util.Locale;
 @SuppressWarnings("PMD.CommentRequired")
 public class PasswordObjective extends Objective implements Listener {
 
-    private final String regex;
-    private final boolean ignoreCase;
+    private final Pattern regex;
     private final String passwordPrefix;
     private final EventID[] failEvents;
 
     public PasswordObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         template = ObjectiveData.class;
-        regex = instruction.next().replace('_', ' ');
-        ignoreCase = instruction.hasArgument("ignoreCase");
+        final String pattern = instruction.next().replace('_', ' ');
+        final int regexFlags = instruction.hasArgument("ignoreCase") ? Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE : 0;
+        regex = Pattern.compile(pattern, regexFlags);
         final String prefix = instruction.getOptional("prefix");
         passwordPrefix = prefix == null || prefix.isEmpty() ? prefix : prefix + ": ";
         failEvents = instruction.getList(instruction.getOptional("fail"), instruction::getEvent).toArray(new EventID[0]);
@@ -67,13 +67,8 @@ public class PasswordObjective extends Objective implements Listener {
         }
         final String password = message.substring(prefix.length());
         if (checkConditions(playerID)) {
-            if ((ignoreCase ? password.toLowerCase(Locale.ROOT) : password).matches(regex)) {
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        completeObjective(playerID);
-                    }
-                }.runTask(BetonQuest.getInstance());
+            if (regex.matcher(password).matches()) {
+                Bukkit.getScheduler().runTask(BetonQuest.getInstance(), () -> completeObjective(playerID));
 
                 if (fromCommand) {
                     return !prefix.isEmpty();


### PR DESCRIPTION
# Description
Case insensitive password objectives that contain upper case letters did not work.

Example:
`password_ci: password CaseInsensitive ignoreCase prefix:ci fail:fail events:msg`

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
