### PR TITLE
fix mirror repositories of dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
                 "blocked": "false"
               },
               {
-                "id": "BQ-Mirror",
+                "id": "BetonQuest-Mirror",
                 "mirrorOf": "*",
                 "url": "https://betonquest.org/nexus/repository/default/"
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,23 @@ jobs:
       - name: Activate lf line ending check in editorconfig
         run: |
           sed -i "s~#end_of_line = ~end_of_line = ~g" ./.editorconfig
+      - name: Set mirror for http repositories in settings.xml
+        uses: whelk-io/maven-settings-xml-action@v15
+        with:
+          mirrors: |
+            [
+              {
+                "id": "heroes-repo-http",
+                "mirrorOf": "heroes-repo",
+                "url": "http://nexus.hc.to/content/repositories/pub_releases/",
+                "blocked": "false"
+              },
+              {
+                "id": "BQ-Mirror",
+                "mirrorOf": "*",
+                "url": "https://betonquest.org/nexus/repository/default/"
+              }
+            ]
       - name: Build with Maven. Phase 'package'
         if: "github.event_name == 'pull_request'"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,17 +122,11 @@ jobs:
       - name: Activate lf line ending check in editorconfig
         run: |
           sed -i "s~#end_of_line = ~end_of_line = ~g" ./.editorconfig
-      - name: Set mirror for http repositories in settings.xml
+      - name: Set mirror for all repositories in settings.xml
         uses: whelk-io/maven-settings-xml-action@v15
         with:
           mirrors: |
             [
-              {
-                "id": "heroes-repo-http",
-                "mirrorOf": "heroes-repo",
-                "url": "http://nexus.hc.to/content/repositories/pub_releases/",
-                "blocked": "false"
-              },
               {
                 "id": "BetonQuest-Mirror",
                 "mirrorOf": "*",

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -16,7 +16,15 @@ jobs:
       - name: Set mirror for http repositories in settings.xml
         uses: whelk-io/maven-settings-xml-action@v15
         with:
-          mirrors: '[{"id":"heroes-repo-http","mirrorOf":"heroes-repo","url":"http://nexus.hc.to/content/repositories/pub_releases/","blocked":false}]'
+          mirrors: |
+            [
+              {
+                "id": "heroes-repo-http",
+                "mirrorOf": "heroes-repo",
+                "url": "http://nexus.hc.to/content/repositories/pub_releases/",
+                "blocked": "false"
+              }
+            ]
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
@@ -27,7 +35,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn -B -P distributed-repositories,-mirrored-repositories package
+          mvn -B package
 
   documentation:
     name: Build Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -523,56 +523,56 @@
 
   <repositories>
     <repository>
-      <id>papermc-repo</id>
+      <id>betonquest-papermc-repo</id>
       <url>https://papermc.io/repo/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>enginehub-repo</id>
+      <id>betonquest-enginehub-repo</id>
       <url>https://maven.enginehub.org/repo/</url>
     </repository>
     <repository> <!-- lgtm [java/maven/non-https-url] -->
       <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
-      <id>heroes-repo</id>
+      <id>betonquest-heroes-repo</id>
       <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
     </repository>
     <repository>
-      <id>lumine-repo</id>
+      <id>betonquest-lumine-repo</id>
       <url>https://mvn.lumine.io/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>citizensnpcs-repo</id>
+      <id>betonquest-citizensnpcs-repo</id>
       <url>https://repo.citizensnpcs.co/</url>
     </repository>
     <repository>
-      <id>codemc-repo</id>
+      <id>betonquest-codemc-repo</id>
       <url>https://repo.codemc.io/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>placeholderapi-repo</id>
+      <id>betonquest-placeholderapi-repo</id>
       <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
     </repository>
     <repository>
-      <id>dmulloy2-repo</id>
+      <id>betonquest-dmulloy2-repo</id>
       <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
     </repository>
     <repository>
-      <id>lichtspiele-repo</id>
+      <id>betonquest-lichtspiele-repo</id>
       <url>https://nexus.lichtspiele.org/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>elmakers-repo</id>
+      <id>betonquest-elmakers-repo</id>
       <url>https://maven.elmakers.com/repository/</url>
     </repository>
     <repository>
-      <id>jitpack-repo</id>
+      <id>betonquest-jitpack-repo</id>
       <url>https://jitpack.io</url>
     </repository>
     <repository>
-      <id>sonatype-releases-repo</id>
+      <id>betonquest-sonatype-releases-repo</id>
       <url>https://oss.sonatype.org/content/repositories/releases/</url>
     </repository>
     <repository>
-      <id>sonatype-snapshots-repo</id>
+      <id>betonquest-sonatype-snapshots-repo</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,62 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>papermc-repo</id>
+      <url>https://papermc.io/repo/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>enginehub-repo</id>
+      <url>https://maven.enginehub.org/repo/</url>
+    </repository>
+    <repository> <!-- lgtm [java/maven/non-https-url] -->
+      <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
+      <id>heroes-repo</id>
+      <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
+    </repository>
+    <repository>
+      <id>lumine-repo</id>
+      <url>https://mvn.lumine.io/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>citizensnpcs-repo</id>
+      <url>https://repo.citizensnpcs.co/</url>
+    </repository>
+    <repository>
+      <id>codemc-repo</id>
+      <url>https://repo.codemc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>placeholderapi-repo</id>
+      <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+    </repository>
+    <repository>
+      <id>dmulloy2-repo</id>
+      <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+    </repository>
+    <repository>
+      <id>lichtspiele-repo</id>
+      <url>https://nexus.lichtspiele.org/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>elmakers-repo</id>
+      <url>https://maven.elmakers.com/repository/</url>
+    </repository>
+    <repository>
+      <id>jitpack-repo</id>
+      <url>https://jitpack.io</url>
+    </repository>
+    <repository>
+      <id>sonatype-releases-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
   <build>
     <directory>target/artifacts</directory>
     <sourceDirectory>src/main/java</sourceDirectory>
@@ -1001,77 +1057,4 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <profiles>
-    <profile>
-      <id>mirrored-repositories</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>betonquest-repo</id>
-          <url>https://betonquest.org/nexus/repository/default/</url>
-        </repository>
-      </repositories>
-    </profile>
-    <profile>
-      <id>distributed-repositories</id>
-      <repositories>
-        <repository>
-          <id>papermc-repo</id>
-          <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
-        <repository>
-          <id>enginehub-repo</id>
-          <url>https://maven.enginehub.org/repo/</url>
-        </repository>
-        <repository> <!-- lgtm [java/maven/non-https-url] -->
-          <!-- https://github.com/BetonQuest/BetonQuest/issues/1475 -->
-          <id>heroes-repo</id>
-          <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
-        </repository>
-        <repository>
-          <id>lumine-repo</id>
-          <url>https://mvn.lumine.io/repository/maven-public/</url>
-        </repository>
-        <repository>
-          <id>citizensnpcs-repo</id>
-          <url>https://repo.citizensnpcs.co/</url>
-        </repository>
-        <repository>
-          <id>codemc-repo</id>
-          <url>https://repo.codemc.io/repository/maven-public/</url>
-        </repository>
-        <repository>
-          <id>placeholderapi-repo</id>
-          <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-        <repository>
-          <id>dmulloy2-repo</id>
-          <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
-        </repository>
-        <repository>
-          <id>lichtspiele-repo</id>
-          <url>https://nexus.lichtspiele.org/repository/maven-public/</url>
-        </repository>
-        <repository>
-          <id>elmakers-repo</id>
-          <url>https://maven.elmakers.com/repository/</url>
-        </repository>
-        <repository>
-          <id>jitpack-repo</id>
-          <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-          <id>sonatype-releases-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-        <repository>
-          <id>sonatype-snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
# Description
Work in progress for mirror repositories

In the future, everyone who want to use our mirror need to add something like this in his local settings.xml:
```
    <profile>
      <id>BetonQuest-Mirror-Repositories</id>
        <activation>
          <file>
            <exists>/src/main/java/org/betonquest/betonquest/BetonQuest.java</exists>
          </file>
        </activation>
      <mirrors>
        <mirror>
          <id>BQ-Mirror</id>
          <url>https://betonquest.org/nexus/repository/default/</url>
          <mirrorOf>*</mirrorOf>
        </mirror>
      </mirrors>
    </profile>
```

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [X]  ... update the changelog?
- [X]  ... update the documentation?
- [X]  ... adjust the ConfigUpdater?
- [X]  ... solve all TODOs?
- [X]  ... remove any commented out code?
- [X]  ... add debug messages?
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
