### PR TITLE
Fix NPCGlow throw an error when new npc is spawn.

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/NPCGlow.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/NPCGlow.java
@@ -149,7 +149,11 @@ public final class NPCGlow extends BukkitRunnable implements Listener {
         if (!npc.isSpawned()) {
             return;
         }
+
         final Integer npcID = npc.getId();
+        if(!npcConditions.containsKey(npcID)){
+            return;
+        }
 
         final Entity entity = npc.getEntity();
         final Set<ConditionID> conditions = npcConditions.get(npcID);


### PR DESCRIPTION
> [12:48:15] [Server thread/ERROR]: Could not pass event NPCSpawnEvent to BetonQuest v2.0.0-DEV-476
java.lang.NullPointerException: Cannot invoke "java.util.Set.isEmpty()" because "conditions" is null
	at org.betonquest.betonquest.compatibility.protocollib.NPCGlow.applyVisibility(NPCGlow.java:157) ~[BetonQuest.jar:?]
	at org.betonquest.betonquest.compatibility.protocollib.NPCGlow.lambda$applyGlow$2(NPCGlow.java:199) ~[BetonQuest.jar:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:?]
	at java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290) ~[?:?]
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?]
	at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:686) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233) ~[?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:765) ~[?:?]
	at org.betonquest.betonquest.compatibility.protocollib.NPCGlow.applyGlow(NPCGlow.java:199) ~[BetonQuest.jar:?]
	at org.betonquest.betonquest.compatibility.protocollib.NPCGlow.onNPCSpawn(NPCGlow.java:303) ~[BetonQuest.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor68.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-273]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at net.citizensnpcs.npc.CitizensNPC$1.accept(CitizensNPC.java:335) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.npc.CitizensNPC$1.accept(CitizensNPC.java:313) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.npc.CitizensNPC.spawn(CitizensNPC.java:394) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.commands.NPCCommands.create(NPCCommands.java:708) ~[Citizens-2.0.30-b2793.jar:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:577) ~[?:?]
	at net.citizensnpcs.api.command.CommandManager.executeCommand(CommandManager.java:187) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.api.command.CommandManager.execute(CommandManager.java:97) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.api.command.CommandManager.executeSafe(CommandManager.java:228) ~[Citizens-2.0.30-b2793.jar:?]
	at net.citizensnpcs.Citizens.onCommand(Citizens.java:345) ~[Citizens-2.0.30-b2793.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:155) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R1.CraftServer.dispatchCommand(CraftServer.java:916) ~[paper-1.19.2.jar:git-Paper-273]
	at org.bukkit.craftbukkit.v1_19_R1.command.BukkitCommandWrapper.run(BukkitCommandWrapper.java:64) ~[paper-1.19.2.jar:git-Paper-273]
	at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:264) ~[paper-1.19.2.jar:?]
	at net.minecraft.commands.Commands.performCommand(Commands.java:305) ~[?:?]
	at net.minecraft.commands.Commands.performCommand(Commands.java:289) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performChatCommand(ServerGamePacketListenerImpl.java:2294) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$20(ServerGamePacketListenerImpl.java:2248) ~[?:?]
	at net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:59) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1341) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1318) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1311) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1289) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1177) ~[paper-1.19.2.jar:git-Paper-273]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305) ~[paper-1.19.2.jar:git-Paper-273]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
