### PR TITLE
Revert "make use of Spigot library loading"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
     </dependency>
 
     <!-- from codemc repository -->
-    <!-- BStats cannot be provided by the server, it must be relocated. They have custom code that ensures that. -->
     <dependency>
       <groupId>org.bstats</groupId>
       <artifactId>bstats-bukkit</artifactId>
@@ -307,19 +306,16 @@
       <groupId>net.kyori</groupId>
       <artifactId>adventure-api</artifactId>
       <version>4.11.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.kyori</groupId>
       <artifactId>adventure-platform-bukkit</artifactId>
       <version>4.1.2</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.kyori</groupId>
       <artifactId>adventure-text-serializer-plain</artifactId>
       <version>4.11.0</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- from minecraft repository -->
@@ -380,31 +376,26 @@
           <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20220924</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
@@ -415,13 +406,11 @@
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
       <version>9.2.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
       <version>5.0.1</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- only dependencies from maven central that are for testing -->
@@ -639,8 +628,16 @@
               <artifactSet>
                 <includes>
                   <include>org.bstats</include>
+                  <include>org.apache.maven</include>
+                  <include>org.apache.commons</include>
+                  <include>com.google.guava</include>
+                  <include>commons-io</include>
+                  <include>org.json</include>
+                  <include>net.kyori</include>
                   <include>com.comphenix.packetwrapper</include>
                   <include>io.papermc:paperlib</include>
+                  <include>com.cronutils:cron-utils</include>
+                  <include>com.zaxxer</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -669,12 +666,42 @@
                   <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.org.bstats</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.maven</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.org.apache.maven</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.org.apache.commons
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.google.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.org.json</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.kyori</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.net.kyori</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.comphenix.packetwrapper</pattern>
-                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.comphenix.packetwrapper</shadedPattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.comphenix.packetwrapper
+                  </shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.papermc.lib</pattern>
                   <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.io.papermc.lib</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.cronutils</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.cronutils</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.zaxxer.hikari</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.zaxxer.hikari</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -75,14 +75,4 @@ permissions:
     default: true
   betonquest.language:
     default: true
-libraries:
-  - org.apache.maven:maven-artifact:3.8.6
-  - org.apache.commons:commons-lang3:3.12.0
-  - com.google.guava:guava:31.1-jre
-  - commons-io:commons-io:2.11.0
-  - org.json:json:20220320
-  - net.kyori:adventure-api:4.11.0
-  - net.kyori:adventure-platform-bukkit:4.1.2
-  - net.kyori:adventure-text-serializer-plain:4.11.0
-  - com.cronutils:cron-utils:9.2.0
-  - com.zaxxer:HikariCP:5.0.1
+  


### PR DESCRIPTION
This reverts commit 2ea39270
The reason for this is that there may be version conflicts between libraries. The class loader loads two plugins, that depend on each other, in the same classpath. Even if their libraries don't use the same version. This is a conceptual issue with the libraries feature and can break the plugins.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
