### PR TITLE
Update cron-utils to 9.2.0 and use native implementation for `@reboot` nicknames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
     <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
-      <version>9.1.7</version>
+      <version>9.2.0</version>
     </dependency>
 
     <!-- only dependencies from maven central that are for testing -->

--- a/src/main/java/org/betonquest/betonquest/api/schedule/CronSchedule.java
+++ b/src/main/java/org/betonquest/betonquest/api/schedule/CronSchedule.java
@@ -1,7 +1,7 @@
 package org.betonquest.betonquest.api.schedule;
 
 import com.cronutils.model.Cron;
-import com.cronutils.model.SingleCron;
+import com.cronutils.model.RebootCron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
@@ -10,11 +10,8 @@ import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.modules.schedule.ScheduleID;
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -24,6 +21,7 @@ public abstract class CronSchedule extends Schedule {
 
     /**
      * The unix cron syntax shall be used by default.
+     * {@code @reboot} nickname is not supported by default.
      */
     public static final CronDefinition DEFAULT_CRON_DEFINITION = CronDefinitionBuilder.defineCron()
             .withMinutes().withValidRange(0, 59).withStrictRange().and()
@@ -38,19 +36,25 @@ public abstract class CronSchedule extends Schedule {
             .instance();
 
     /**
-     * Statement that means that the schedule should run on reboot.
+     * The unix cron syntax but with support for {@code @reboot} nickname.
      */
-    private static final String REBOOT_ALIAS = "@reboot";
+    public static final CronDefinition REBOOT_CRON_DEFINITION = CronDefinitionBuilder.defineCron()
+            .withMinutes().withValidRange(0, 59).withStrictRange().and()
+            .withHours().withValidRange(0, 23).withStrictRange().and()
+            .withDayOfMonth().withValidRange(1, 31).withStrictRange().and()
+            .withMonth().withValidRange(1, 12).withStrictRange().and()
+            .withDayOfWeek().withValidRange(0, 7).withMondayDoWValue(1).withIntMapping(7, 0).withStrictRange().and()
+            .withSupportedNicknameYearly().withSupportedNicknameAnnually()
+            .withSupportedNicknameMonthly().withSupportedNicknameWeekly()
+            .withSupportedNicknameMidnight().withSupportedNicknameDaily()
+            .withSupportedNicknameHourly()
+            .withSupportedNicknameReboot()
+            .instance();
 
     /**
      * Cron expression that defines when the events from this schedule shall run.
      */
     protected final Cron timeCron;
-
-    /**
-     * If events from this schedule shall run on reboot.
-     */
-    protected final boolean onReboot;
 
     /**
      * Provides information when the events from this schedule shall be executed.
@@ -67,7 +71,7 @@ public abstract class CronSchedule extends Schedule {
      * @throws InstructionParseException if parsing the config failed
      */
     public CronSchedule(final ScheduleID scheduleId, final ConfigurationSection instruction) throws InstructionParseException {
-        this(scheduleId, instruction, DEFAULT_CRON_DEFINITION, false);
+        this(scheduleId, instruction, DEFAULT_CRON_DEFINITION);
     }
 
     /**
@@ -75,27 +79,19 @@ public abstract class CronSchedule extends Schedule {
      * <b>Make sure to create a constructor with the following two arguments when extending this class:</b>
      * {@code ScheduleID id, ConfigurationSection instruction}
      *
-     * @param scheduleID      id of the new schedule
-     * @param instruction     config defining the schedule
-     * @param cronDefinition  a custom cron syntax, you may use {@link #DEFAULT_CRON_DEFINITION}
-     * @param rebootSupported if {@code  @reboot} statement is supported by this schedule type
+     * @param scheduleID     id of the new schedule
+     * @param instruction    config defining the schedule
+     * @param cronDefinition a custom cron syntax, you may use {@link #DEFAULT_CRON_DEFINITION}
      * @throws InstructionParseException if parsing the config failed
      */
     protected CronSchedule(final ScheduleID scheduleID, final ConfigurationSection instruction,
-                           final CronDefinition cronDefinition, final boolean rebootSupported) throws InstructionParseException {
+                           final CronDefinition cronDefinition) throws InstructionParseException {
         super(scheduleID, instruction);
-        if (rebootSupported && REBOOT_ALIAS.equals(super.time.trim().toLowerCase(Locale.ROOT))) {
-            this.timeCron = new SingleCron(cronDefinition, List.of());
-            this.onReboot = true;
-            this.executionTime = new NoExecutionTime();
-        } else {
-            try {
-                this.timeCron = new CronParser(cronDefinition).parse(super.time).validate();
-                this.onReboot = false;
-                this.executionTime = ExecutionTime.forCron(timeCron);
-            } catch (final IllegalArgumentException e) {
-                throw new InstructionParseException("Time is no valid cron syntax: '" + super.time + "'", e);
-            }
+        try {
+            this.timeCron = new CronParser(cronDefinition).parse(super.time).validate();
+            this.executionTime = ExecutionTime.forCron(timeCron);
+        } catch (final IllegalArgumentException e) {
+            throw new InstructionParseException("Time is no valid cron syntax: '" + super.time + "'", e);
         }
     }
 
@@ -115,7 +111,7 @@ public abstract class CronSchedule extends Schedule {
      * @return true if schedule should run on reboot, false otherwise
      */
     public boolean shouldRunOnReboot() {
-        return onReboot;
+        return timeCron instanceof RebootCron;
     }
 
     /**
@@ -143,38 +139,5 @@ public abstract class CronSchedule extends Schedule {
      */
     public Optional<Instant> getLastExecution() {
         return executionTime.lastExecution(ZonedDateTime.now()).map(Instant::from);
-    }
-
-    /**
-     * Implementation for {@link ExecutionTime} that cannot calculate any execution times.
-     * <p>
-     * Used for {@code @reboot} schedules
-     */
-    private static class NoExecutionTime implements ExecutionTime {
-
-        @Override
-        public Optional<ZonedDateTime> nextExecution(final ZonedDateTime date) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Duration> timeToNextExecution(final ZonedDateTime date) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<ZonedDateTime> lastExecution(final ZonedDateTime date) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Duration> timeFromLastExecution(final ZonedDateTime date) {
-            return Optional.empty();
-        }
-
-        @Override
-        public boolean isMatch(final ZonedDateTime date) {
-            return false;
-        }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedule.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedule.java
@@ -18,6 +18,6 @@ public class RealtimeCronSchedule extends CronSchedule {
      * @throws InstructionParseException if parsing the config failed
      */
     public RealtimeCronSchedule(final ScheduleID scheduleID, final ConfigurationSection instruction) throws InstructionParseException {
-        super(scheduleID, instruction, DEFAULT_CRON_DEFINITION, true);
+        super(scheduleID, instruction, REBOOT_CRON_DEFINITION);
     }
 }

--- a/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.betonquest.betonquest.api.schedule.CronSchedule.DEFAULT_CRON_DEFINITION;
+import static org.betonquest.betonquest.api.schedule.CronSchedule.REBOOT_CRON_DEFINITION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -18,7 +18,7 @@ public class CronRebootScheduleTest extends CronScheduleBaseTest {
 
     @Override
     protected CronSchedule createSchedule() throws InstructionParseException {
-        return new CronSchedule(scheduleID, section, DEFAULT_CRON_DEFINITION, true) {
+        return new CronSchedule(scheduleID, section, REBOOT_CRON_DEFINITION) {
         };
     }
 


### PR DESCRIPTION
# Description
As cron-utils 9.2.0 will natively support it we no longer have to work our way around this and can clean up some code.

## Related Issues
<!-- Issue number if existing. -->
https://github.com/jmrozanec/cron-utils/issues/520

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
