### PR TITLE
Fix #2060 BetonQuest cannot start without Holographic Displays

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -48,6 +48,9 @@ public class HologramLoop {
      */
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength", "PMD.NcssCount", "PMD.NPathComplexity", "PMD.CognitiveComplexity", "PMD.UseStringBufferForStringAppends"})
     public HologramLoop() {
+        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerIndividualPlaceholder("bq", new HologramPlaceholder());
+        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerGlobalPlaceholder("bqg", new HologramGlobalPlaceholder());
+
         final int defaultInterval = BetonQuest.getInstance().getPluginConfig().getInt("hologram_update_interval", 10 * 20);
         final HolographicDisplaysAPI holographicDisplaysAPI = HolographicDisplaysAPI.get(BetonQuest.getInstance());
         // get all holograms and their condition

--- a/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -48,11 +48,12 @@ public class HologramLoop {
      */
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength", "PMD.NcssCount", "PMD.NPathComplexity", "PMD.CognitiveComplexity", "PMD.UseStringBufferForStringAppends"})
     public HologramLoop() {
-        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerIndividualPlaceholder("bq", new HologramPlaceholder());
-        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerGlobalPlaceholder("bqg", new HologramGlobalPlaceholder());
-
         final int defaultInterval = BetonQuest.getInstance().getPluginConfig().getInt("hologram_update_interval", 10 * 20);
         final HolographicDisplaysAPI holographicDisplaysAPI = HolographicDisplaysAPI.get(BetonQuest.getInstance());
+
+        holographicDisplaysAPI.registerIndividualPlaceholder("bq", new HologramPlaceholder());
+        holographicDisplaysAPI.registerGlobalPlaceholder("bqg", new HologramGlobalPlaceholder());
+
         // get all holograms and their condition
         for (final QuestPackage pack : Config.getPackages().values()) {
             final String packName = pack.getPackagePath();

--- a/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
@@ -1,7 +1,5 @@
 package org.betonquest.betonquest.compatibility.holographicdisplays;
 
-import me.filoghost.holographicdisplays.api.HolographicDisplaysAPI;
-import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.compatibility.Integrator;
 import org.betonquest.betonquest.compatibility.citizens.CitizensHologram;
@@ -32,9 +30,6 @@ public class HolographicDisplaysIntegrator implements Integrator {
     @Override
     public void hook() {
         hologramLoop = new HologramLoop();
-
-        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerIndividualPlaceholder("bq", new HologramPlaceholder());
-        HolographicDisplaysAPI.get(BetonQuest.getInstance()).registerGlobalPlaceholder("bqg", new HologramGlobalPlaceholder());
 
         // if Citizens is hooked, start CitizensHologram
         if (Compatibility.getHooked().contains("Citizens")) {


### PR DESCRIPTION
## Description
Fixes #2060 by moving all HD API calls away from the integrator to the HologramLoop.

### Related Issues
<!-- Issue number if existing. -->
Closes #2060 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
