### PR TITLE
Create profile that allowes skipping all time-consuming verification steps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,7 @@ jobs:
             ]
       - name: Publish to Maven Repository
         run: |
-          mvn -B deploy
+          mvn -Pskip-verification -B deploy
         env:
           REPOSITORY_URL: ${{ secrets.REPOSITORY_URL }}
           REPOSITORY_USER: ${{ secrets.REPOSITORY_USER }}

--- a/pom.xml
+++ b/pom.xml
@@ -726,7 +726,6 @@
         <executions>
           <execution>
             <id>check</id>
-            <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>
@@ -738,6 +737,7 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <executions>
           <execution>
+            <id>check</id>
             <goals>
               <goal>check</goal>
             </goals>
@@ -753,6 +753,7 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>check</id>
             <goals>
               <goal>check</goal>
             </goals>
@@ -764,6 +765,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>
           <execution>
+            <id>check</id>
             <goals>
               <goal>check</goal>
             </goals>
@@ -989,4 +991,49 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>skip-verification</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.ec4j.maven</groupId>
+            <artifactId>editorconfig-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
# Description
This is now used in the deploy job because verification was already done in the build job before.

## Related Issues
James' complaint that builds take too long. 😄 

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
