### PR TITLE
Add a VariableString object and add variable support for RPGMenu titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mmspawn` event now supports the `marked` argument
 - `mmobkill` objective now supports the `marked` argument
 - `marked` argument now supports %player% variable
+- variable support for menu titles
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Menu-Menu.md
+++ b/docs/Documentation/Menu-Menu.md
@@ -28,7 +28,7 @@ This section tells you about each setting which has to be set (or can optionally
   Fist of all you have to set the title of your menu.
   It will be displayed in the top left corner of your menu.
   You can use [color codes](https://minecraft.gamepedia.com/Formatting_codes) with `&` instead of `§` to color the
-  title.  
+  title. Variables are supported.
   **Example:** `title: '&6&lQuests'`
 
 * `height`: *(number from `1` to `6`)*  

--- a/src/main/java/org/betonquest/betonquest/VariableString.java
+++ b/src/main/java/org/betonquest/betonquest/VariableString.java
@@ -12,8 +12,19 @@ import java.util.List;
  */
 public class VariableString {
 
+    /**
+     * The string that may contain variables.
+     */
     private final String string;
+
+    /**
+     * The list of variables in the string.
+     */
     private final List<String> variables = new ArrayList<>();
+
+    /**
+     * The package in which the string is defined.
+     */
     private final QuestPackage questPackage;
 
 

--- a/src/main/java/org/betonquest/betonquest/VariableString.java
+++ b/src/main/java/org/betonquest/betonquest/VariableString.java
@@ -1,0 +1,59 @@
+package org.betonquest.betonquest;
+
+import org.betonquest.betonquest.api.config.QuestPackage;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a string that can contain variables.
+ * Makes handling instructions with variables easier.
+ */
+public class VariableString {
+
+    private final String string;
+    private final List<String> variables = new ArrayList<>();
+    private final QuestPackage questPackage;
+
+
+    /**
+     * Creates a new VariableString.
+     *
+     * @param questPackage the package in which the string is used
+     * @param string       the string that may contain variables
+     * @throws InstructionParseException if the variables could not be created
+     */
+    public VariableString(final QuestPackage questPackage, final String string) throws InstructionParseException {
+        this.string = string;
+        this.questPackage = questPackage;
+
+        for (final String variable : BetonQuest.resolveVariables(string)) {
+            try {
+                BetonQuest.createVariable(questPackage, variable);
+            } catch (final InstructionParseException exception) {
+                throw new InstructionParseException("Could not create '" + variable + "' variable: "
+                        + exception.getMessage(), exception);
+            }
+            if (!variables.contains(variable)) {
+                variables.add(variable);
+            }
+        }
+    }
+
+
+    /**
+     * Resolves all variables in the string and returns the result.
+     *
+     * @param playerID the ID of the player to resolve the variables for
+     * @return the string with all variables resolved
+     */
+    public String getString(final String playerID) {
+        String resolvedString = "";
+        for (final String variable : variables) {
+            final String resolvedVariable = BetonQuest.getInstance().getVariableValue(questPackage.getPackagePath(), variable, playerID);
+            resolvedString = string.replace(variable, resolvedVariable);
+        }
+        return resolvedString;
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/VariableString.java
+++ b/src/main/java/org/betonquest/betonquest/VariableString.java
@@ -60,10 +60,10 @@ public class VariableString {
      * @return the string with all variables resolved
      */
     public String getString(final String playerID) {
-        String resolvedString = "";
+        String resolvedString = string;
         for (final String variable : variables) {
             final String resolvedVariable = BetonQuest.getInstance().getVariableValue(questPackage.getPackagePath(), variable, playerID);
-            resolvedString = string.replace(variable, resolvedVariable);
+            resolvedString = resolvedString.replace(variable, resolvedVariable);
         }
         return resolvedString;
     }

--- a/src/main/java/org/betonquest/betonquest/menu/Menu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/Menu.java
@@ -52,11 +52,6 @@ public class Menu extends SimpleYMLSection implements Listener {
      * The title of the menu
      */
     private final VariableString title;
-    /**
-     * All variables that are included in the title;
-     */
-    private final List<String> titleVariables = new ArrayList<>();
-
     /*
      * Hashmap with a items id as key and the menu item object containing all data of the item
      *
@@ -97,7 +92,7 @@ public class Menu extends SimpleYMLSection implements Listener {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
     private final RPGMenu menu = BetonQuest.getInstance().getRpgMenu();
 
-    @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
+    @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity", "PMD.ExcessiveMethodLength", "PMD.Constr"})
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Menu(final MenuID menuID) throws InvalidConfigurationException {
         super(menuID.getFullID(), menuID.getConfig());
@@ -109,9 +104,10 @@ public class Menu extends SimpleYMLSection implements Listener {
         }
         //load title
         try {
-            this.title = new VariableString(getPackage(), ChatColor.translateAlternateColorCodes('&', getString("title")));
+            final String title = ChatColor.translateAlternateColorCodes('&', getString("title"));
+            this.title = new VariableString(this.menuID.getPackage(), title);
         } catch (final InstructionParseException e) {
-            throw new InvalidConfigurationException(e.getMessage());
+            throw new InvalidConfigurationException(e.getMessage(), e);
         }
         //load opening conditions
         this.openConditions = new ArrayList<>();

--- a/src/main/java/org/betonquest/betonquest/menu/Menu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/Menu.java
@@ -92,7 +92,7 @@ public class Menu extends SimpleYMLSection implements Listener {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
     private final RPGMenu menu = BetonQuest.getInstance().getRpgMenu();
 
-    @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity", "PMD.ExcessiveMethodLength", "PMD.Constr"})
+    @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity", "PMD.ExcessiveMethodLength"})
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Menu(final MenuID menuID) throws InvalidConfigurationException {
         super(menuID.getFullID(), menuID.getConfig());

--- a/src/main/java/org/betonquest/betonquest/menu/Menu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/Menu.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.menu;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.CustomLog;
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.config.QuestPackage;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
@@ -50,7 +51,11 @@ public class Menu extends SimpleYMLSection implements Listener {
     /**
      * The title of the menu
      */
-    private final String title;
+    private final VariableString title;
+    /**
+     * All variables that are included in the title;
+     */
+    private final List<String> titleVariables = new ArrayList<>();
 
     /*
      * Hashmap with a items id as key and the menu item object containing all data of the item
@@ -103,7 +108,11 @@ public class Menu extends SimpleYMLSection implements Listener {
             throw new Invalid("height");
         }
         //load title
-        this.title = ChatColor.translateAlternateColorCodes('&', getString("title"));
+        try {
+            this.title = new VariableString(getPackage(), ChatColor.translateAlternateColorCodes('&', getString("title")));
+        } catch (final InstructionParseException e) {
+            throw new InvalidConfigurationException(e.getMessage());
+        }
         //load opening conditions
         this.openConditions = new ArrayList<>();
         try {
@@ -297,8 +306,8 @@ public class Menu extends SimpleYMLSection implements Listener {
     /**
      * @return the title of the menu
      */
-    public String getTitle() {
-        return title;
+    public String getTitle(final String playerID) {
+        return title.getString(playerID);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/menu/OpenedMenu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/OpenedMenu.java
@@ -46,7 +46,7 @@ public class OpenedMenu implements Listener {
 
         this.data = menu;
         this.playerId = player.getUniqueId();
-        final Inventory inventory = Bukkit.createInventory(null, data.getSize(), data.getTitle());
+        final Inventory inventory = Bukkit.createInventory(null, data.getSize(), data.getTitle(playerId.toString()));
         this.update(player, inventory);
         player.openInventory(inventory);
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());

--- a/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
+++ b/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
@@ -73,7 +73,7 @@ public class MenuObjective extends Objective implements Listener {
                         + "menu with id " + menuID + " isn't loaded");
                 return "";
             }
-            return menuData.getTitle();
+            return menuData.getTitle(playerID);
         }
         return "";
     }

--- a/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuVariable.java
+++ b/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuVariable.java
@@ -24,6 +24,6 @@ public class MenuVariable extends Variable {
         if (menu == null) {
             return "";
         }
-        return menu.getData().getTitle();
+        return menu.getData().getTitle(playerID);
     }
 }


### PR DESCRIPTION
# Description
I added a VariableString object because I wanted to add variable support to RPGMenu titles and once again realized how fucked up the usage of string variables is. This is meant to be a temporary solution before variable handling get's reworked. That's also why I didn't bother replacing all places in the code that use the shitty old way of resolving string variables.

Variable support in RPGMenu titles is crucial because it allows questers to create custom font menus based on conditions.
Example use case in private chat.

## Checklist
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the changelog?
- [ ]  ... update the documentation?
- [ ]  ~~... adjust the ConfigUpdater?~~
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add debug messages?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
