### PR TITLE
[DOCS] New Icons

### DIFF
--- a/docs/API/API.md
+++ b/docs/API/API.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/gear-16
+---
 ## Accessing the plugin
 
 !!! warning

--- a/docs/API/Logging.md
+++ b/docs/API/Logging.md
@@ -1,3 +1,6 @@
+---
+icon: material/text-box-outline
+---
 --8<-- "API-State/Draft.md"
 
 This page shows you everything you need to know about the BetonQuest logger, no matter if you are working on BetonQuest 

--- a/docs/API/Overview.md
+++ b/docs/API/Overview.md
@@ -1,3 +1,6 @@
+---
+icon: material/handshake
+---
 !!! caution "Work in Progress! :construction: :construction_worker:  :construction_site:"
 
     **Both the plugin and the API are currently getting redesigned.**

--- a/docs/Documentation/CHANGELOG.md
+++ b/docs/Documentation/CHANGELOG.md
@@ -1,1 +1,4 @@
+---
+icon: material/cards-variant
+---
 # Placeholder Changelog

--- a/docs/Documentation/Commands-and-permissions.md
+++ b/docs/Documentation/Commands-and-permissions.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/lock
+---
 # Commands and permissions
 
 ## Commands

--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -1,3 +1,6 @@
+---
+icon: material/handshake
+---
 # Compatibility
 **In total 30 plugins have dedicated support for BetonQuest.**
 

--- a/docs/Documentation/Conditions-List.md
+++ b/docs/Documentation/Conditions-List.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/question-16
+---
 # Conditions List
 
 ## Advancement: `advancement`

--- a/docs/Documentation/Configuration.md
+++ b/docs/Documentation/Configuration.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/wrench
+---
 # Configuration
 
 The configuration of BetonQuest is mainly done in the `config.yml` file. All of its options are described on this page.

--- a/docs/Documentation/Conversations.md
+++ b/docs/Documentation/Conversations.md
@@ -1,3 +1,6 @@
+---
+icon: material/message-text
+---
 ## General Information
 Each conversation must define name of the NPC 
 (some conversations can be not bound to any NPC, so it’s important to specify it even though an NPC will have a name) and his initial options.

--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/gear-16
+---
 # Events List
 
 ## Cancel quest: `cancel`

--- a/docs/Documentation/Notification-IO's-&-Categories.md
+++ b/docs/Documentation/Notification-IO's-&-Categories.md
@@ -1,3 +1,6 @@
+---
+icon: material/party-popper
+---
 ## Notify IO's
 
 A NotifyIO is a method of displaying a notification to the player. Here's a demo video showing an example configuration

--- a/docs/Documentation/Notification-Settings.md
+++ b/docs/Documentation/Notification-Settings.md
@@ -1,3 +1,6 @@
+---
+icon: material/volume-high
+---
 BetonQuest features a powerful notify system that allows you to display any information to your players.
 You can freely choose between many NotifyIO's like simple chat output, (sub)titles, advancements or sounds. They all come
 with unique options that allow you to customize them. Just take a look at this example configuration:

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -1,3 +1,6 @@
+---
+icon: material/check-circle
+---
 # Objectives List
 
 ## Action: `action`

--- a/docs/Documentation/Reference.md
+++ b/docs/Documentation/Reference.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/book
+---
 # Reference
 
 This chapter describes all aspects of BetonQuest in one place. You should read it at least once to know what you're dealing with and where to search for information if you ever have any problems.

--- a/docs/Documentation/Reference.md
+++ b/docs/Documentation/Reference.md
@@ -1,5 +1,5 @@
 ---
-icon: fontawesome/solid/book
+icon: octicons/book-16
 ---
 # Reference
 

--- a/docs/Documentation/Updating/Migration.md
+++ b/docs/Documentation/Updating/Migration.md
@@ -1,3 +1,6 @@
+---
+icon: material/upload
+---
 This migration guide currently needs to be done manually. As long as BQ 2.0 is in development, this will not change!
 
 Before you start migrating, you should **backup your system**!

