### PR TITLE
replaced plugin config calls the ConfigurationFile object

### DIFF
--- a/src/main/java/org/betonquest/betonquest/commands/LangCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/LangCommand.java
@@ -73,7 +73,7 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
             }
 
         } else {
-            BetonQuest.getInstance().getConfig().set("language", args[0]);
+            BetonQuest.getInstance().getPluginConfig().set("language", args[0]);
             sender.sendMessage(Config.getMessage(args[0], "default_language_changed"));
         }
         return true;

--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -1684,6 +1684,12 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             } else {
                 logWatcher.endDebug();
             }
+            try {
+                logWatcher.saveDebuggingToConfig();
+            } catch (final IOException e) {
+                sender.sendMessage("Could not save new debugging state to configuration file!");
+                LOG.warn("Could not save new debugging state to configuration file! " + e.getMessage(), e);
+            }
             sender.sendMessage("§2Debugging mode was " + (logWatcher.isDebugging() ? "enabled" : "disabled") + '!');
             LOG.info("Debuging mode was " + (logWatcher.isDebugging() ? "enabled" : "disabled") + '!');
             return;

--- a/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/Compatibility.java
@@ -49,7 +49,6 @@ public class Compatibility implements Listener {
 
     private static Compatibility instance;
     private final Map<String, Integrator> integrators = new HashMap<>();
-    private final BetonQuest betonQuest = BetonQuest.getInstance();
     private final List<String> hooked = new ArrayList<>();
 
     @SuppressWarnings("PMD.AssignmentToNonFinalStatic")
@@ -153,7 +152,7 @@ public class Compatibility implements Listener {
         }
 
         // hook into the plugin if it's enabled in the config
-        if ("true".equalsIgnoreCase(betonQuest.getConfig().getString("hook." + name.toLowerCase(Locale.ROOT)))) {
+        if ("true".equalsIgnoreCase(BetonQuest.getInstance().getPluginConfig().getString("hook." + name.toLowerCase(Locale.ROOT)))) {
             LOG.info("Hooking into " + name);
 
             // log important information in case of an error

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensListener.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensListener.java
@@ -53,11 +53,11 @@ public class CitizensListener implements Listener {
         rightClick = new RightClickListener();
         Bukkit.getPluginManager().registerEvents(rightClick, plugin);
 
-        if (plugin.getConfig().getBoolean("acceptNPCLeftClick")) {
+        if (plugin.getPluginConfig().getBoolean("acceptNPCLeftClick")) {
             leftClick = new LeftClickListener();
             Bukkit.getPluginManager().registerEvents(leftClick, plugin);
         }
-        interactionLimit = plugin.getConfig().getInt("npcInteractionLimit", 500);
+        interactionLimit = plugin.getPluginConfig().getInt("npcInteractionLimit", 500);
     }
 
     @SuppressWarnings({"PMD.AvoidLiteralsInIfCondition", "PMD.CyclomaticComplexity", "PMD.NPathComplexity"})

--- a/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -148,7 +148,7 @@ public class HologramLoop {
                 }
             }
         };
-        runnable.runTaskTimerAsynchronously(BetonQuest.getInstance(), 20, BetonQuest.getInstance().getConfig()
+        runnable.runTaskTimerAsynchronously(BetonQuest.getInstance(), 20, BetonQuest.getInstance().getPluginConfig()
                 .getInt("hologram_update_interval", 20 * 10));
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/NPCHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/NPCHider.java
@@ -38,7 +38,7 @@ public final class NPCHider extends BukkitRunnable implements Listener {
     private NPCHider() {
         super();
         npcs = new HashMap<>();
-        final int updateInterval = BetonQuest.getInstance().getConfig().getInt("npc_hider_check_interval", 5 * 20);
+        final int updateInterval = BetonQuest.getInstance().getPluginConfig().getInt("npc_hider_check_interval", 5 * 20);
         hider = new EntityHider(BetonQuest.getInstance(), EntityHider.Policy.BLACKLIST);
         loadFromConfig();
         runTaskTimer(BetonQuest.getInstance(), 0, updateInterval);

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -103,8 +103,8 @@ public class Conversation implements Listener {
         this.location = location;
         this.convID = conversationID;
         this.data = plugin.getConversation(convID);
-        this.blacklist = plugin.getConfig().getStringList("cmd_blacklist");
-        this.messagesDelaying = "true".equalsIgnoreCase(plugin.getConfig().getString("display_chat_after_conversation"));
+        this.blacklist = plugin.getPluginConfig().getStringList("cmd_blacklist");
+        this.messagesDelaying = "true".equalsIgnoreCase(plugin.getPluginConfig().getString("display_chat_after_conversation"));
 
         // check if data is present
         if (data == null) {

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
@@ -89,7 +89,7 @@ public class ConversationData {
         }
         final String stop = pack.getString("conversations." + name + ".stop");
         blockMovement = stop != null && stop.equalsIgnoreCase("true");
-        final String rawConvIO = pack.getString("conversations." + name + ".conversationIO", BetonQuest.getInstance().getConfig().getString("default_conversation_IO", "menu,chest"));
+        final String rawConvIO = pack.getString("conversations." + name + ".conversationIO", BetonQuest.getInstance().getPluginConfig().getString("default_conversation_IO", "menu,chest"));
 
         // check if all data is valid (or at least exist)
         for (final String s : rawConvIO.split(",")) {
@@ -102,7 +102,7 @@ public class ConversationData {
             throw new InstructionParseException("No registered conversation IO found: " + rawConvIO);
         }
 
-        final String rawInterceptor = pack.getString("conversations." + name + ".interceptor", BetonQuest.getInstance().getConfig().getString("default_interceptor", "simple"));
+        final String rawInterceptor = pack.getString("conversations." + name + ".interceptor", BetonQuest.getInstance().getPluginConfig().getString("default_interceptor", "simple"));
         for (final String s : rawInterceptor.split(",")) {
             if (BetonQuest.getInstance().getInterceptor(s.trim()) != null) {
                 interceptor = s.trim();

--- a/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
@@ -99,8 +99,8 @@ public class InventoryConvIO implements Listener, ConversationIO {
         loc = player.getLocation();
 
         // Load config
-        if (BetonQuest.getInstance().getConfig().contains("conversation_IO_config.chest")) {
-            final ConfigurationSection config = BetonQuest.getInstance().getConfig().getConfigurationSection("conversation_IO_config.chest");
+        if (BetonQuest.getInstance().getPluginConfig().contains("conversation_IO_config.chest")) {
+            final ConfigurationSection config = BetonQuest.getInstance().getPluginConfig().getConfigurationSection("conversation_IO_config.chest");
             showNumber = config.getBoolean("show_number", true);
             showNPCText = config.getBoolean("show_npc_text", true);
         }

--- a/src/main/java/org/betonquest/betonquest/database/Connector.java
+++ b/src/main/java/org/betonquest/betonquest/database/Connector.java
@@ -25,7 +25,7 @@ public class Connector {
      */
     public Connector() {
         final BetonQuest plugin = BetonQuest.getInstance();
-        prefix = plugin.getConfig().getString("mysql.prefix", "");
+        prefix = plugin.getPluginConfig().getString("mysql.prefix", "");
         database = plugin.getDB();
         connection = database.getConnection();
         refresh();

--- a/src/main/java/org/betonquest/betonquest/database/Database.java
+++ b/src/main/java/org/betonquest/betonquest/database/Database.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.database;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.CustomLog;
+import org.betonquest.betonquest.BetonQuest;
 import org.bukkit.plugin.Plugin;
 
 import java.sql.Connection;
@@ -19,9 +20,9 @@ public abstract class Database {
     protected String prefix;
     protected Connection con;
 
-    protected Database(final Plugin plugin) {
+    protected Database(final BetonQuest plugin) {
         this.plugin = plugin;
-        this.prefix = plugin.getConfig().getString("mysql.prefix", "");
+        this.prefix = plugin.getPluginConfig().getString("mysql.prefix", "");
     }
 
     public Connection getConnection() {

--- a/src/main/java/org/betonquest/betonquest/database/MySQL.java
+++ b/src/main/java/org/betonquest/betonquest/database/MySQL.java
@@ -1,7 +1,7 @@
 package org.betonquest.betonquest.database;
 
 import lombok.CustomLog;
-import org.bukkit.plugin.Plugin;
+import org.betonquest.betonquest.BetonQuest;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -29,7 +29,7 @@ public class MySQL extends Database {
      * @param username Username
      * @param password Password
      */
-    public MySQL(final Plugin plugin, final String hostname, final String port, final String database, final String username, final String password) {
+    public MySQL(final BetonQuest plugin, final String hostname, final String port, final String database, final String username, final String password) {
         super(plugin);
         this.hostname = hostname;
         this.port = port;

--- a/src/main/java/org/betonquest/betonquest/database/SQLite.java
+++ b/src/main/java/org/betonquest/betonquest/database/SQLite.java
@@ -2,7 +2,7 @@ package org.betonquest.betonquest.database;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.CustomLog;
-import org.bukkit.plugin.Plugin;
+import org.betonquest.betonquest.BetonQuest;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class SQLite extends Database {
      * @param plugin     Plugin instance
      * @param dbLocation Location of the Database (Must end in .db)
      */
-    public SQLite(final Plugin plugin, final String dbLocation) {
+    public SQLite(final BetonQuest plugin, final String dbLocation) {
         super(plugin);
         this.dbLocation = dbLocation;
     }

--- a/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
@@ -221,7 +221,7 @@ public class QuestItemHandler implements Listener {
     @SuppressWarnings("deprecation")
     @EventHandler(ignoreCancelled = true)
     public void onItemBreak(final PlayerItemBreakEvent event) {
-        if ("false".equalsIgnoreCase(BetonQuest.getInstance().getConfig().getString("quest_items_unbreakable"))) {
+        if ("false".equalsIgnoreCase(BetonQuest.getInstance().getPluginConfig().getString("quest_items_unbreakable"))) {
             return;
         }
         // prevent quest items from breaking

--- a/src/main/java/org/betonquest/betonquest/mechanics/PlayerHider.java
+++ b/src/main/java/org/betonquest/betonquest/mechanics/PlayerHider.java
@@ -51,7 +51,7 @@ public class PlayerHider {
             }
         }
 
-        final long period = BetonQuest.getInstance().getConfig().getLong("player_hider_check_interval", 20);
+        final long period = BetonQuest.getInstance().getPluginConfig().getLong("player_hider_check_interval", 20);
         bukkitTask = Bukkit.getScheduler().runTaskTimer(BetonQuest.getInstance(), this::updateVisibility, 1, period);
     }
 

--- a/src/main/java/org/betonquest/betonquest/menu/RPGMenu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/RPGMenu.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.menu;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.CustomLog;
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.api.config.QuestPackage;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
@@ -118,8 +119,10 @@ public class RPGMenu {
         this.pluginCommand = new RPGMenuCommand();
         //create config if it doesn't exist
         final File config = new File(BetonQuest.getInstance().getDataFolder(), "menuConfig.yml");
-        if (!config.exists()) {
-            BetonQuest.getInstance().saveResource("menuConfig.yml", false);
+        try {
+            ConfigAccessor.create(config, BetonQuest.getInstance(), "menuConfig.yml");
+        } catch (InvalidConfigurationException | FileNotFoundException e) {
+            LOG.warn(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/betonquest/betonquest/notify/Notify.java
+++ b/src/main/java/org/betonquest/betonquest/notify/Notify.java
@@ -28,7 +28,7 @@ public final class Notify {
 
     public static void load() {
         loadCategorySettings();
-        defaultNotifyIO = BetonQuest.getInstance().getConfig().getString("default_notify_IO");
+        defaultNotifyIO = BetonQuest.getInstance().getPluginConfig().getString("default_notify_IO");
     }
 
     public static NotifyIO get() {

--- a/src/main/java/org/betonquest/betonquest/utils/Utils.java
+++ b/src/main/java/org/betonquest/betonquest/utils/Utils.java
@@ -70,7 +70,7 @@ public final class Utils {
         }
         // zip all the files
         final String outputPath = backupFolder.getAbsolutePath() + File.separator + "backup-"
-                + instance.getConfig().getString("version", null);
+                + instance.getPluginConfig().getString("version", null);
 
         Zipper.zip(instance.getDataFolder(), outputPath, "^backup.*", "^database\\.db$", "^changelog\\.txt$", "^logs$");
         // delete database backup so it doesn't make a mess later on

--- a/src/main/java/org/betonquest/betonquest/utils/versioning/Updater.java
+++ b/src/main/java/org/betonquest/betonquest/utils/versioning/Updater.java
@@ -11,7 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -363,12 +362,11 @@ public class Updater {
          */
         @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
         public UpdaterConfig() {
-            final FileConfiguration config = BetonQuest.getInstance().getConfig();
 
-            enabled = config.getBoolean("update.enabled", true);
-            ingameNotification = config.getBoolean("update.ingameNotification", true);
+            enabled = BetonQuest.getInstance().getPluginConfig().getBoolean("update.enabled", true);
+            ingameNotification = BetonQuest.getInstance().getPluginConfig().getBoolean("update.ingameNotification", true);
 
-            String updateStrategy = config.getString("update.strategy", "MINOR").toUpperCase(Locale.ROOT);
+            String updateStrategy = BetonQuest.getInstance().getPluginConfig().getString("update.strategy", "MINOR").toUpperCase(Locale.ROOT);
             boolean downloadDev = updateStrategy.endsWith(DEV_INDICATOR);
             if (downloadDev) {
                 updateStrategy = updateStrategy.substring(0, updateStrategy.length() - DEV_INDICATOR.length());
@@ -388,7 +386,7 @@ public class Updater {
                 automatic = false;
                 forcedStrategy = true;
             } else {
-                automatic = config.getBoolean("update.automatic", false);
+                automatic = BetonQuest.getInstance().getPluginConfig().getBoolean("update.automatic", false);
                 forcedStrategy = false;
             }
             this.downloadDev = downloadDev;


### PR DESCRIPTION
Merge first: #1772

# Description
This replaces all plugin.getConfig calls and related save calls with the new ConfigurationFile object.

Currently there is one issue left, that need to be solved by refactoring.
In the BetonQuest class the call `new LogWatcher(this, adventure);` need a instance of the `ConfigurationFile` of the config.yml but this is created a couple lines later with `Config.setup(this);`.

At the moment the server throws an exception during startup.

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
