### PR TITLE
fixed inaccurate location variable decimal rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - packet chat interceptor does not catch action bar anymore
 - time event does not work with floating point values
 - global variable recursive resolution cross packages
+- inaccurate location variable decimal rounding
 - `location` objective - is now more robust if the player changes a world
 - `brew` objective - now counts newly brewed potions even if there were already some potions of the desired type in
 - `chestput` objective - did now work with double chests

--- a/src/main/java/org/betonquest/betonquest/variables/LocationVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/LocationVariable.java
@@ -78,7 +78,7 @@ public class LocationVariable extends Variable {
 
         if (decimalPlaces == 0) {
             final DecimalFormat formatter = new DecimalFormat("#");
-            formatter.setRoundingMode(RoundingMode.DOWN);
+            formatter.setRoundingMode(RoundingMode.FLOOR);
             return String.format(Locale.US, format,
                     formatter.format(posX),
                     formatter.format(posY),


### PR DESCRIPTION
<!-- Please describe your changes here. -->
We already fixed this 2 years ago, but we did not fixed it, because we did used the wrong rounding mode for negative locations

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
