### PR TITLE
location & region objectives now also respect players moving in vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `weather` event - now has an optional variable duration (in seconds) and an optional world param
 - `paste` event - can now be static
 - `chestput` objective - can now block other players from accessing a chest while someone is putting items inside
+- The location and region objectives now register movement of players inside a vehicle
 - Things that are also changed in 1.12.X:
     - math variable now allows rounding output with the ~ operator
     - French translation has been updated

--- a/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
@@ -7,6 +7,7 @@ import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -17,8 +18,10 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.vehicle.VehicleMoveEvent;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -79,6 +82,18 @@ public class RegionObjective extends Objective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onMove(final PlayerMoveEvent event) {
         checkLocation(event.getPlayer(), event.getTo());
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onRide(final VehicleMoveEvent event) {
+        qreHandler.handle(() -> {
+            final List<Entity> passengers = event.getVehicle().getPassengers();
+            for (final Entity passenger : passengers) {
+                if (passenger instanceof Player player) {
+                    checkLocation(player, event.getTo());
+                }
+            }
+        });
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")


### PR DESCRIPTION
# Description
The location objective does not work when the player is mounted on flyable mounts.
Happens because the objective only cares about the player themselves moving.
These problems might appear more often now that McPets etc. are growing in popularity. Thus we should add more events to our objectives to cover mounted states.

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the changelog?
- [x]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add debug messages?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
