### PR TITLE
Less user hostile cookie consent

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ extra:
     title: Cookie consent
     cookies:
       analytics: Google Analytics
+      checked: false
     description: >
       <p style="margin-top: 0px; margin-bottom: 0px;">We use cookies to:</p>
       <ul style="margin-top: 0px; margin-bottom: 0px;">


### PR DESCRIPTION
# Description
The cookie banner of mkdocs follows many common practices of other websites.
But by doing that it also implements some deceptive, user-hostile designs (commonly referred to as Dark Patterns).

For more information on what Dark Patterns are and why they should be avoided I suggest reading this article:
https://usercentrics.com/knowledge-hub/dark-patterns-and-how-they-affect-consent/

To sum it up deceptive designs are noticed and disliked by users while being potentially illegal.

As a first step to fix this google analytics should be opt-in instead of opt-out. 
Additionally I opened an issue at mkdocs to alter the consent dialogue [1].  

## Related Issues
1. squidfunk/mkdocs-material#3970

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
~~- [ ]  ... update the changelog?~~
~~- [ ]  ... update the documentation?~~
~~- [ ]  ... adjust the ConfigUpdater?~~
~~- [ ]  ... solve all TODOs?~~
~~- [ ]  ... remove any commented out code?~~
~~- [ ]  ... add debug messages?~~
~~- [ ]  ... clean the commit history?~~

Check if the build pipeline succeeded for this PR!
