### PR TITLE
#2043 Add absolute properties to BlockObjective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - variable support for menu titles
 - configurable cooldown to menu conversation IO
 - `freeze` event - ProtocolLib compatibility feature: Blocks the player from moving for the specified amount of ticks
+- `block` objective - properties: `absoluteAmount`, `absoluteLeft` and `absoluteTotal`
 - `command` objective
 - `equip` objective
 - `delay` objective - now support variables

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -41,8 +41,8 @@ To complete this objective the player must break or place the specified amount o
 
 | Parameter       | Syntax                                           | Default Value          | Explanation                                                                                                                                                                                                                                                               |
 |-----------------|--------------------------------------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _Block Type_    | [Block Selector](./Reference.md#block-selectors) | :octicons-x-circle-16: | The block which must be broken.                                                                                                                                                                                                                                           |
-| _Amount_        | Number                                           | :octicons-x-circle-16: | The amount of blocks to place / destroy. More than 0 for placing and less than 0 for breaking blocks.                                                                                                                                                                     |
+| _Block Type_    | [Block Selector](./Reference.md#block-selectors) | :octicons-x-circle-16: | The block which must be broken / placed.                                                                                                                                                                                                                                  |
+| _Amount_        | Number                                           | :octicons-x-circle-16: | The amount of blocks to break / place. Less than 0 for breaking and more than 0 for placing blocks.                                                                                                                                                                       |
 | _Safety Check_  | Keyword (`noSafety`)                             | Safety Check Enabled   | The Safety Check prevents faking the objective. The progress will be reduced when the player does to opposite of what they are supposed to do. Example: Player must break 10 blocks. They place 10 of their stored blocks. Now the total amount of blocks to break is 20. |
 | _Notifications_ | Keyword (`notify`)                               | Disabled               | Displays messages to the player each time they progress the objective. Optionally with the notification interval after colon.                                                                                                                                             |
 
@@ -57,13 +57,20 @@ objectives:
 <h5> Variable Properties </h5> 
 
 Note that these follow the same rules as the amount argument, meaning that blocks to break are a negative number!
-You can use this variable to always get positive values: `%math.calc:|objective.breakLogs.left|%`
 
 | Name     | Example Output | Explanation                                                                                         |
 |----------|----------------|-----------------------------------------------------------------------------------------------------|
-| _amount_ | 6              | Shows the amount of blocks already broken / placed.                                                 |
-| _left_   | 4              | Shows the amount of blocks that still need to be broken / placed for the objective to be completed. |
-| _total_  | 10             | Shows the initial amount of blocks that needed to be broken / placed.                               |
+| _amount_ | -6 / 6         | Shows the amount of blocks already broken / placed.                                                 |
+| _left_   | -4 / 4         | Shows the amount of blocks that still need to be broken / placed for the objective to be completed. |
+| _total_  | -10 / 10       | Shows the initial amount of blocks that needed to be broken / placed.                               |
+
+You can use these variables to always get positive values:
+
+| Name              | Example Output | Explanation                                                                                                  |
+|-------------------|----------------|--------------------------------------------------------------------------------------------------------------|
+| _absoluteAmount_  | 6              | Shows the absolute amount of blocks already broken / placed.                                                 |
+| _absoluteLeft_    | 4              | Shows the absolute amount of blocks that still need to be broken / placed for the objective to be completed. |
+| _absoluteTotal_   | 10             | Shows the initial absolute amount of blocks that needed to be broken / placed.                               |
 
 
 ## Breed animals: `breed`

--- a/src/main/java/org/betonquest/betonquest/api/CountingObjective.java
+++ b/src/main/java/org/betonquest/betonquest/api/CountingObjective.java
@@ -52,16 +52,16 @@ public abstract class CountingObjective extends Objective {
 
     @Override
     public String getProperty(final String name, final Profile profile) {
-        switch (name.toLowerCase(Locale.ROOT)) {
-            case "amount":
-                return Integer.toString(getCountingData(profile).getCompletedAmount());
-            case "left":
-                return Integer.toString(getCountingData(profile).getAmountLeft());
-            case "total":
-                return Integer.toString(getCountingData(profile).getTargetAmount());
-            default:
-                return "";
-        }
+        final Integer data = switch (name.toLowerCase(Locale.ROOT)) {
+            case "amount" -> getCountingData(profile).getCompletedAmount();
+            case "left" -> getCountingData(profile).getAmountLeft();
+            case "total" -> getCountingData(profile).getTargetAmount();
+            case "absoluteamount" -> Math.abs(getCountingData(profile).getCompletedAmount());
+            case "absoluteleft" -> Math.abs(getCountingData(profile).getAmountLeft());
+            case "absolutetotal" -> Math.abs(getCountingData(profile).getTargetAmount());
+            default -> null;
+        };
+        return data == null ? "" : data.toString();
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
@@ -16,8 +16,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 
-import java.util.Locale;
-
 /**
  * Player has to break/place specified amount of blocks. Doing opposite thing
  * (breaking when should be placing) will reverse the progress.
@@ -36,25 +34,6 @@ public class BlockObjective extends CountingObjective implements Listener {
         exactMatch = instruction.hasArgument("exactMatch");
         targetAmount = instruction.getInt();
         noSafety = instruction.hasArgument("noSafety");
-    }
-
-    @Override
-    public String getProperty(final String name, final Profile profile) {
-        switch (name.toLowerCase(Locale.ROOT)) {
-            case "amount":
-            case "left":
-            case "total":
-                return super.getProperty(name, profile);
-            case "absoluteamount":
-            case "absoluteleft":
-            case "absolutetotal":
-                return Integer.toString(
-                        Math.abs(
-                                Integer.valueOf(
-                                        super.getProperty(name.replace("absolute", ""), profile))));
-            default:
-                return "";
-        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)

--- a/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/BlockObjective.java
@@ -16,6 +16,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 
+import java.util.Locale;
+
 /**
  * Player has to break/place specified amount of blocks. Doing opposite thing
  * (breaking when should be placing) will reverse the progress.
@@ -34,6 +36,25 @@ public class BlockObjective extends CountingObjective implements Listener {
         exactMatch = instruction.hasArgument("exactMatch");
         targetAmount = instruction.getInt();
         noSafety = instruction.hasArgument("noSafety");
+    }
+
+    @Override
+    public String getProperty(final String name, final Profile profile) {
+        switch (name.toLowerCase(Locale.ROOT)) {
+            case "amount":
+            case "left":
+            case "total":
+                return super.getProperty(name, profile);
+            case "absoluteamount":
+            case "absoluteleft":
+            case "absolutetotal":
+                return Integer.toString(
+                        Math.abs(
+                                Integer.valueOf(
+                                        super.getProperty(name.replace("absolute", ""), profile))));
+            default:
+                return "";
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)


### PR DESCRIPTION
## Description
The absolute values for properties amount, left and total with names absoluteAmount, absoluteLeft and absoluteTotal are added to the BlockObjective only and not to the other CountingObjectives.

### Related Issues
Closes #2043 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
