### PR TITLE
updated quests from 4.5.1 to 4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,14 +186,14 @@
     <dependency>
       <groupId>me.blackvein.quests</groupId>
       <artifactId>quests-api</artifactId>
-      <version>4.5.1</version>
+      <version>4.6.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>me.blackvein.quests</groupId>
       <artifactId>quests-core</artifactId>
-      <version>4.5.1</version>
+      <version>4.6.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
## Description
this should solve the issue that com.github.PikaMug:LocaleLib:jar:2.8 could not be resolved in the Daily Dependency Check build


### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
