### PR TITLE
fix MythicHider uses invalid method after refactoring

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/MythicHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/MythicHider.java
@@ -153,7 +153,7 @@ public final class MythicHider extends BukkitRunnable implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerJoin(final PlayerJoinEvent event) {
-        applyVisibility(event.getPlayer());
+        applyVisibility(PlayerConverter.getID(event.getPlayer()));
     }
 
     @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
## Description
<!-- Please describe your changes here. -->
This error was introduced in 71ee003e86389be3176d504218415b9636aac02d. A previously unused method was now automatically used because the method signature of the method that used `Player` was changed to `Profile`. Since a Player is also an `Entity`, the unused method served as a silent fallback. Unfortuenately that does not work at all.

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
