### PR TITLE
Fix warning messages in BetonQuest.getVariableValue() [BQ 1.12]

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -1157,9 +1157,9 @@ public class BetonQuest extends JavaPlugin {
             }
             return var.getValue(playerID);
         } catch (final InstructionParseException e) {
-            LogUtils.getLogger().log(Level.WARNING, "&cCould not create variable: " + e.getMessage());
+            LogUtils.getLogger().log(Level.WARNING, "&cCould not create variable '" + name + "': " + e.getMessage());
             LogUtils.logThrowable(e);
-            return "&cCould not resolve variable. The variable type or the object seems to be invalid.";
+            return "";
         }
     }
 


### PR DESCRIPTION
Commit 3259f5afb0818b3bd4da96546419d556e21bae10 forgot this line and @seyfahni was to quick with merging #1456  ⚡😅.

So here is the pull request to fix it. 
