### PR TITLE
java 16 adjustments for minecraft 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 16
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -234,7 +234,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 16
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/daily_dependency_check.yml
+++ b/.github/workflows/daily_dependency_check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 16
           overwrite-settings: false
 
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <current-date>${maven.build.timestamp}</current-date>
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>16</maven.compiler.target>
+    <maven.compiler.source>16</maven.compiler.source>
   </properties>
 
   <name>BetonQuest</name>
@@ -574,6 +574,10 @@
       <id>betonquest-sonatype-snapshots-repo</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
+    <repository>
+      <id>betonquest-maven-shade-plugin-snapshot-repo</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
   </repositories>
 
   <build>
@@ -850,7 +854,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
+          <version>3.3.0-SNAPSHOT</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -574,11 +574,13 @@
       <id>betonquest-sonatype-snapshots-repo</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
-    <repository>
-      <id>betonquest-maven-shade-plugin-snapshot-repo</id>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-    </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>betonquest-apache-snapshot-repo</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <directory>target/artifacts</directory>


### PR DESCRIPTION
# Description
This is wip RP for java 16 compilation. BQ already work on java 16.

~~But we still compile with java 1.8. With Minecraft 1.17 we want to change this to compile with java 16. But at the moment we have still issues.
First the latest release of `maven-shade-plugin` is not supporting java 16. This can be solved by using `3.3.0-SNAPSHOT`.
Unfortunately the version `3.3.0-SNAPSHOT` of `maven-shade-plugin` is not stored correctly in there snapshot repository https://repository.apache.org/content/repositories/snapshots/ . 
Therefore a workaround is to install `maven-shade-plugin` in the version `3.3.0-SNAPSHOT` manually with `mvn innstall`. But this is not a solution for our build envireoment.~~

~~There is also a Jira issue, but you can only see it if you have an account: https://issues.apache.org/jira/browse/MSHADE-395~~

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
