### PR TITLE
Added support for not displaying the compass targets and cancel quest…

### DIFF
--- a/docs/Documentation/Configuration.md
+++ b/docs/Documentation/Configuration.md
@@ -221,6 +221,12 @@ The items need to be defined in a package, and then you need to reference the it
   - `cancel_button` the item to show the quest cancelers.  
   - `compass_button` the item to show the quest compass.
 
+### Backpack
+
+ `backpack` gives the option to disable displaying certain buttons in the backpack, such as the compass targets and
+ cancel quest buttons.
+ * `show_compass_targets`
+ * `show_cancel`
 ### Misc settings
 
 * `date_format` is the Java [date format](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)

--- a/src/main/java/org/betonquest/betonquest/Backpack.java
+++ b/src/main/java/org/betonquest/betonquest/Backpack.java
@@ -144,6 +144,8 @@ public class Backpack implements Listener {
         private final int pages;
         private final int pageOffset;
         private final boolean showJournal;
+        private final boolean showCancel;
+        private final boolean showCompassTargets;
         private final List<ItemStack> backpackItems;
 
         /**
@@ -211,6 +213,7 @@ public class Backpack implements Listener {
                 content[50] = next;
             }
             // set "cancel quest" button
+            this.showCancel = Boolean.parseBoolean(Config.getString("config.backpack.show_cancel"));
             ItemStack cancel = null;
             final String cancelButton = Config.getString("config.items.backpack.cancel_button");
             if (cancelButton != null && !cancelButton.isEmpty()) {
@@ -226,8 +229,11 @@ public class Backpack implements Listener {
             final ItemMeta meta = cancel.getItemMeta();
             meta.setDisplayName(Config.getMessage(lang, "cancel").replaceAll("&", "§"));
             cancel.setItemMeta(meta);
-            content[45] = cancel;
+            if (showCancel) {
+                content[45] = cancel;
+            }
             // set "compass targets" button
+            this.showCompassTargets = Boolean.parseBoolean(Config.getString("config.backpack.show_compass_targets"));
             ItemStack compassItem = null;
             final String compassButton = Config.getString("config.items.backpack.compass_button");
             if (compassButton != null && !compassButton.isEmpty()) {
@@ -243,7 +249,9 @@ public class Backpack implements Listener {
             final ItemMeta compassMeta = compassItem.getItemMeta();
             compassMeta.setDisplayName(Config.getMessage(lang, "compass").replace('&', '&'));
             compassItem.setItemMeta(compassMeta);
-            content[46] = compassItem;
+            if (showCompassTargets) {
+                content[46] = compassItem;
+            }
             // set the inventory and display it
             inv.setContents(content);
             onlineProfile.getPlayer().openInventory(inv);
@@ -334,10 +342,10 @@ public class Backpack implements Listener {
                 display = new Page(page - 1);
             } else if (slot == 50 && page < pages) {
                 display = new Page(page + 1);
-            } else if (slot == 45) {
+            } else if (slot == 45 && showCancel) {
                 // slot 45 is a slot with quest cancelers
                 display = new Cancelers();
-            } else if (slot == 46) {
+            } else if (slot == 46 && showCompassTargets) {
                 // slot 46 is a slot with compass pointers
                 display = new Compass();
             }


### PR DESCRIPTION
Added support for not displaying the compass targets and cancel quest buttons in the journal

## Description
<!-- Please describe your changes here. -->
Added support for not displaying the compass targets and cancel quest buttons in the journal, code just checks the config file in the new backpack section and will read whether the user want's the items disabled. I think in the future the journal visibility config could also be moved to this section as well as some other config items.
### Related Issues
<!-- Issue number if existing. -->
Closes #2049 

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
