### PR TITLE
fix conditions tutorial having wrong condition names

### DIFF
--- a/docs/Tutorials/Getting-Started/Basics/Conditions.md
+++ b/docs/Tutorials/Getting-Started/Basics/Conditions.md
@@ -155,7 +155,7 @@ This tag condition is "true" if the player has the defined tag. Let's break it d
   it after what it should check.
 *  The Condition Instruction:
     - `tag`: The first value in the instruction is always the **condition type**.
-    - `foodReceivedTag`: This is the name of the tag that the player must have.
+    - `foodReceived`: This is the name of the tag that the player must have.
 
 
 Tags can be assigned to a player using events. Let's create an event that gives the player the tag:
@@ -191,7 +191,7 @@ conversations:
         text: "You're welcome! Take it... &7*gives food*"
         events: "giveFoodToPlayer,{==addFoodReceivedTag==}" #(3)!
         pointer: "thankYou"
-        conditions: "!foodReceivedTag"
+        conditions: "!hasReceivedFood"
       alreadyReceivedFood:
         text: "Hey %player%! I think I already gave you your welcome food..."
         conditions: "hasReceivedFood"  #(4)!
@@ -215,7 +215,7 @@ conversations:
    This is because this option has no conditions and is the last option in the `first` list.
 3. These events will be executed if the player chooses the `foodAnswer` option. It will give the player the food and the
    tag `foodReceived`.
-4. This condition ensures that the player will only see the `alreadyFoodReceived` option if he has the tag `foodReceivedTag`.
+4. This condition ensures that the player will only see the `alreadyFoodReceived` option if he has the tag `foodReceived`.
 
 
 As you can see we also added new options to it. Now the NPC will say that you already received the food


### PR DESCRIPTION
## Description
<!-- Please describe your changes here. -->

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
