### PR TITLE
Hunger condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `burn` event - ignites player for given seconds, supports variables
 - `velocity` event - throws the player by a vector (can be variable) with a direction and modification
 - `block` objective - added argument `noSafety` which disables removing progress when the player does the opposite of what the objective asks for
-- `hunger` condition and event added
+- `hunger` condition and event
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `burn` event - ignites player for given seconds, supports variables
 - `velocity` event - throws the player by a vector (can be variable) with a direction and modification
 - `block` objective - added argument `noSafety` which disables removing progress when the player does the opposite of what the objective asks for
+- `hunger` condition and event added
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Conditions-List.md
+++ b/docs/Documentation/Conditions-List.md
@@ -213,7 +213,7 @@ This condition requires the player to be _below_ specific Y height. The required
 
 ## Hunger: `hunger`
 
-Requires the player to have equal or more hunger points, the condition is the same as `health` just for hunger. If the player is required to have less than the specified amount invert the condition with an exclamation mark (`!`). If the hunger level is below 7, the player cannot sprint.
+Requires the player to have equal or more hunger points, the condition is the same as `health` just for hunger. If the hunger level is below 7, the player cannot sprint.
 
 !!! example
     ```YAML

--- a/docs/Documentation/Conditions-List.md
+++ b/docs/Documentation/Conditions-List.md
@@ -210,6 +210,15 @@ This condition requires the player to be _below_ specific Y height. The required
     ```YAML
     height 16
     ```
+
+## Hunger: `hunger`
+
+Requires the player to have equal or more hunger points, the condition is the same as `health` just for hunger. If the player is required to have less than the specified amount invert the condition with an exclamation mark (`!`). If the hunger level is below 7, the player cannot sprint.
+
+!!! example
+    ```YAML
+    hunger 15
+    ```
     
 ## In Conversation: `inconversation`
 

--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -250,6 +250,16 @@ Works the same way as a normal tag event, but instead of setting a tag for one p
     globaltag add global_areNPCsAgressive
     ```
 
+## Hunger: `hunger`
+
+This event changes the food level of the player. The second argument is the modification type. There are `give`/`add`, `take` and `set`. The second argument is the amount. With `set` can the food level be anything. If `give` or `take` is specified and the final amount won't be more than 20 or less than 0. If the hunger level is below 7, the player cannot sprint.
+
+!!! example
+    ```YAML
+    hunger set 20
+    hunger add 5
+    ```
+
 ## If else: `if`
 
 This event will check a condition, and based on the outcome it will run the first or second event. The instruction string is `if condition event1 else event2`, where `condition` is a condition ID and `event1` and `event2` are event IDs. `else` keyword is mandatory between events for no practical reason.

--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -252,12 +252,12 @@ Works the same way as a normal tag event, but instead of setting a tag for one p
 
 ## Hunger: `hunger`
 
-This event changes the food level of the player. The second argument is the modification type. There are `give`/`add`, `take` and `set`. The second argument is the amount. With `set` can the food level be anything. If `give` or `take` is specified and the final amount won't be more than 20 or less than 0. If the hunger level is below 7, the player cannot sprint.
+This event changes the food level of the player. The second argument is the modification type. There are `give`, `take` and `set`. The second argument is the amount. With `set` can the food level be anything. If `give` or `take` is specified and the final amount won't be more than 20 or less than 0. If the hunger level is below 7, the player cannot sprint.
 
 !!! example
     ```YAML
     hunger set 20
-    hunger add 5
+    hunger give 5
     ```
 
 ## If else: `if`

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -52,6 +52,7 @@ import org.betonquest.betonquest.conditions.GlobalTagCondition;
 import org.betonquest.betonquest.conditions.HandCondition;
 import org.betonquest.betonquest.conditions.HealthCondition;
 import org.betonquest.betonquest.conditions.HeightCondition;
+import org.betonquest.betonquest.conditions.HungerCondition;
 import org.betonquest.betonquest.conditions.InConversationCondition;
 import org.betonquest.betonquest.conditions.ItemCondition;
 import org.betonquest.betonquest.conditions.JournalCondition;
@@ -117,6 +118,7 @@ import org.betonquest.betonquest.events.GiveEvent;
 import org.betonquest.betonquest.events.GiveJournalEvent;
 import org.betonquest.betonquest.events.GlobalPointEvent;
 import org.betonquest.betonquest.events.GlobalTagEvent;
+import org.betonquest.betonquest.events.HungerEvent;
 import org.betonquest.betonquest.events.IfElseEvent;
 import org.betonquest.betonquest.events.KillEvent;
 import org.betonquest.betonquest.events.KillMobEvent;
