### PR TITLE
fixed NPE exception when there is no killer for a EntityDeathEvent

### DIFF
--- a/src/main/java/org/betonquest/betonquest/MobKillListener.java
+++ b/src/main/java/org/betonquest/betonquest/MobKillListener.java
@@ -1,10 +1,10 @@
 package org.betonquest.betonquest;
 
 import org.betonquest.betonquest.api.MobKillNotifier;
-import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -22,7 +22,9 @@ public class MobKillListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onKill(final EntityDeathEvent event) {
         final LivingEntity entity = event.getEntity();
-        final Profile killer = PlayerConverter.getID(entity.getKiller());
-        MobKillNotifier.addKill(killer, entity);
+        final Player killer = entity.getKiller();
+        if (killer != null) {
+            MobKillNotifier.addKill(PlayerConverter.getID(killer), entity);
+        }
     }
 }


### PR DESCRIPTION
## Description
A Bug reported in DC:
```
[Server thread/ERROR]: Could not pass event MobKilledEvent to BetonQuest v2.0.0-DEV-406
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.getUniqueId()" because "this.val$player" is null
    at org.betonquest.betonquest.utils.PlayerConverter$2.hashCode(PlayerConverter.java:128) ~[BetonQuest.jar:?]
    at java.util.HashMap.hash(HashMap.java:337) ~[?:?]
    at java.util.HashMap.getNode(HashMap.java:567) ~[?:?]
    at java.util.HashMap.containsKey(HashMap.java:593) ~[?:?]
    at org.betonquest.betonquest.api.Objective.containsPlayer(Objective.java:403) ~[BetonQuest.jar:?]
    at org.betonquest.betonquest.objectives.MobKillObjective.onMobKill(MobKillObjective.java:53) ~[BetonQuest.jar:?]
    at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor726.execute(Unknown Source) ~[?:?]
    at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
    at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-201]
    at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
    at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
    at org.betonquest.betonquest.api.MobKillNotifier.addKill(MobKillNotifier.java:55) ~[BetonQuest.jar:?]
    at org.betonquest.betonquest.MobKillListener.onKill(MobKillListener.java:26) ~[BetonQuest.jar:?]
```
This bug was introduced by Profiles

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
