### PR TITLE
Fix betonquest not enabling if compatible plugin can't be hooked

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -25,7 +25,6 @@ import org.betonquest.betonquest.compatibility.skript.SkriptIntegrator;
 import org.betonquest.betonquest.compatibility.vault.VaultIntegrator;
 import org.betonquest.betonquest.compatibility.worldedit.WorldEditIntegrator;
 import org.betonquest.betonquest.compatibility.worldguard.WorldGuardIntegrator;
-import org.betonquest.betonquest.exceptions.HookException;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -133,6 +132,7 @@ public class Compatibility implements Listener {
         hook(event.getPlugin());
     }
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void hook(final Plugin hook) {
 
         // don't want to hook twice
@@ -161,10 +161,10 @@ public class Compatibility implements Listener {
             try {
                 integrator.hook();
                 hooked.add(name);
-            } catch (final HookException exception) {
+            } catch (final Exception | LinkageError exception) {
                 final String message = String.format("There was an error while hooking into %s %s (BetonQuest %s, Spigot %s)! %s",
-                        exception.getPluginName(),
-                        exception.getPluginVersion(),
+                        plugin.getName(),
+                        plugin.getDescription().getVersion(),
                         BetonQuest.getInstance().getDescription().getVersion(),
                         Bukkit.getVersion(),
                         exception.getMessage());

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -25,6 +25,7 @@ import org.betonquest.betonquest.compatibility.skript.SkriptIntegrator;
 import org.betonquest.betonquest.compatibility.vault.VaultIntegrator;
 import org.betonquest.betonquest.compatibility.worldedit.WorldEditIntegrator;
 import org.betonquest.betonquest.compatibility.worldguard.WorldGuardIntegrator;
+import org.betonquest.betonquest.exceptions.HookException;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -161,7 +162,7 @@ public class Compatibility implements Listener {
             try {
                 integrator.hook();
                 hooked.add(name);
-            } catch (final Exception | LinkageError exception) {
+            } catch (final HookException | RuntimeException | LinkageError exception) {
                 final String message = String.format("There was an error while hooking into %s %s (BetonQuest %s, Spigot %s)! %s",
                         hookedPlugin.getName(),
                         hookedPlugin.getDescription().getVersion(),

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -162,15 +162,25 @@ public class Compatibility implements Listener {
             try {
                 integrator.hook();
                 hooked.add(name);
-            } catch (final HookException | RuntimeException | LinkageError exception) {
-                final String message = String.format("There was an error while hooking into %s %s (BetonQuest %s, Spigot %s)! %s",
+            } catch (final HookException exception) {
+                final String message = String.format("Could not hook into %s %s! %s",
+                        hookedPlugin.getName(),
+                        hookedPlugin.getDescription().getVersion(),
+                        exception.getMessage());
+                LOG.warning(null, message);
+                LOG.debug(null, message, exception);
+                LOG.warning(null, "BetonQuest will work correctly, except for that single integration. "
+                        + "You can turn it off by setting 'hook." + name.toLowerCase(Locale.ROOT)
+                        + "' to false in config.yml file.");
+            } catch (final RuntimeException | LinkageError exception) {
+                final String message = String.format("There was an unexpected error while hooking into %s %s (BetonQuest %s, Spigot %s)! %s",
                         hookedPlugin.getName(),
                         hookedPlugin.getDescription().getVersion(),
                         BetonQuest.getInstance().getDescription().getVersion(),
                         Bukkit.getVersion(),
                         exception.getMessage());
                 LOG.warning(null, message, exception);
-                LOG.warning(null, "BetonQuest will work correctly save for that single integration. "
+                LOG.warning(null, "BetonQuest will work correctly, except for that single integration. "
                         + "You can turn it off by setting 'hook." + name.toLowerCase(Locale.ROOT)
                         + "' to false in config.yml file.");
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -47,7 +47,7 @@ public class Compatibility implements Listener {
 
     private static Compatibility instance;
     private final Map<String, Integrator> integrators = new HashMap<>();
-    private final BetonQuest plugin = BetonQuest.getInstance();
+    private final BetonQuest betonQuest = BetonQuest.getInstance();
     private final List<String> hooked = new ArrayList<>();
 
     @SuppressWarnings("PMD.AssignmentToNonFinalStatic")
@@ -88,7 +88,7 @@ public class Compatibility implements Listener {
 
         // hook into ProtocolLib
         if (Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")
-                && "true".equalsIgnoreCase(plugin.getConfig().getString("hook.protocollib"))) {
+                && "true".equalsIgnoreCase(betonQuest.getConfig().getString("hook.protocollib"))) {
             hooked.add("ProtocolLib");
         }
         new BukkitRunnable() {
@@ -133,19 +133,19 @@ public class Compatibility implements Listener {
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void hook(final Plugin hook) {
+    private void hook(final Plugin hookedPlugin) {
 
         // don't want to hook twice
-        if (hooked.contains(hook.getName())) {
+        if (hooked.contains(hookedPlugin.getName())) {
             return;
         }
 
         // don't want to hook into disabled plugins
-        if (!hook.isEnabled()) {
+        if (!hookedPlugin.isEnabled()) {
             return;
         }
 
-        final String name = hook.getName();
+        final String name = hookedPlugin.getName();
         final Integrator integrator = integrators.get(name);
 
         // this plugin is not an integration
@@ -154,7 +154,7 @@ public class Compatibility implements Listener {
         }
 
         // hook into the plugin if it's enabled in the config
-        if ("true".equalsIgnoreCase(plugin.getConfig().getString("hook." + name.toLowerCase(Locale.ROOT)))) {
+        if ("true".equalsIgnoreCase(betonQuest.getConfig().getString("hook." + name.toLowerCase(Locale.ROOT)))) {
             LOG.info(null, "Hooking into " + name);
 
             // log important information in case of an error
@@ -163,8 +163,8 @@ public class Compatibility implements Listener {
                 hooked.add(name);
             } catch (final Exception | LinkageError exception) {
                 final String message = String.format("There was an error while hooking into %s %s (BetonQuest %s, Spigot %s)! %s",
-                        plugin.getName(),
-                        plugin.getDescription().getVersion(),
+                        hookedPlugin.getName(),
+                        hookedPlugin.getDescription().getVersion(),
                         BetonQuest.getInstance().getDescription().getVersion(),
                         Bukkit.getVersion(),
                         exception.getMessage());

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -167,8 +167,7 @@ public class Compatibility implements Listener {
                         hookedPlugin.getName(),
                         hookedPlugin.getDescription().getVersion(),
                         exception.getMessage());
-                LOG.warning(null, message);
-                LOG.debug(null, message, exception);
+                LOG.warning(null, message, exception);
                 LOG.warning(null, "BetonQuest will work correctly, except for that single integration. "
                         + "You can turn it off by setting 'hook." + name.toLowerCase(Locale.ROOT)
                         + "' to false in config.yml file.");

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -178,7 +178,7 @@ public class Compatibility implements Listener {
                         BetonQuest.getInstance().getDescription().getVersion(),
                         Bukkit.getVersion(),
                         exception.getMessage());
-                LOG.warning(null, message, exception);
+                LOG.error(null, message, exception);
                 LOG.warning(null, "BetonQuest will work correctly, except for that single integration. "
                         + "You can turn it off by setting 'hook." + name.toLowerCase(Locale.ROOT)
                         + "' to false in config.yml file.");


### PR DESCRIPTION
# Description
If an error occurs while hooking into a plugin BetonQuest would not detect that and fail to enable.
Instead the error is logged and the hook will be disabled.