@@ -785,6 +787,7 @@ public class BetonQuest extends JavaPlugin {
         registerConditions("fly", FlyingCondition.class);
         registerConditions("burning", BurningCondition.class);
         registerConditions("inconversation", InConversationCondition.class);
+        registerConditions("hunger", HungerCondition.class);
 
         // register events
         registerEvents("objective", ObjectiveEvent.class);
@@ -837,6 +840,7 @@ public class BetonQuest extends JavaPlugin {
         registerEvents("freeze", FreezeEvent.class);
         registerEvent("burn", new BurnEventFactory(getServer(), getServer().getScheduler(), this));
         registerEvent("velocity", new VelocityEventFactory(getServer(), getServer().getScheduler(), this));
+        registerEvents("hunger", HungerEvent.class);
 
         // register objectives
         registerObjectives("location", LocationObjective.class);

--- a/src/main/java/org/betonquest/betonquest/conditions/HungerCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/HungerCondition.java
@@ -1,0 +1,28 @@
+package org.betonquest.betonquest.conditions;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.betonquest.betonquest.utils.PlayerConverter;
+
+/**
+ * Requires the player to have specified amount of hunger (or more)
+ */
+@SuppressWarnings("PMD.CommentRequired")
+public class HungerCondition extends Condition {
+
+    private final VariableNumber hunger;
+
+    public HungerCondition(final Instruction instruction) throws InstructionParseException {
+        super(instruction, true);
+        hunger = instruction.getVarNum();
+    }
+
+    @Override
+    protected Boolean execute(final String playerID) throws QuestRuntimeException {
+        return PlayerConverter.getPlayer(playerID).getFoodLevel() >= hunger.getDouble(playerID);
+    }
+
+}

--- a/src/main/java/org/betonquest/betonquest/events/HungerEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/HungerEvent.java
@@ -7,7 +7,7 @@ import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.entity.Player;
 
-import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Sets the hunger level of the player.
@@ -20,11 +20,18 @@ public class HungerEvent extends QuestEvent {
 
     public HungerEvent(final Instruction instruction) throws InstructionParseException {
         super(instruction, false);
-        this.action = HungerAction.get(instruction.next());
+
         try {
+            this.action = HungerAction.valueOf(instruction.next().toUpperCase(Locale.ROOT).trim());
             this.amount = Short.parseShort(instruction.next());
         } catch (NumberFormatException e) {
             throw new InstructionParseException("Error while parsing hunger amount! Must be a number.", e);
+        } catch (IllegalArgumentException e) {
+            throw new InstructionParseException("Error while parsing action! Must be 'set', 'give', or 'take'.", e);
+        }
+
+        if (amount < 0 || amount > 20) {
+            throw new InstructionParseException("Hunger amount must be between 0 and 20! Event will be ignored.");
         }
     }
 
@@ -42,24 +49,9 @@ public class HungerEvent extends QuestEvent {
     }
 
     private enum HungerAction {
-        GIVE("give", "add"),
-        TAKE("take", "remove"),
-        SET("set");
-
-        private final String[] aliases;
-
-        HungerAction(final String... aliases) {
-            this.aliases = aliases.clone();
-        }
-
-        public static HungerAction get(final String alias) throws InstructionParseException {
-            for (final HungerAction action : values()) {
-                if (Arrays.stream(action.aliases).anyMatch(a -> a.equalsIgnoreCase(alias))) {
-                    return action;
-                }
-            }
-            throw new InstructionParseException("Cannot parse hunger action '" + alias + "'");
-        }
+        GIVE,
+        TAKE,
+        SET
     }
 
 

--- a/src/main/java/org/betonquest/betonquest/events/HungerEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/HungerEvent.java
@@ -1,0 +1,66 @@
+package org.betonquest.betonquest.events;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.QuestEvent;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.utils.PlayerConverter;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+
+/**
+ * Sets the hunger level of the player.
+ */
+@SuppressWarnings("PMD.CommentRequired")
+public class HungerEvent extends QuestEvent {
+
+    private final HungerAction action;
+    private final short amount;
+
+    public HungerEvent(final Instruction instruction) throws InstructionParseException {
+        super(instruction, false);
+        this.action = HungerAction.get(instruction.next());
+        try {
+            this.amount = Short.parseShort(instruction.next());
+        } catch (NumberFormatException e) {
+            throw new InstructionParseException("Error while parsing hunger amount! Must be a number.", e);
+        }
+    }
+
+    @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    protected Void execute(final String playerID) {
+        final Player player = PlayerConverter.getPlayer(playerID);
+
+        switch (this.action) {
+            case GIVE -> player.setFoodLevel(Math.min(player.getFoodLevel() + this.amount, 20));
+            case TAKE -> player.setFoodLevel(Math.max(player.getFoodLevel() - this.amount, 0));
+            case SET -> player.setFoodLevel(this.amount);
+        }
+        return null;
+    }
+
+    private enum HungerAction {
+        GIVE("give", "add"),
+        TAKE("take", "remove"),
+        SET("set");
+
+        private final String[] aliases;
+
+        HungerAction(final String... aliases) {
+            this.aliases = aliases.clone();
+        }
+
+        public static HungerAction get(final String alias) throws InstructionParseException {
+            for (final HungerAction action : values()) {
+                if (Arrays.stream(action.aliases).anyMatch(a -> a.equalsIgnoreCase(alias))) {
+                    return action;
+                }
+            }
+            throw new InstructionParseException("Cannot parse hunger action '" + alias + "'");
+        }
+    }
+
+
+}


### PR DESCRIPTION
## Description
Adds a condition that is met when the player's food level is equal to or larger than the given amount. Similar to the health condition. The hunger event allows to modify the food level with set, add and take methods.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
