### PR TITLE
fix quest items cannot break blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - notifications using the chatIO were catched by the conversation interceptor
 - case insensitive `password` objective did not work if the password contained upper case letters
 - global variables didn't work in quester names
+- quest items couldn't interact with any blocks, which also prevented them from mining blocks
 ### Security
 - it was possible to put a QuestItem into a chest
 

--- a/src/main/java/pl/betoncraft/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/pl/betoncraft/betonquest/item/QuestItemHandler.java
@@ -3,6 +3,7 @@ package pl.betoncraft.betonquest.item;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -239,19 +240,17 @@ public class QuestItemHandler implements Listener {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
+        final ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
 
-        if (event.getClickedBlock() != null) {
-            final String clickedBlock = event.getClickedBlock().getType().toString();
-            if ("LECTERN".equals(clickedBlock)
-                    || "CAMPFIRE".equals(clickedBlock)
-                    || "COMPOSTER".equals(clickedBlock)
-                    || "RESPAWN_ANCHOR".equals(clickedBlock)) {
-                final String playerID = PlayerConverter.getID(event.getPlayer());
-                final ItemStack item = event.getItem();
-                if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
-                    event.setCancelled(true);
-                }
+        if (!EnchantmentTarget.TOOL.includes(item.getType())) {
+            final String playerID = PlayerConverter.getID(event.getPlayer());
+            if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
+                event.setCancelled(true);
             }
+
         }
     }
 

--- a/src/main/java/pl/betoncraft/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/pl/betoncraft/betonquest/item/QuestItemHandler.java
@@ -232,16 +232,25 @@ public class QuestItemHandler implements Listener {
         }
     }
 
+    @SuppressFBWarnings
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     @EventHandler(ignoreCancelled = true)
     public void onInteractEvent(final PlayerInteractEvent event) {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final ItemStack item = event.getItem();
+
         if (event.getClickedBlock() != null) {
-            final String playerID = PlayerConverter.getID(event.getPlayer());
-            if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
-                event.setCancelled(true);
+            final String clickedBlock = event.getClickedBlock().getType().toString();
+            if ("LECTERN".equals(clickedBlock)
+                    || "CAMPFIRE".equals(clickedBlock)
+                    || "COMPOSTER".equals(clickedBlock)
+                    || "RESPAWN_ANCHOR".equals(clickedBlock)) {
+                final String playerID = PlayerConverter.getID(event.getPlayer());
+                final ItemStack item = event.getItem();
+                if (Journal.isJournal(playerID, item) || Utils.isQuestItem(item)) {
+                    event.setCancelled(true);
+                }
             }
         }
     }


### PR DESCRIPTION
This makes it possible to interact with (and mine) all blocks except Lecterns, Campfires, Composters and Respawn Anchors.

# Description
<!-- Your description here. -->

## Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
