### PR TITLE
fix ActionObjective uses paperAPI

### DIFF
--- a/src/main/java/org/betonquest/betonquest/objectives/ActionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ActionObjective.java
@@ -24,6 +24,11 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
+import static org.bukkit.event.block.Action.LEFT_CLICK_AIR;
+import static org.bukkit.event.block.Action.LEFT_CLICK_BLOCK;
+import static org.bukkit.event.block.Action.RIGHT_CLICK_AIR;
+import static org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK;
+
 /**
  * Player has to click on a block (or air). Left click, right click and any one of
  * them is supported.
@@ -137,7 +142,8 @@ public class ActionObjective extends Objective implements Listener {
             if (action == Action.PHYSICAL) {
                 return false;
             }
-            return this == ANY || this == RIGHT && action.isRightClick() || this == LEFT && action.isLeftClick();
+            return this == ANY || this == RIGHT && (action == RIGHT_CLICK_AIR || action == RIGHT_CLICK_BLOCK)
+                    || this == LEFT && (action == LEFT_CLICK_AIR || action == LEFT_CLICK_BLOCK);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes here. -->

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
