### PR TITLE
Fix run event producing NullPointerException when run in static context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - `interact` objective - did not work with armorstands
     - `action` objective - for `any` block ignored location
     - `weather` event - storm did not work
+    - `run` event - NPE when run as static event / schedule
 ### Security
 - it was possible to put a QuestItem into a chest
 - bump log4j dependency 2.15.0 to fix CVE-2021-44228

--- a/src/main/java/org/betonquest/betonquest/events/RunEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/RunEvent.java
@@ -64,7 +64,7 @@ public class RunEvent extends QuestEvent {
     @Override
     protected Void execute(final String playerID) throws QuestRuntimeException {
         for (final QuestEvent event : internalEvents) {
-            event.handle(playerID);
+            event.fire(playerID);
         }
         return null;
     }


### PR DESCRIPTION
# Description
Run event produces the following NPE when run from a schedule with a non-static event inside:

![](https://media.discordapp.net/attachments/407222203013398529/997758372327723079/unknown.png)

This is due to it calling `QuestEvent#handle()` which does not handle calling non-static events. 

## Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
