### PR TITLE
fixed exception when menuConfig.yml is deleted during runtime

### DIFF
--- a/src/main/java/org/betonquest/betonquest/menu/config/RPGMenuConfig.java
+++ b/src/main/java/org/betonquest/betonquest/menu/config/RPGMenuConfig.java
@@ -41,7 +41,7 @@ public class RPGMenuConfig extends SimpleYMLSection {
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public RPGMenuConfig() throws InvalidConfigurationException, FileNotFoundException {
-        super("menuConfig.yml", ConfigAccessor.create(new File(BetonQuest.getInstance().getDataFolder(), "menuConfig.yml")).getConfig());
+        super("menuConfig.yml", ConfigAccessor.create(new File(BetonQuest.getInstance().getDataFolder(), "menuConfig.yml"), BetonQuest.getInstance(), "menuConfig.yml").getConfig());
         //load languages
         if (!config.contains("messages") || !config.isConfigurationSection("messages")) {
             throw new Missing("messages");


### PR DESCRIPTION
# Description
Exception
```
org.bukkit.command.CommandException: Unhandled exception executing command 'q' in plugin BetonQuest v2.0.0-DEV-307
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.18.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[paper-api-1.18.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_18_R2.CraftServer.dispatchCommand(CraftServer.java:906) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleCommand(ServerGamePacketListenerImpl.java:2307) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleChat(ServerGamePacketListenerImpl.java:2118) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleChat(ServerGamePacketListenerImpl.java:2099) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundChatPacket.handle(ServerboundChatPacket.java:46) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundChatPacket.a(ServerboundChatPacket.java:6) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1400) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:188) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1377) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1370) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1348) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1230) ~[paper-1.18.2.jar:git-Paper-378]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.18.2.jar:git-Paper-378]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.plugin.Plugin.getResource(String)" because "plugin" is null
        at org.betonquest.betonquest.modules.config.ConfigAccessorImpl.readFromResource(ConfigAccessorImpl.java:75) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.modules.config.ConfigAccessorImpl.<init>(ConfigAccessorImpl.java:50) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.api.config.ConfigAccessor.create(ConfigAccessor.java:57) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.api.config.ConfigAccessor.create(ConfigAccessor.java:26) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.menu.config.RPGMenuConfig.<init>(RPGMenuConfig.java:44) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.menu.RPGMenu.reloadData(RPGMenu.java:154) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.BetonQuest.loadData(BetonQuest.java:1088) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.BetonQuest.reload(BetonQuest.java:1119) ~[BetonQuest-b307.jar:?]
        at org.betonquest.betonquest.commands.QuestCommand.onCommand(QuestCommand.java:275) ~[BetonQuest-b307.jar:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.18.2-R0.1-SNAPSHOT.jar:?]
        ... 21 more
```

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
