### PR TITLE
Fix async call of ObjectiveChangeEvent.

### DIFF
--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.core.Logger;
 import org.betonquest.betonquest.api.Condition;
 import org.betonquest.betonquest.api.LoadDataEvent;
 import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.QuestEvent;
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
@@ -462,10 +461,7 @@ public class BetonQuest extends JavaPlugin {
                     "Player " + PlayerConverter.getName(playerID) + " already has the " + objectiveID + " objective!");
             return;
         }
-        final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                Objective.ObjectiveState.ACTIVE, Objective.ObjectiveState.PAUSED);
-        Bukkit.getServer().getPluginManager().callEvent(event);
-        objective.addPlayer(playerID, instruction);
+        objective.resumeObjectiveForPlayer(playerID, instruction);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
+++ b/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
@@ -2,7 +2,6 @@ package org.betonquest.betonquest;
 
 import lombok.CustomLog;
 import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.conversation.ConversationResumer;
 import org.betonquest.betonquest.database.PlayerData;
@@ -80,10 +79,7 @@ public class JoinQuitListener implements Listener {
     public void onPlayerQuit(final PlayerQuitEvent event) {
         final String playerID = PlayerConverter.getID(event.getPlayer());
         for (final Objective objective : BetonQuest.getInstance().getPlayerObjectives(playerID)) {
-            final PlayerObjectiveChangeEvent objectiveEvent = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                    Objective.ObjectiveState.PAUSED, Objective.ObjectiveState.ACTIVE);
-            Bukkit.getServer().getPluginManager().callEvent(objectiveEvent);
-            objective.removePlayer(playerID);
+            objective.pauseObjectiveForPlayer(playerID);
         }
         BetonQuest.getInstance().removePlayerData(playerID);
     }

--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.Journal;
 import org.betonquest.betonquest.Point;
 import org.betonquest.betonquest.Pointer;
 import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.config.ConfigAccessor;
@@ -1296,10 +1295,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             case "d":
                 LOG.debug(null,
                         "Deleting objective " + objectiveID + " for player " + PlayerConverter.getName(playerID));
-                final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                        Objective.ObjectiveState.CANCELED, Objective.ObjectiveState.ACTIVE);
-                Bukkit.getServer().getPluginManager().callEvent(event);
-                objective.removePlayer(playerID);
+                objective.cancelObjectiveForPlayer(playerID);
                 playerData.removeRawObjective(objectiveID);
                 sendMessage(sender, "objective_removed");
                 break;
@@ -1524,10 +1520,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
                         data = "";
                     }
                     final Objective objective = BetonQuest.getInstance().getObjective(nameID);
-                    final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                            Objective.ObjectiveState.PAUSED, Objective.ObjectiveState.ACTIVE);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
-                    objective.removePlayer(playerID);
+                    objective.pauseObjectiveForPlayer(playerID);
                     BetonQuest.getInstance().getPlayerData(playerID).removeRawObjective(nameID);
                     BetonQuest.resumeObjective(PlayerConverter.getID(player), renameID, data);
                 }
@@ -1632,10 +1625,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
                 for (final Player player : Bukkit.getOnlinePlayers()) {
                     final String playerID = PlayerConverter.getID(player);
                     final Objective objective = BetonQuest.getInstance().getObjective(objectiveID);
-                    final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                            Objective.ObjectiveState.CANCELED, Objective.ObjectiveState.ACTIVE);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
-                    objective.removePlayer(playerID);
+                    objective.cancelObjectiveForPlayer(playerID);
                     BetonQuest.getInstance().getPlayerData(playerID).removeRawObjective(objectiveID);
                 }
                 break;

--- a/src/main/java/org/betonquest/betonquest/config/QuestCanceler.java
+++ b/src/main/java/org/betonquest/betonquest/config/QuestCanceler.java
@@ -5,7 +5,6 @@ import lombok.CustomLog;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Journal;
 import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
@@ -219,10 +218,7 @@ public class QuestCanceler {
             for (final ObjectiveID objectiveID : objectives) {
                 LOG.debug(objectiveID.getPackage(), "  Removing objective " + objectiveID);
                 final Objective objective = BetonQuest.getInstance().getObjective(objectiveID);
-                final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), objective,
-                        Objective.ObjectiveState.CANCELED, Objective.ObjectiveState.ACTIVE);
-                Bukkit.getServer().getPluginManager().callEvent(event);
-                objective.removePlayer(playerID);
+                objective.cancelObjectiveForPlayer(playerID);
                 playerData.removeRawObjective(objectiveID);
             }
         }

--- a/src/main/java/org/betonquest/betonquest/database/PlayerData.java
+++ b/src/main/java/org/betonquest/betonquest/database/PlayerData.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.Journal;
 import org.betonquest.betonquest.Point;
 import org.betonquest.betonquest.Pointer;
 import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.config.QuestCanceler;
 import org.betonquest.betonquest.database.Connector.QueryType;
@@ -17,7 +16,6 @@ import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
 import org.betonquest.betonquest.id.ObjectiveID;
 import org.betonquest.betonquest.item.QuestItem;
 import org.betonquest.betonquest.utils.PlayerConverter;
-import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
 import java.sql.ResultSet;
@@ -494,10 +492,7 @@ public class PlayerData {
      */
     public void purgePlayer() {
         for (final Objective obj : BetonQuest.getInstance().getPlayerObjectives(playerID)) {
-            final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID), obj,
-                    Objective.ObjectiveState.CANCELED, Objective.ObjectiveState.ACTIVE);
-            Bukkit.getServer().getPluginManager().callEvent(event);
-            obj.removePlayer(playerID);
+            obj.cancelObjectiveForPlayer(playerID);
         }
         // clear all lists
         objectives.clear();

--- a/src/main/java/org/betonquest/betonquest/events/ObjectiveEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/ObjectiveEvent.java
@@ -3,8 +3,6 @@ package org.betonquest.betonquest.events;
 import lombok.CustomLog;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
-import org.betonquest.betonquest.api.Objective;
-import org.betonquest.betonquest.api.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.QuestEvent;
 import org.betonquest.betonquest.database.Connector;
 import org.betonquest.betonquest.database.PlayerData;
@@ -21,7 +19,7 @@ import java.util.Arrays;
 import java.util.Locale;
 
 /**
- * Starts an objective for the player
+ * Starts an objective for the player.
  */
 @SuppressWarnings({"PMD.CommentRequired", "PMD.AvoidDuplicateLiterals"})
 @CustomLog
@@ -89,10 +87,7 @@ public class ObjectiveEvent extends QuestEvent {
                     break;
                 case "delete":
                 case "remove":
-                    final PlayerObjectiveChangeEvent event = new PlayerObjectiveChangeEvent(PlayerConverter.getPlayer(playerID),
-                            BetonQuest.getInstance().getObjective(objective), Objective.ObjectiveState.CANCELED, Objective.ObjectiveState.ACTIVE);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
-                    BetonQuest.getInstance().getObjective(objective).removePlayer(playerID);
+                    BetonQuest.getInstance().getObjective(objective).cancelObjectiveForPlayer(playerID);
                     BetonQuest.getInstance().getPlayerData(playerID).removeRawObjective(objective);
                     break;
                 case "complete":


### PR DESCRIPTION
# Description
Refactoring of `Objective#addPlayer()` and `Objective#removePlayer()` to call the event always synchronously and reduce coupling of the `ObjectiveChangeEvent`.

## Related Issues
Closes #1546

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
