### PR TITLE
add `noSafety` argument to block objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `globaltag` and `globalpoint` variables
 - `burn` event - ignites player for given seconds, supports variables
 - `velocity` event - throws the player by a vector (can be variable) with a direction and modification
-- `block` objective now has argument `noSafety` which disables removing progress when the player does the opposite of what the objective asks for
+- `block` objective - added argument `noSafety` which disables removing progress when the player does the opposite of what the objective asks for
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `globaltag` and `globalpoint` variables
 - `burn` event - ignites player for given seconds, supports variables
 - `velocity` event - throws the player by a vector (can be variable) with a direction and modification
+- `block` objective now has argument `noSafety` which disables removing progress when the player does the opposite of what the objective asks for
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -35,22 +35,36 @@ give accurate results. Experiment with this objective a bit to make sure you've 
     arrow 100.5;200.5;300.5;world 1.1 events:reward conditions:correct_player_position
     ```
 
-## Block: `block`
+## :material-pickaxe: Break or Place Blocks: `block`
 
-To complete this objective the player must break or place the specified amount of blocks. The first argument is a
-[Block Selector](./Reference.md#block-selectors). Next is amount. It can be more than 0 for placing and
-less than 0 for destroying. You can also use the `notify` keyword to display messages to the player each time he updates
-amount of blocks, optionally with the notification interval after colon.
+To complete this objective the player must break or place the specified amount of blocks.
 
-This objective has three properties: `amount`, `left` and `total`. `amount` is the amount of blocks already done,
-`left` is the amount of blocks still needed to complete the objective and `total` is the amount of blocks initially
-needed.
-Note that it follows the same rules as the amount argument, meaning that blocks to break are a negative number!
+| Parameter       | Syntax                                           | Default Value          | Explanation                                                                                                                                                                                                                                                               |
+|-----------------|--------------------------------------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _Block Type_    | [Block Selector](./Reference.md#block-selectors) | :octicons-x-circle-16: | The block which must be broken.                                                                                                                                                                                                                                           |
+| _Amount_        | Number                                           | :octicons-x-circle-16: | The amount of blocks to place / destroy. More than 0 for placing and less than 0 for breaking blocks.                                                                                                                                                                     |
+| _Safety Check_  | Keyword (`noSafety`)                             | Safety Check Enabled   | The Safety Check prevents faking the objective. The progress will be reduced when the player does to opposite of what they are supposed to do. Example: Player must break 10 blocks. They place 10 of their stored blocks. Now the total amount of blocks to break is 20. |
+| _Notifications_ | Keyword (`notify`)                               | Disabled               | Displays messages to the player each time they progress the objective. Optionally with the notification interval after colon.                                                                                                                                             |
 
-!!! example
-    ```YAML
-    block LOG -16 events:reward notify:5
-    ```
+
+```YAML
+objectives:
+  breakLogs: "block LOG -16 events:reward notify"
+  placeBricks: "block BRICKS 64 events:epicReward notify:5"
+  breakIron: "block IRON_ORE -16 noSafety notify events:dailyReward"
+```
+
+<h5> Variable Properties </h5> 
+
+Note that these follow the same rules as the amount argument, meaning that blocks to break are a negative number!
+You can use this variable to always get positive values: `%math.calc:|objective.breakLogs.left|%`
+
+| Name     | Example Output | Explanation                                                                                         |
+|----------|----------------|-----------------------------------------------------------------------------------------------------|
+| _amount_ | 6              | Shows the amount of blocks already broken / placed.                                                 |
+| _left_   | 4              | Shows the amount of blocks that still need to be broken / placed for the objective to be completed. |
+| _total_  | 10             | Shows the initial amount of blocks that needed to be broken / placed.                               |
+
 
 ## Breed animals: `breed`
 

--- a/docs/Participate/Process/Docs/Workflow.md
+++ b/docs/Participate/Process/Docs/Workflow.md
@@ -12,10 +12,10 @@ Run this command in IntelliJ's terminal window (at the bottom) to start a live p
 It will be available on [127.0.0.1:8000](http://127.0.0.1:8000/) by default.
 
 ``` bash linenums="1" 
-mkdocs serve --dirtyreload # (1)
+mkdocs serve --livereload # (1)
 ```
 
-1. `--dirtyreload` is an optional argument that determines that only changed files will be re-build.
+1. `--livereload` is an optional argument that determines that only changed files will be re-build.
    This drastically decreases build time. However, it may lead to inaccurate navigation within your site.
    Serve without this argument to validate your changes once finished.
 

--- a/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
@@ -25,18 +25,23 @@ public class BlockObjective extends CountingObjective implements Listener {
 
     private final BlockSelector selector;
     private final boolean exactMatch;
+    private final boolean noSafety;
 
     public BlockObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         selector = instruction.getBlockSelector();
         exactMatch = instruction.hasArgument("exactMatch");
         targetAmount = instruction.getInt();
+        noSafety = instruction.hasArgument("noSafety");
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onBlockPlace(final BlockPlaceEvent event) {
         final String playerID = PlayerConverter.getID(event.getPlayer());
         if (containsPlayer(playerID) && selector.match(event.getBlock(), exactMatch) && checkConditions(playerID)) {
+            if (getCountingData(playerID).getDirectionFactor() < 0 && noSafety) {
+                return;
+            }
             handleDataChange(playerID, getCountingData(playerID).add());
         }
     }
@@ -45,6 +50,9 @@ public class BlockObjective extends CountingObjective implements Listener {
     public void onBlockBreak(final BlockBreakEvent event) {
         final String playerID = PlayerConverter.getID(event.getPlayer());
         if (containsPlayer(playerID) && selector.match(event.getBlock(), exactMatch) && checkConditions(playerID)) {
+            if (getCountingData(playerID).getDirectionFactor() > 0 && noSafety) {
+                return;
+            }
             handleDataChange(playerID, getCountingData(playerID).subtract());
         }
     }


### PR DESCRIPTION
## Description
- block objective now has argument noSafety which disables removing progress when the player does the opposite of what the objective asks for

![grafik](https://user-images.githubusercontent.com/40303883/191227510-d41cb55c-3bf4-4a99-80e4-570ef27f9e61.png)

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
