### PR TITLE
Added New Heroes Attribute Condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `fish` objective now has `hookLocation` and `range` settings.
 - `burning` condition
 - `inconversation` condition
+- `heroesattribute` condition - Heroes compatibility feature: Checks a player's level for a particular attribute against a value
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -297,7 +297,7 @@ be displayed to the player for which you ran the event.
       playEffect: particle beton loc:100;200;300;world;180;-90 private
     ```
 
-## [Heroes](http://dev.bukkit.org/bukkit-plugins/heroes/)
+## [Heroes](https://www.spigotmc.org/resources/24734/)
 
 When you install Heroes, all kills done via this plugin's skills will be counted in MobKill objectives.
 
@@ -310,6 +310,15 @@ This condition checks the classes of the player. The first argument must be `pri
 !!! example
     ```YAML
     heroesclass mastered warrior
+    ```
+
+#### Heroes Attribute: `heroesattribute`
+
+This condition check's the level of a player's attribute. The first argument must be `strength`, `constitution`, `endurance`, `dexterity`, `intellect`, `wisdom`, or `charisma`. Second argument is the required level of the attribute.
+
+!!! example
+    ```YAML
+    heroesattribute strength 5
     ```
 
 #### Skill: `heroesskill`

--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -314,7 +314,7 @@ This condition checks the classes of the player. The first argument must be `pri
 
 #### Heroes Attribute: `heroesattribute`
 
-This condition check's the level of a player's attribute. The first argument must be `strength`, `constitution`, `endurance`, `dexterity`, `intellect`, `wisdom`, or `charisma`. Second argument is the required level of the attribute.
+This condition check's the level of a player's attribute. The first argument must be `strength`, `constitution`, `endurance`, `dexterity`, `intellect`, `wisdom`, or `charisma`. Second argument is the required level of the attribute. Must be greater than or equal the specified number.
 
 !!! example
     ```YAML

--- a/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesAttributeCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesAttributeCondition.java
@@ -1,0 +1,41 @@
+package org.betonquest.betonquest.compatibility.heroes;
+
+import com.herocraftonline.heroes.Heroes;
+import com.herocraftonline.heroes.attributes.AttributeType;
+import com.herocraftonline.heroes.characters.Hero;
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.betonquest.betonquest.utils.PlayerConverter;
+
+/**
+ * Checks an attribute of a player and if greater than or equal to a level
+ */
+@SuppressWarnings("PMD.CommentRequired")
+public class HeroesAttributeCondition extends Condition {
+    private final AttributeType attribute;
+    private final VariableNumber level;
+
+    public HeroesAttributeCondition(final Instruction instruction) throws InstructionParseException {
+        super(instruction, true);
+        attribute = findAttribute(instruction.next());
+        level = instruction.getVarNum(instruction.next());
+    }
+
+    private AttributeType findAttribute(final String string) throws InstructionParseException {
+        for (final AttributeType t : AttributeType.values()) {
+            if (t.name().equalsIgnoreCase(string)) {
+                return t;
+            }
+        }
+        throw new InstructionParseException("Attribute '" + string + "' does not exist!");
+    }
+
+    @Override
+    protected Boolean execute(final String playerID) throws QuestRuntimeException {
+        final Hero hero = Heroes.getInstance().getCharacterManager().getHero(PlayerConverter.getPlayer(playerID));
+        return hero.getAttributeValue(attribute) >= level.getInt(playerID);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesIntegrator.java
@@ -15,6 +15,7 @@ public class HeroesIntegrator implements Integrator {
 
     @Override
     public void hook() {
+        plugin.registerConditions("heroesattribute", HeroesAttributeCondition.class);
         plugin.registerConditions("heroesclass", HeroesClassCondition.class);
         plugin.registerConditions("heroesskill", HeroesSkillCondition.class);
         plugin.registerEvents("heroesexp", HeroesExperienceEvent.class);


### PR DESCRIPTION
# Description
Added a simple condition for more compatibility with the Heroes plugin. Returns true if a player has an attribute level which is greater than or equal to the number specified.
(Created new pull request as I messed up rebasing...)
Formatted as such
`heroesattribute <attribute> <level>`

## Checklist
- [x]  ... test their changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [x]  ~~... adjust the ConfigUpdater?~~
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!