### PR TITLE
Fix case insensitive password objective [BQ 1.12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - empty values in `variable` objective now don't break on player join
 - PacketInterceptor sync wait lag
 - notifications using the chatIO were catched by the conversation interceptor
+- case insensitive `password` objective did not work if the password contained upper case letters
 ### Security
 - it was possible to put a QuestItem into a chest
 


### PR DESCRIPTION
# Description
Case insensitive password objectives that contain upper case letters did not work.

Example:
`password_ci: password CaseInsensitive ignoreCase prefix:ci fail:fail events:msg`

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
