### PR TITLE
BlockObjective added break argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - all objectives that can be advanced without directly completing now support `left`, `amount` and `total` variables
 - `action` objective cancels now the event, before other plugins check for it (better third-party support)
 - the French translation has been updated
+- block objective, added break argument instead using (-)
 ### Deprecated
 ### Removed
 - `message` event

--- a/documentation/Documentation/Objectives-List.md
+++ b/documentation/Documentation/Objectives-List.md
@@ -35,18 +35,19 @@ give accurate results. Experiment with this objective a bit to make sure you've 
 ## Block: `block`
 
 To complete this objective the player must break or place the specified amount of blocks. The first argument is a
-[Block Selector](./Reference.md#block-selectors). Next is amount. It can be more than 0 for placing and
-less than 0 for destroying. You can also use the `notify` keyword to display messages to the player each time he updates
+[Block Selector](./Reference.md#block-selectors). Next is amount. You can use `break` keyword for destroying. 
+You can also use the `notify` keyword to display messages to the player each time he updates
 amount of blocks, optionally with the notification interval after colon.
 
 This objective has three properties: `amount`, `left` and `total`. `amount` is the amount of blocks already done,
 `left` is the amount of blocks still needed to complete the objective and `total` is the amount of blocks initially
 needed.
-Note that it follows the same rules as the amount argument, meaning that blocks to break are a negative number!
+Note that placed block by player that run the objective will not add progress to destroying block
 
 !!! example
     ```YAML
-    block LOG -16 events:reward notify:5
+    block LOG 16 break events:reward notify:5
+    block LOG 16 events:reward notify:5
     ```
 
 ## Breed animals: `breed`

--- a/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
@@ -8,49 +8,72 @@ import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.utils.BlockSelector;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.Bukkit;
+import org.bukkit.block.data.Ageable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.metadata.FixedMetadataValue;
 
 /**
  * Player has to break/place specified amount of blocks. Doing opposite thing
- * (breaking when should be placing) will reverse the progress.
+ * (breaking when should be placing) will not count the progress.
  */
-@SuppressWarnings({"PMD.CommentRequired", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.CommentRequired", "PMD.AvoidDuplicateLiterals", "PMD.AvoidLiteralsInIfCondition"})
 @CustomLog
 public class BlockObjective extends CountingObjective implements Listener {
 
     private final BlockSelector selector;
     private final boolean exactMatch;
+    private final boolean blockBreak;
 
     public BlockObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         selector = instruction.getBlockSelector();
         exactMatch = instruction.hasArgument("exactMatch");
+        blockBreak = instruction.hasArgument("break");
         targetAmount = instruction.getInt();
+
+        if (targetAmount < 1){
+            throw new InstructionParseException("the amount cannot be less than 1");
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onBlockPlace(final BlockPlaceEvent event) {
         final String playerID = PlayerConverter.getID(event.getPlayer());
-        if (containsPlayer(playerID) && selector.match(event.getBlock(), exactMatch) && checkConditions(playerID)) {
-            handleDataChange(playerID, getCountingData(playerID).add());
+        if (containsPlayer(playerID)
+                && selector.match(event.getBlock(), exactMatch)
+                && checkConditions(playerID)
+                && !blockBreak) {
+            handleDataChange(playerID);
+        }
+
+        if(blockBreak
+                && selector.match(event.getBlock(), exactMatch)
+                && checkConditions(playerID)
+                && !(event.getBlockPlaced().getBlockData() instanceof Ageable)) {
+            event.getBlockPlaced().setMetadata("PlayerPlaced", new FixedMetadataValue(BetonQuest.getInstance(), playerID));
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onBlockBreak(final BlockBreakEvent event) {
         final String playerID = PlayerConverter.getID(event.getPlayer());
-        if (containsPlayer(playerID) && selector.match(event.getBlock(), exactMatch) && checkConditions(playerID)) {
-            handleDataChange(playerID, getCountingData(playerID).subtract());
+        if (blockBreak
+                && containsPlayer(playerID)
+                && selector.match(event.getBlock(), exactMatch)
+                && checkConditions(playerID)
+                && !event.getBlock().hasMetadata("PlayerPlaced")) {
+            handleDataChange(playerID);
         }
     }
 
-    private void handleDataChange(final String playerID, final CountingData data) {
-        final String message = data.getDirectionFactor() > 0 ? "blocks_to_place" : "blocks_to_break";
+    private void handleDataChange(final String playerID) {
+        final String message = blockBreak ? "blocks_to_break" : "blocks_to_place";
+        getCountingData(playerID).progress();
         completeIfDoneOrNotify(playerID, message);
     }
 

--- a/src/main/resources/default/objectives.yml
+++ b/src/main/resources/default/objectives.yml
@@ -1,1 +1,1 @@
-wood: block $block$ -16 events:tag_wood_done,entry_wood_done
+wood: block $block$ 16 break events:tag_wood_done,entry_wood_done


### PR DESCRIPTION
# Description
Remake block objective, added new break argument. And if player have break argument it will not count the block if the block placed by player that run the objective

## Related Issues
Closes #786 

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [x]  ... test your changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ... adjust the ConfigUpdater?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
