### PR TITLE
`consume` objective now uses the `CountingObjective` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `bossbar` notify style now supports variables for the `progress` argument
 - `delay` objective property: `rawSeconds`
 - `fish` objective now has `hookLocation` and `range` settings.
+- `consume` objective now has `amount` argument.
 - `mmoprofessionlevelup` objective can now check the main character level as well
 - `burning` condition
 - `inconversation` condition

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -103,15 +103,30 @@ argument. By default, only one player can look into the chest at the same time. 
     chestput 0;50;100;world apple:42 events:message multipleaccess:true
     ```
 
-## Eat/drink: `consume`
+## :material-food-fork-drink: Eat/drink: `consume`
 
-This objective is completed by eating specified food or drinking specified potion. The only required argument is the ID
-of an item from the _items_ section.
+This objective is completed by eating the specified food or drinking the specified potion. 
 
-!!! example
-    ```YAML
-    consume tawny_owl events:faster_endurance_regen
-    ```
+| Parameter       | Syntax                       | Default Value          | Explanation                                                                                                                   |
+|-----------------|------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| _Item_          | [Item](./Reference.md#items) | :octicons-x-circle-16: | The item or potion that must be consumed.                                                                                     |
+| _Amount_        | amount:number                | 1                      | The amount of items to consume.                                                                                               |
+
+
+```YAML
+objectives:
+  eatApple: "consume apple events:faster_endurance_regen"
+  eatSteak: "consume steak amount:4 events:health_boost"
+```
+
+<h5> Variable Properties </h5> 
+
+| Name     | Example Output | Explanation                                                                                 |
+|----------|----------------|---------------------------------------------------------------------------------------------|
+| _amount_ | 6              | Shows the amount of items already consumed.                                                 |
+| _left_   | 4              | Shows the amount of items that still need to be consumed for the objective to be completed. |
+| _total_  | 10             | Shows the initial amount of items that needed to be consumed.                               |
+
 
 ## Crafting: `craft`
 

--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -109,6 +109,18 @@ public class Instruction {
         return parts[index];
     }
 
+    /**
+     * Gets an optional value or the default value if value is not present.
+     *
+     * @param prefix        the prefix of the optional value
+     * @param defaultString the default value
+     * @return the value or the default value
+     */
+    public String getOptional(final String prefix, final String defaultString) {
+        final String optionalValue = getOptional(prefix);
+        return optionalValue == null ? defaultString : optionalValue;
+    }
+
     public String getOptional(final String prefix) {
         for (final String part : parts) {
             if (part.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT) + ":")) {
@@ -127,16 +139,6 @@ public class Instruction {
             }
         }
         return false;
-    }
-
-    /**
-     * Checks whether the instruction has an optional argument with the given prefix.
-     *
-     * @param prefix the prefix of the optional argument
-     * @return true if the instruction has an optional argument with the given prefix
-     */
-    public boolean hasOptional(final String prefix) {
-        return getOptional(prefix) != null;
     }
 
     /////////////////////

--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -129,6 +129,16 @@ public class Instruction {
         return false;
     }
 
+    /**
+     * Checks whether the instruction has an optional argument with the given prefix.
+     *
+     * @param prefix the prefix of the optional argument
+     * @return true if the instruction has an optional argument with the given prefix
+     */
+    public boolean hasOptional(final String prefix) {
+        return getOptional(prefix) != null;
+    }
+
     /////////////////////
     ///    OBJECTS    ///
     /////////////////////

--- a/src/main/java/org/betonquest/betonquest/objectives/ConsumeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ConsumeObjective.java
@@ -2,7 +2,7 @@ package org.betonquest.betonquest.objectives;
 
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
-import org.betonquest.betonquest.api.Objective;
+import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.item.QuestItem;
@@ -14,24 +14,49 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 
 /**
- * Requires the player to consume an item (eat food or drink s potion).
+ * Requires the player to consume an item (eat food or drink a potion).
  */
 @SuppressWarnings("PMD.CommentRequired")
-public class ConsumeObjective extends Objective implements Listener {
+public class ConsumeObjective extends CountingObjective implements Listener {
 
+    /**
+     * The name of the argument that determines the amount of items to consume.
+     */
+    public static final String AMOUNT_ARGUMENT = "amount";
+
+    /**
+     * The item to consume.
+     */
     private final QuestItem item;
 
+    /**
+     * Constructs a new {@code ConsumeObjective} for the given {@code Instruction}.
+     *
+     * @param instruction the instruction out of a quest package
+     * @throws InstructionParseException if the instruction is invalid
+     */
     public ConsumeObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         item = instruction.getQuestItem();
+        if (instruction.hasOptional(AMOUNT_ARGUMENT)) {
+            targetAmount = Integer.parseInt(instruction.getOptional(AMOUNT_ARGUMENT));
+        } else {
+            targetAmount = 1;
+        }
     }
 
+
+    /**
+     * The listener that handles a consumed item.
+     *
+     * @param event the Bukkit event for consuming an item
+     */
     @EventHandler(ignoreCancelled = true)
     public void onConsume(final PlayerItemConsumeEvent event) {
         final Profile profile = PlayerConverter.getID(event.getPlayer());
         if (containsPlayer(profile) && item.compare(event.getItem()) && checkConditions(profile)) {
-            completeObjective(profile);
+            getCountingData(profile).progress();
+            completeIfDoneOrNotify(profile);
         }
     }
 
@@ -44,15 +69,4 @@ public class ConsumeObjective extends Objective implements Listener {
     public void stop() {
         HandlerList.unregisterAll(this);
     }
-
-    @Override
-    public String getDefaultDataInstruction() {
-        return "";
-    }
-
-    @Override
-    public String getProperty(final String name, final Profile profile) {
-        return "";
-    }
-
 }

--- a/src/main/java/org/betonquest/betonquest/objectives/ConsumeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ConsumeObjective.java
@@ -38,11 +38,7 @@ public class ConsumeObjective extends CountingObjective implements Listener {
     public ConsumeObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         item = instruction.getQuestItem();
-        if (instruction.hasOptional(AMOUNT_ARGUMENT)) {
-            targetAmount = Integer.parseInt(instruction.getOptional(AMOUNT_ARGUMENT));
-        } else {
-            targetAmount = 1;
-        }
+        targetAmount = Integer.parseInt(instruction.getOptional(AMOUNT_ARGUMENT, "1"));
     }
 
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes here. -->
This adds an `amount` argument.

![grafik](https://user-images.githubusercontent.com/40303883/198019043-a814ea07-e438-4ce3-bc4e-af343cccd5f8.png)


### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
