### PR TITLE
add deathRadiusAllPlayers to mmobkillobjective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mmspawn` event now has argument `private` Visually hides the spawned mob from other players. Does not stop sound or particles
 - `mmspawn` event now supports the `marked` argument
 - `objective` event now supports a comma separated list of objectives
-- `mmobkill` objective now supports the `marked` argument
+- `mmobkill` objective now supports the `marked` and `deathRadiusAllPlayers` argument
 - `marked` argument now supports %player% variable 
 - `globaltag` and `globalpoint` variables
 - `burn` event - ignites player for given seconds, supports variables

--- a/docs/Documentation/Compatibility.md
+++ b/docs/Documentation/Compatibility.md
@@ -766,6 +766,8 @@ You can optionally add the `amount:` argument to specify how many of these mobs 
 to add the optional arguments `minLevel` and `maxLevel` to further customize what mobs need to be killed.
 You can also add an optional `neutralDeathRadiusAllPlayers` argument to complete the objective for each nearby player
 within the defined radius when the mob is killed by any non-player source.
+Alternatively, you could use the `deathRadiusAllPlayers` argument to count all deaths of the specified mythic mob(s),
+no matter if it was killed by a non-player source or not.
 You can add a `notify` keyword if you want to send a notification to players whenever the objective progresses.
 You can also add an optional `marked` argument to only count kills marked with the `mspawn` event.
 The only supported variable for the marked argument is `%player%`.
@@ -778,6 +780,7 @@ This objective has three properties: `amount`, `left` and `total`. `amount` is t
     mmobkill SkeletalKnight amount:2 events:reward
     mmobkill SnekBoss,SnailBoss,SunBoss amount:10 events:reward
     mmobkill SnekBoss amount:2 minlevel:4 maxlevel:6 events:reward marked:DungeonBoss3
+    mmobkill dungeonDevil deathRadiusAllPlayers:30 events:reward
     ```
 
 ### Conditions


### PR DESCRIPTION
## Description
This argument allows to count all kills for all players in the given area, regardeless of kill-source-type.
Solving this with the party system alone was not feasable as that would mean building a point based scoring system for > 50 objectives + party events for each of them.

I have noted down some meta information to our discussion about the BQ language rework to integrate such features directly into the new syntax.

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
