### PR TITLE
fix cancellationException is being logged during server shutdown

### DIFF
--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -373,6 +373,11 @@ public class BetonQuest extends JavaPlugin {
                         return false;
                     }
                 } catch (InterruptedException | ExecutionException e) {
+                    if (PaperLib.isPaper() && Bukkit.getServer().isStopping()) {
+                        return false;
+                    }
+                    log.warn("The following exception is only ok when the server is currently stopping." +
+                            "Switch to papermc.io to fix this.");
                     log.reportException(e);
                     return false;
                 }
@@ -981,8 +986,8 @@ public class BetonQuest extends JavaPlugin {
         rpgMenu = new RPGMenu();
         rpgMenu.onEnable();
 
-        // done
-        log.info("BetonQuest succesfully enabled!");
+        PaperLib.suggestPaper(this);
+        log.info("BetonQuest successfully enabled!");
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -1227,6 +1227,7 @@ public class BetonQuest extends JavaPlugin {
         }
     }
 
+    @SuppressWarnings("PMD.DoNotUseThreads")
     @Override
     public void onDisable() {
         //stop all schedules
@@ -1264,11 +1265,13 @@ public class BetonQuest extends JavaPlugin {
         }
         FreezeEvent.cleanup();
 
-        final java.util.logging.Logger serverLogger = getServer().getLogger().getParent();
-        serverLogger.removeHandler(debugHistoryHandler);
-        serverLogger.removeHandler(chatHandler);
-        debugHistoryHandler.close();
-        chatHandler.close();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            final java.util.logging.Logger serverLogger = getServer().getLogger().getParent();
+            serverLogger.removeHandler(debugHistoryHandler);
+            serverLogger.removeHandler(chatHandler);
+            debugHistoryHandler.close();
+            chatHandler.close();
+        }));
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -373,6 +373,12 @@ public class BetonQuest extends JavaPlugin {
                         return false;
                     }
                 } catch (InterruptedException | ExecutionException e) {
+                    // Currently conditions that are forced to be sync cause every CompletableFuture.get() call
+                    // to delay the check by one tick.
+                    // If this happens during a shutdown, the check will be delayed past the last tick.
+                    // This will throw a CancellationException and IllegalPluginAccessExceptions.
+                    // For Paper we can detect this and only log it to the debug log.
+                    // When the conditions get reworked, this complete check can be removed including the Spigot message.
                     if (PaperLib.isPaper() && Bukkit.getServer().isStopping()) {
                         log.debug("Exception during shutdown while checking conditions (expected):", e);
                         return false;

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -374,10 +374,13 @@ public class BetonQuest extends JavaPlugin {
                     }
                 } catch (InterruptedException | ExecutionException e) {
                     if (PaperLib.isPaper() && Bukkit.getServer().isStopping()) {
+                        log.debug("Exception during shutdown while checking conditions (expected):", e);
                         return false;
                     }
-                    log.warn("The following exception is only ok when the server is currently stopping." +
-                            "Switch to papermc.io to fix this.");
+                    if (PaperLib.isSpigot()) {
+                        log.warn("The following exception is only ok when the server is currently stopping." +
+                                "Switch to papermc.io to fix this.");
+                    }
                     log.reportException(e);
                     return false;
                 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -131,7 +131,7 @@ public class HologramLoop {
                             pointName = packName + '.' + pointName;
                         }
 
-                        TopXObject.OrderType orderType;
+                        final TopXObject.OrderType orderType;
                         if ("desc".equalsIgnoreCase(validator.group(2))) {
                             orderType = TopXObject.OrderType.DESCENDING;
                         } else if ("asc".equalsIgnoreCase(validator.group(2))) {
@@ -144,7 +144,7 @@ public class HologramLoop {
                         int limit;
                         try { // negative limits are checked by regex
                             limit = Integer.parseInt(validator.group(3));
-                        } catch (NumberFormatException e) {
+                        } catch (final NumberFormatException e) {
                             LOG.warn(pack, "Top list limit must be numeric! Using limit 10.");
                             limit = 10;
                         }
@@ -221,7 +221,7 @@ public class HologramLoop {
             runnable = new BukkitRunnable() {
                 @Override
                 public void run() {
-                    holograms.forEach(h -> {
+                    holograms.stream().parallel().forEach(h -> {
                         h.updateVisibility();
                         h.updateContent();
                     });


### PR DESCRIPTION
This fix is not available on Spigot due to missing API. Instead a warning message is logged.

Additionally, this PR introduces a warning on server startup if the server is running Spigot and not Paper.

## Description
<!-- Please describe your changes here. -->

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
