### PR TITLE
fix quest items cannot break blocks 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - notifications using the chatIO were catched by the conversation interceptor
 - case insensitive `password` objective did not work if the password contained upper case letters
 - global variables didn't work in quester names
+- quest items couldn't interact with any blocks, which also prevented them from mining blocks
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
@@ -8,6 +8,7 @@ import org.betonquest.betonquest.utils.PlayerConverter;
 import org.betonquest.betonquest.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -231,28 +232,25 @@ public class QuestItemHandler implements Listener {
             event.getPlayer().getInventory().addItem(copy);
         }
     }
-@SuppressFBWarnings
+
+    @SuppressFBWarnings
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     @EventHandler(ignoreCancelled = true)
     public void onInteractEvent(final PlayerInteractEvent event) {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-
-        if (event.getClickedBlock() == null) {
+        final ItemStack item = event.getItem();
+        if (item == null) {
             return;
         }
 
-        final String clickedBlock = event.getClickedBlock().getType().toString();
-        if ("LECTERN".equals(clickedBlock)
-                || "CAMPFIRE".equals(clickedBlock)
-                || "COMPOSTER".equals(clickedBlock)
-                || "RESPAWN_ANCHOR".equals(clickedBlock)) {
+        if (!EnchantmentTarget.TOOL.includes(item.getType())) {
             final String playerID = PlayerConverter.getID(event.getPlayer());
-            final ItemStack item = event.getItem();
             if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
                 event.setCancelled(true);
             }
+
         }
     }
 

--- a/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
@@ -232,14 +232,24 @@ public class QuestItemHandler implements Listener {
         }
     }
 
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     @EventHandler(ignoreCancelled = true)
     public void onInteractEvent(final PlayerInteractEvent event) {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final ItemStack item = event.getItem();
-        if (event.getClickedBlock() != null) {
+
+        if (event.getClickedBlock() == null) {
+            return;
+        }
+
+        final String clickedBlock = event.getClickedBlock().getType().toString();
+        if ("LECTERN".equals(clickedBlock)
+                || "CAMPFIRE".equals(clickedBlock)
+                || "COMPOSTER".equals(clickedBlock)
+                || "RESPAWN_ANCHOR".equals(clickedBlock)) {
             final String playerID = PlayerConverter.getID(event.getPlayer());
+            final ItemStack item = event.getItem();
             if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
                 event.setCancelled(true);
             }

--- a/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
@@ -231,7 +231,7 @@ public class QuestItemHandler implements Listener {
             event.getPlayer().getInventory().addItem(copy);
         }
     }
-
+@SuppressFBWarnings
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     @EventHandler(ignoreCancelled = true)
     public void onInteractEvent(final PlayerInteractEvent event) {


### PR DESCRIPTION
# Description
This makes it possible to interact with (and mine) all blocks except Lecterns, Campfires, Composters and Respawn Anchors.

PLEASE SQUASH WHEN MERGING

## Related Issues
#1503 

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [X]  ... update the changelog?
- [ ]  ... ~~update the documentation?~~
- [ ]  ... ~~adjust the ConfigUpdater?~~
- [ ]  ... ~~solve all TODOs?~~
- [ ]  ... ~~remove any commented out code?~~
- [ ]  ... ~~add debug messages?~~
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
