### PR TITLE
fix quest item name comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sometimes messages in a conversation are not send when packet interceptor is used
 - added missing config options to the default config
 - `menu open` event does not show the previous menu again anymore
+- quest item empty name comparison
 ### Security
 - it was possible to put a QuestItem into a chest
 - the take event is now threadsafe

--- a/src/main/java/org/betonquest/betonquest/item/QuestItem.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItem.java
@@ -364,7 +364,8 @@ public class QuestItem {
             return false;
         }
         final ItemMeta meta = item.getItemMeta();
-        if (!name.check(meta.getDisplayName())) {
+        final String displayName = meta.hasDisplayName() ? meta.getDisplayName() : null;
+        if (!name.check(displayName)) {
             return false;
         }
         if (!lore.check(meta.getLore())) {


### PR DESCRIPTION
# Description
Using hasDisplayName()  instead of the raw name makes sure that the comparision works with both `null` and empty string values for an item that has no display name.

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [X]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
