### PR TITLE
Fix global variables in untranslated quester names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - brew objective now counts newly brewed potions even if there were already some potions of the desired type in other slots present
 - notifications using the chatIO were catched by the conversation interceptor
 - case insensitive `password` objective did not work if the password contained upper case letters
+- global variables didn't work in quester names
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
@@ -66,7 +66,7 @@ public class ConversationData {
                 quester.put(lang, ChatColor.translateAlternateColorCodes('&', pack.getString("conversations." + name + ".quester." + lang)));
             }
         } else {
-            quester.put(Config.getLanguage(), ChatColor.translateAlternateColorCodes('&', conv.getString("quester")));
+            quester.put(Config.getLanguage(), ChatColor.translateAlternateColorCodes('&', pack.getString("conversations." + name + ".quester")));
         }
         if (conv.isConfigurationSection("prefix")) {
             //noinspection ConstantConditions


### PR DESCRIPTION
# Description
`quester: $npc_name$` doesn't work, but
```yaml
quester:
  en: $npc_name$
```
does. This PR fixes that issue.

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