--- a/docs/Documentation/Updating/index.md
+++ b/docs/Documentation/Updating/index.md
@@ -1,3 +1,6 @@
+---
+icon: material/download
+---
 <style>
 .table {
   max-width: 1200px;

--- a/docs/Documentation/Variables-List.md
+++ b/docs/Documentation/Variables-List.md
@@ -1,3 +1,6 @@
+---
+icon: material/variable-box
+---
 # Variables List
 
 ## Custom Strings

--- a/docs/Participate/Misc/Versioning-and-Releasing.md
+++ b/docs/Participate/Misc/Versioning-and-Releasing.md
@@ -1,3 +1,6 @@
+---
+icon: material/factory
+---
 #Versioning and Releasing
 
 ##Versioning

--- a/docs/Participate/Overview.md
+++ b/docs/Participate/Overview.md
@@ -1,3 +1,6 @@
+---
+icon: material/handshake
+---
 There are two options to support projects like this one:
 
 ## Donate Time :material-clock-time-four:

--- a/docs/Participate/Process/Code/Adding-a-new-Dependency.md
+++ b/docs/Participate/Process/Code/Adding-a-new-Dependency.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/package-dependencies-16
+---
 ## Requirements 
 You can only add support for plugins that have a public API. This means Maven must be able to resolve the dependency 
 from an online repository. Adding dependencies from you local harddrive is NOT allowed as this stops everyone from 

--- a/docs/Participate/Process/Code/Checking-Requirements.md
+++ b/docs/Participate/Process/Code/Checking-Requirements.md
@@ -1,3 +1,6 @@
+---
+icon: material/magnify
+---
 ###Fulfil the Contributing Requirements
 Run `mvn verify` before [Submitting Changes](../Submitting-Changes.md) to check if your change
 meets the project's requirements regarding code style and quality.

--- a/docs/Participate/Process/Code/Writing-JUnit-Tests.md
+++ b/docs/Participate/Process/Code/Writing-JUnit-Tests.md
@@ -1,3 +1,6 @@
+---
+icon: material/test-tube
+---
 Here you can find a summary on how to write JUnit tests for BetonQuest. In order to understand this, you need to have
 basic knowledge of JUnit tests and mocking of objects and classes.
 

--- a/docs/Participate/Process/Code/index.md
+++ b/docs/Participate/Process/Code/index.md
@@ -1,4 +1,7 @@
-# 👨‍🔧 Changing Code
+---
+icon: material/code-json
+---
+# Changing Code
 
 Make sure to [setup the project](../../Setup-Project.md) before doing this step. 
 You should always [create a new branch](../Create-a-new-Branch.md) everytime you develop a new feature,

--- a/docs/Participate/Process/Create-a-new-Branch.md
+++ b/docs/Participate/Process/Create-a-new-Branch.md
@@ -1,3 +1,6 @@
+---
+icon: material/source-branch-plus
+---
 A new branch should always be created from an up to date `master` branch.
 That's why you [added the BetonQuest repositry](../Setup-Project.md#adding-remote-repository) `upstream`.
 Now click on your current branch in the bottom right corner, probably `master`.

--- a/docs/Participate/Process/Docs/Guidelines.md
+++ b/docs/Participate/Process/Docs/Guidelines.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/pen-nib
+---
 You need to follow these rules in order to contribute to the docs. They are important for a good user experience and provide
 a consistent baseline for other contributors to work with.
 

--- a/docs/Participate/Process/Docs/Principles.md
+++ b/docs/Participate/Process/Docs/Principles.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/book
+---
 A brief overview of basic documentation principles.
 
 

--- a/docs/Participate/Process/Docs/index.md
+++ b/docs/Participate/Process/Docs/index.md
@@ -1,3 +1,6 @@
+---
+icon: material/pen
+---
 # 👨‍🏫 Changing Docs
 
 Make sure to [setup the project](../../Setup-Project.md) before doing this step.

--- a/docs/Participate/Process/Maintaining-the-Changelog.md
+++ b/docs/Participate/Process/Maintaining-the-Changelog.md
@@ -1,3 +1,6 @@
+---
+icon: material/cards-variant
+---
 Before you make a commit, you should keep in mind, that you need to add a changelog entry.
 
 We have 6 categories in the CHANGELOG.md file for each version.

--- a/docs/Participate/Process/Submitting-Changes.md
+++ b/docs/Participate/Process/Submitting-Changes.md
@@ -1,3 +1,6 @@
+---
+icon: fontawesome/solid/flag-checkered
+---
 The last step of the contributing process is to submit your changes. This is done via a pull request on GitHub. 
 A pull request basically is asking us to pull your changes into our codebase. Let's create one!
 

--- a/docs/Participate/Setup-Project.md
+++ b/docs/Participate/Setup-Project.md
@@ -1,3 +1,6 @@
+---
+icon: material/flag
+---
 The BetonQuest Organisation recommends <a href="https://www.jetbrains.com/idea/" target="_blank">IntelliJ</a>
 (Community Edition) as the IDE (Integrated Development Environment).
 The advantage of using IntelliJ is that this guide contains some steps and the project contains some files

--- a/docs/Tutorials/Frequently-Asked-Questions.md
+++ b/docs/Tutorials/Frequently-Asked-Questions.md
@@ -1,3 +1,6 @@
+---
+icon: material/chat-question
+---
 #FAQ
 If you have any questions please read this page first. You can easily look for your questions using the table of contents 
 to the right. It's very likely that it has been already asked and answered. 
@@ -276,3 +279,17 @@ Now, simply add this `Rewards` event to every one of your objectives and you hav
 complete a quest's objective in a non-linear fashion! You can add as many or as little objectives as you want, you just
 have to add the additional objectives to the conditions.
 
+## Creating quest menus
+To create a menu that gives the player a overview of his open quests just define one menu item for each quest.
+Set the [conditions](Menu-Menu.md#the-items-section) for this item so it is only displayed if the quest is not finished (use the [tag condition](Conditions-List.md#tag-tag)).  
+Then assign all those items to [a row of slots](Menu-Menu.md#the-slots-section) so that they are sorted perfectly.
+
+You can also add click events to display npc locations, add compass targets, directly open the conversations or cancel the quest.
+
+Or you could define separate items for open and finished quests or even to show the progress. Just be a bit creative.
+
+## Menus displaying players stats
+You may also use menus to display the stats of a player. Just use [variables](Variables-List.md) in the text or for the amount of an item.
+
+For example try displaying a players money using the varible from [Vault integration](http://dev.bukkit.org/bukkit-plugins/vault/)
+or use [PlaceholderAPI](Compatibility.md#placeholderapi) to show placeholders from many other plugins.

--- a/docs/Tutorials/Getting-Started/Installing-BetonQuest.md
+++ b/docs/Tutorials/Getting-Started/Installing-BetonQuest.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/download-24
+---
 # Installation
 In order to use <a href="https://www.spigotmc.org/resources/betonquest.2117/" target="_blank">BetonQuest</a> you (obviously)
 need to add the `BetonQuest.jar` that you downloaded from Spigot to your plugins folder. If there is no plugin folder in your

--- a/docs/Tutorials/Getting-Started/Learn-BetonQuest.md
+++ b/docs/Tutorials/Getting-Started/Learn-BetonQuest.md
@@ -1,3 +1,6 @@
+---
+icon: material/pencil
+---
 There are two ways to get started with BetonQuest:
 
 1. Full beginner guide: A step-by-step tutorial to learn everything you need to know in an order which makes sense to a new BetonQuest user.

--- a/docs/Tutorials/Getting-Started/Setting-up-a-local-test-server.md
+++ b/docs/Tutorials/Getting-Started/Setting-up-a-local-test-server.md
@@ -1,3 +1,6 @@
+---
+icon: octicons/terminal-16
+---
 # Setting up a local test server
 
 ## Why do I need a local server?!

--- a/docs/Tutorials/Getting-Started/Setting-up-the-editor.md
+++ b/docs/Tutorials/Getting-Started/Setting-up-the-editor.md
@@ -1,3 +1,6 @@
+---
+icon: material/wrench
+---
 #Setting up the editor
 
 In theory, you can edit quests with any editor. However, using the feature-packed but lightweight 

--- a/docs/Tutorials/Getting-Started/YAML-for-questers.md
+++ b/docs/Tutorials/Getting-Started/YAML-for-questers.md
@@ -1,3 +1,6 @@
+---
+icon: material/newspaper
+---
 ##YAML Syntax
 Before we can start you need to understand the fundamentals of YAML.
 You have no idea what that is? Well YAML is the format most plugins store their config data in.

--- a/docs/Tutorials/Welcome.md
+++ b/docs/Tutorials/Welcome.md
@@ -1,3 +1,6 @@
+---
+icon: material/hand-wave
+---
 # Welcome!
 Welcome to BetonQuest! Thank you for trying it out. This plugin can do some really 
 cool stuff and therefore requires some learning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+icon: material/rocket-launch
 template: home.html
 title: Home
 hide:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,28 +151,27 @@ extra:
 #Notice that here are a few strange looking hairspaces in here.
 #They make the space between the emojis and the text look equal
 nav:
-  - '🚀 Home': index.md
-  - '🎓 Tutorials':
-      - '👋 Welcome!': Tutorials/Welcome.md
+  - 'Home': index.md
+  - 'Tutorials':
+      - 'Welcome!': Tutorials/Welcome.md
       - 'Getting Started':
-          - '💻 Setting up a local test server': Tutorials/Getting-Started/Setting-up-a-local-test-server.md
-          - '📥 Installing BetonQuest': Tutorials/Getting-Started/Installing-BetonQuest.md
-          - '✒️ Setting up the editor': Tutorials/Getting-Started/Setting-up-the-editor.md
-          - '📑 YAML for questers': Tutorials/Getting-Started/YAML-for-questers.md
-          - '🎓 Learn BetonQuest': Tutorials/Getting-Started/Learn-BetonQuest.md
-      - '❓ Frequently Asked Questions':
-          - '🤔  General FAQ': Tutorials/Frequently-Asked-Questions.md
-  - '📚 Documentation':
+          - 'Setting up a local test server': Tutorials/Getting-Started/Setting-up-a-local-test-server.md
+          - 'Installing BetonQuest': Tutorials/Getting-Started/Installing-BetonQuest.md
+          - 'Setting up the editor': Tutorials/Getting-Started/Setting-up-the-editor.md
+          - 'YAML for questers': Tutorials/Getting-Started/YAML-for-questers.md
+          - 'Learn BetonQuest': Tutorials/Getting-Started/Learn-BetonQuest.md
+      - 'Frequently Asked Questions':
+          - 'General FAQ': Tutorials/Frequently-Asked-Questions.md
+  - 'Documentation':
       - 'General':
-          - '📚   Reference': Documentation/Reference.md
-          - '💬  Conversations': Documentation/Conversations.md
-          - '   📱     Menus': Documentation/Menus.md
+          - 'Reference': Documentation/Reference.md
+          - 'Conversations': Documentation/Conversations.md
       - 'Types':
-          - '✔️ Objectives List': Documentation/Objectives-List.md
-          - '⚙️ Events List': Documentation/Events-List.md
-          - '  ❓    Conditions List': Documentation/Conditions-List.md
-          - '🤝 Compatibility List': Documentation/Compatibility.md
-          - '🔮   Variables List': Documentation/Variables-List.md
+          - 'Objectives List': Documentation/Objectives-List.md
+          - 'Events List': Documentation/Events-List.md
+          - 'Conditions List': Documentation/Conditions-List.md
+          - 'Compatibility List': Documentation/Compatibility.md
+          - 'Variables List': Documentation/Variables-List.md
       - 'Notifications':
           - 'Settings': Documentation/Notification-Settings.md
           - "IO's & Categories": Documentation/Notification-IO's-&-Categories.md
@@ -182,31 +181,31 @@ nav:
           - 'Commands': Documentation/Menu-Commands.md
           - 'Config': Documentation/Menu-Config.md
       - 'Technical':
-          - '🔒 Permissions & Commands': Documentation/Commands-and-permissions.md
-          - '📥 Updating':
+          - 'Permissions & Commands': Documentation/Commands-and-permissions.md
+          - 'Updating':
               - Documentation/Updating/index.md
-              - '📤 Migration': Documentation/Updating/Migration.md
-          - '🔧  Configuration': Documentation/Configuration.md
-          - '🗃️ Changelog': Documentation/CHANGELOG.md
-  - '🔌 API':
-      - '🤝 Overview': API/Overview.md
-      - '⚙️ API': API/API.md
-      - '📑 Logging': API/Logging.md
-  - '🧪 Participate':
-      - '🤝 Overview': Participate/Overview.md
-      - '🚩 Setup Project': Participate/Setup-Project.md
+              - 'Migration': Documentation/Updating/Migration.md
+          - 'Configuration': Documentation/Configuration.md
+          - 'Changelog': Documentation/CHANGELOG.md
+  - 'API':
+      - 'Overview': API/Overview.md
+      - 'API': API/API.md
+      - 'Logging': API/Logging.md
+  - 'Participate':
+      - 'Overview': Participate/Overview.md
+      - 'Setup Project': Participate/Setup-Project.md
       - Process:
-          - '🧬 Create a new Branch': Participate/Process/Create-a-new-Branch.md
-          - '👨‍🔧 Changing Code':
+          - 'Create a new Branch': Participate/Process/Create-a-new-Branch.md
+          - 'Changing Code':
               - Participate/Process/Code/index.md
-              - '🕵️‍♂️  Checking Requirements': Participate/Process/Code/Checking-Requirements.md
-              - '📥 Adding a Dependency': Participate/Process/Code/Adding-a-new-Dependency.md
-              - '📋    Writing JUnit Tests': Participate/Process/Code/Writing-JUnit-Tests.md
-          - '👨‍🏫 Changing Docs':
+              - 'Checking Requirements': Participate/Process/Code/Checking-Requirements.md
+              - 'Adding a Dependency': Participate/Process/Code/Adding-a-new-Dependency.md
+              - 'Writing JUnit Tests': Participate/Process/Code/Writing-JUnit-Tests.md
+          - 'Changing Docs':
               - Participate/Process/Docs/index.md
-              - '✒️ Fundamental Principles': Participate/Process/Docs/Principles.md
-              - '📚 Guidelines': Participate/Process/Docs/Guidelines.md
-          - '📑 Maintaining the Changelog': Participate/Process/Maintaining-the-Changelog.md
-          - '🏁 Submitting Changes': Participate/Process/Submitting-Changes.md
+              - 'Fundamental Principles': Participate/Process/Docs/Principles.md
+              - 'Guidelines': Participate/Process/Docs/Guidelines.md
+          - 'Maintaining the Changelog': Participate/Process/Maintaining-the-Changelog.md
+          - 'Submitting Changes': Participate/Process/Submitting-Changes.md
       - Misc:
-          - '🏭 Versioning & Releasing': Participate/Misc/Versioning-and-Releasing.md
+          - 'Versioning & Releasing': Participate/Misc/Versioning-and-Releasing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,8 +164,8 @@ nav:
           - 'General FAQ': Tutorials/Frequently-Asked-Questions.md
   - 'Documentation':
       - 'General':
-          - '📚   Reference': Documentation/Reference.md
-          - '💬  Conversations': Documentation/Conversations.md
+          - 'Conversations': Documentation/Conversations.md
+          - 'Reference': Documentation/Reference.md
       - 'Types':
           - 'Objectives List': Documentation/Objectives-List.md
           - 'Events List': Documentation/Events-List.md
@@ -173,8 +173,8 @@ nav:
           - 'Compatibility List': Documentation/Compatibility.md
           - 'Variables List': Documentation/Variables-List.md
       - 'Notifications':
-          - '🔊   Settings': Documentation/Notification-Settings.md
-          - "🏷️   IO's & Categories": Documentation/Notification-IO's-&-Categories.md
+          - 'Settings': Documentation/Notification-Settings.md
+          - "IO's & Categories": Documentation/Notification-IO's-&-Categories.md
       - 'Menus':
           - 'Menus': Documentation/Menu-Menu.md
           - 'Elements': Documentation/Menu-Elements.md


### PR DESCRIPTION
# Description
mkdocs-material has added official support for page icons. This PR removes our previous hacky solution with hair spaces and Unicode icons.

This feature does not work with Unicode icons (although one could theoretically add them via the custom icons support).
Therefore, all Unicode icons have been replaced with their material icon counterparts / different icons. 

## Evaluation
The mkdocs-material icon system has pros and cons, here is a breakdown:

Advantages:
* More Icons available for pages
  * IT specific icons (e.g. Git, JUnit, )
  * Larger catalog in general 
  * Brand icons
* Icons look the same on every device since they come with our docs and do not rely on vendor specific implementations
* Icons can be easily found in the mkdocs-material docs ([icon search in codeblock](https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-icon))

Disadvantages:
* Sections cannot contain Unicode Icons without adding them to the theme
* Tabs can only contain icons when there is an index page
  * This is not the case for our docs, therefore all tab icons have been removed

## Visual Preview
Excerpt of the Participate section: Left is new, right is old
![grafik](https://user-images.githubusercontent.com/40303883/170544829-46c3ea2b-4085-4f8c-8d69-7c9c09fd83de.png)

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
