### PR TITLE
`/q version` command "click to copy" was simplified to prevent copyin…

### DIFF
--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -1604,24 +1604,12 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         final String hooked = hookedJoiner.toString();
 
         final Component compHeader = Component.text(BetonQuest.getInstance().getPluginTag() + versionInfo);
-        final Component compVersionBetonQuestKey = Component.text(colorKey + versionBetonQuest)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(versionBetonQuest + versionBetonQuestValue)));
-        final Component compVersionBetonQuestValue = Component.text(versionBetonQuestValue)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(versionBetonQuestValue)));
-        final Component compVersionServerKey = Component.text(colorKey + versionServer)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(versionServer + versionServerValue)));
-        final Component compVersionServerValue = Component.text(versionServerValue)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(versionServerValue)));
-        final Component compHookedKey = Component.text(colorKey + hookedInto)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(hookedInto + hooked)));
-        final Component compHookedValue = Component.text(hooked)
-                .hoverEvent(Component.text(clickToCopy))
-                .clickEvent(ClickEvent.suggestCommand(ChatColor.stripColor(hooked)));
+        final Component compVersionBetonQuestKey = Component.text(colorKey + versionBetonQuest);
+        final Component compVersionBetonQuestValue = Component.text(versionBetonQuestValue);
+        final Component compVersionServerKey = Component.text(colorKey + versionServer);
+        final Component compVersionServerValue = Component.text(versionServerValue);
+        final Component compHookedKey = Component.text(colorKey + hookedInto);
+        final Component compHookedValue = Component.text(hooked);
         final Component compCopyAll = Component.text(clickToCopyAll)
                 .hoverEvent(Component.text(clickToCopy))
                 .clickEvent(ClickEvent.copyToClipboard(ChatColor.stripColor(versionBetonQuest


### PR DESCRIPTION
…g only parts of the version info

before also only parts of the info could be copied, not only the "click to copy" text can be clicked to only copy everything to the clipboard

## Description
<!-- Please describe your changes here. -->

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
