### PR TITLE
Fix PasteSchematicEvent static flag not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Therefore `left` and `right` in the `click` section no longer include shift clicks
 - `folder` event - now executes events immediately if no delay is set
 - `weather` event - now has an optional variable duration (in seconds) and an optional world param
+- `paste` event - can now be static
 - `chestput` objective - can now block other players from accessing a chest while someone is putting items inside
 - Things that are also changed in 1.12.X:
     - math variable now allows rounding output with the ~ operator

--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -1101,6 +1101,8 @@ There is only one argument in this variable, `amount` for showing money amount o
 
 #### Paste schematic: `paste`
 
+**persistent**, **static**
+
 This event will paste a schematic at the given location. The first argument is a location and the second one is the name of schematic file. The file must be located in `WorldEdit/schematics` or `FastAsyncWorldEdit/schematics` and have a name like `some_building.schematic`. An optional `noair` can be added to paste ignoring air blocks.
 If you have only a `.schem` schematic, simply append `.schem` to the schematic name.
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/worldedit/PasteSchematicEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/worldedit/PasteSchematicEvent.java
@@ -40,6 +40,8 @@ public class PasteSchematicEvent extends QuestEvent {
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public PasteSchematicEvent(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
+        staticness = true;
+        persistent = true;
         loc = instruction.getLocation();
         final WorldEditPlugin worldEdit = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
         final File folder = new File(worldEdit.getDataFolder(), "schematics");


### PR DESCRIPTION
# Description
<!-- Your description here. -->
`paste` event can now be properly used in schedules.

## Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
