### PR TITLE
[DOCS] Added Profession argument to MMOCore Event

### DIFF
--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -671,8 +671,8 @@ mmoclassexperience 1 level
 Adds experience in the specified player profession. The amount can be a variable or a number. The `level` argument
 is optional and would convert the amount to levels instead of XP points.
 ```YAML linenums="1"
-mmoprofessionexperience 100
-mmoprofessionexperience 1 level
+mmoprofessionexperience MINING 100
+mmoprofessionexperience CUSTOM_PROFESSION_NAME 1 level
 ```
 
 ####Give class points: `mmocoreclasspoints`


### PR DESCRIPTION
The Give MMOCore Profession XP Event was missing the `profession` argument in the example.
