### PR TITLE
`experience` objective event and condition where reworked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - HolographicDisplays updated to 3.0.0
 - Added staticness indicator to variables that can be executed without a direct player connection
 - written book quest items can now be read
-- `experience` objective event and condition where reworked
+- `experience` objective event and condition were reworked
   - condition and objective do not support raw experience anymore
   - all allow decimal level and variables now
 - Things that are also changed in 1.12.X:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - HolographicDisplays updated to 3.0.0
 - Added staticness indicator to variables that can be executed without a direct player connection
 - written book quest items can now be read
+- `experience` objective event and condition where reworked
+  - condition and objective do not support raw experience anymore
+  - all allow decimal level and variables now
 - Things that are also changed in 1.12.X:
     - math variable now allows rounding output with the ~ operator
     - French translation has been updated

--- a/docs/Documentation/Conditions-List.md
+++ b/docs/Documentation/Conditions-List.md
@@ -127,7 +127,7 @@ with the name of the required entity. Replace all spaces with `_` here. You can 
 
 This condition is met when the player has the specified amount of experience levels.
 You can also define decimal numbers, for example `experience 1.5` will be met when the player has 1.5 or more experience levels.
-If you want to check for an absolute amount of experience points by converting it to levels.
+If you want to check for an absolute amount of experience points you can convert it to decimal levels.
 
 !!! example
     ```YAML

--- a/docs/Documentation/Conditions-List.md
+++ b/docs/Documentation/Conditions-List.md
@@ -125,11 +125,14 @@ with the name of the required entity. Replace all spaces with `_` here. You can 
 
 ## Experience: `experience`
 
-This condition is met when the player has the specified amount of experience points. You can check for whole levels by adding the `level` argument.
+This condition is met when the player has the specified amount of experience levels.
+You can also define decimal numbers, for example `experience 1.5` will be met when the player has 1.5 or more experience levels.
+If you want to check for an absolute amount of experience points by converting it to levels.
 
 !!! example
     ```YAML
-    experience 30 level
+    experience 30
+    experience 5.5
     ```
 
 ## Facing direction: `facing`

--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -664,7 +664,7 @@ events:
 ## Give experience: `experience`
 
 Gives the specified amount of experience points to the player. You can give levels by adding the `level` argument.
-You can also define decimal numbers for level, for example `experience 1.5 level` will give 1 level and half.
+You can also define decimal numbers when giving levels, for example `experience 1.5 level` will give 1 level and half.
 
 !!! example
     ```YAML

--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -663,11 +663,14 @@ events:
     
 ## Give experience: `experience`
 
-Gives the specified amount of experience points to the player. You can give whole levels by adding the `level` argument.
+Gives the specified amount of experience points to the player. You can give levels by adding the `level` argument.
+You can also define decimal numbers for level, for example `experience 1.5 level` will give 1 level and half.
 
 !!! example
     ```YAML
+    experience 15
     experience 4 level
+    experience 4.5 level
     ```
 ## Burn: `burn`
 

--- a/docs/Documentation/Migration.md
+++ b/docs/Documentation/Migration.md
@@ -16,6 +16,7 @@ Skip to the first version that is newer than the version that you're migrating f
 - [2.0.0-DEV-238 - Package Structure Rework](#200-dev-238-package-structure-rework)
 - [2.0.0-DEV-337 - Event Scheduling Rework](#200-dev-337-event-scheduling-rework)
 - [2.0.0-DEV-450 - Package section](#200-dev-450-package-section)
+- [2.0.0-DEV-485 - Experience changes](#200-dev-485-experience-changes)
 
 ### 2.0.0-DEV-98 - RPGMenu Merge
 
@@ -150,3 +151,10 @@ All existing RPGMenu users must update their RPGMenu config file. Simply rename 
             package:
               enabled: false
             ```
+
+### 2.0.0-DEV-485 - Experience changes
+
+- The `experience` event objective and condition has been changed regarding levels. 
+  The condition and the objective do not now allow raw experience anymore, only levels.
+  But for now on they will support decimal numbers, so you can use `experience 1.5` to check for half a level.
+  With that you can convert raw experience to levels.

--- a/docs/Documentation/Migration.md
+++ b/docs/Documentation/Migration.md
@@ -154,7 +154,11 @@ All existing RPGMenu users must update their RPGMenu config file. Simply rename 
 
 ### 2.0.0-DEV-485 - Experience changes
 
-- The `experience` event objective and condition has been changed regarding levels. 
-  The condition and the objective do not now allow raw experience anymore, only levels.
-  But for now on they will support decimal numbers, so you can use `experience 1.5` to check for half a level.
-  With that you can convert raw experience to levels.
+Due to a misuse, all code regarding player experience (`experience` event, condition and objective) has been changed.
+It is not possible to obtain the amount of experience points a player has, only their level can be obtained.  
+If you used these you might have to adjust the configured values because the behaviour changed as follows:
+
+- The `experience` objective and condition do not allow raw experience anymore. Only levels are supported from now on.
+- The `experience` objective, condition and event now supports decimal numbers.  
+  For example, you can use `experience 1.5` to check for one and a half level.  
+  You can convert raw experience points to levels, using such decimal numbers.

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -159,8 +159,8 @@ with a colon. If you need to check for multiple enchantments you can add a list 
 This objective can be completed by reaching the specified amount of experience levels.
 You can also define decimal numbers, for example `experience 1.5` will complete when the player reaches 1.5 experience levels or more.
 If you want to check for an absolute amount of experience points by converting it to levels.
-The objective is checked every time the player gets experience by a natural way, such as killing mobs or mining blocks
-or if the player reaches a new level, also by a command or other plugin.
+The objective is checked every time the player gets experience naturally, such as killing mobs or mining blocks.
+Additionally, it is checked if the player reaches a new level in any way (vanilla level up, commands or other plugins).
 You can use the `notify` keyword to display a message each
 time the player advances the objective, optionally with the notification interval after a colon.
 

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -161,8 +161,10 @@ You can also define decimal numbers, for example `experience 1.5` will complete 
 If you want to check for an absolute amount of experience points you can convert it to decimal levels.
 The objective is checked every time the player gets experience naturally, such as killing mobs or mining blocks.
 Additionally, it is checked if the player reaches a new level in any way (vanilla level up, commands or other plugins).
-You can use the `notify` keyword to display a message each
-time the player advances the objective, optionally with the notification interval after a colon.
+The objective will also imminently complete if the player already has the experience level or more.
+And it will also be completed if the player joins the game with the specified amount of experience levels or more.
+You can use the `notify` keyword to display a message each time the player advances the objective,
+optionally with the notification interval after a colon.
 
 This objective has three properties: `amount`, `left` and `total`. `amount` is the current amount of experience levels,
 `left` is the amount of experience levels still needed and `total` is the amount of experience required.

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -156,13 +156,16 @@ with a colon. If you need to check for multiple enchantments you can add a list 
 
 ## Experience: `experience`
 
-This objective can by completed by reaching specified amount of experience points. You can check for whole levels by
-adding the `level` argument. The conditions are checked when the player levels up, so if they are not met the first
-time, the player will have to meet them and levelup again. You can use the `notify` keyword to display a message each
+This objective can by completed by reaching specified amount of experience levels.
+You can also define decimal numbers, for example `experience 1.5` will complete when the player reaches 1.5 experience levels or more.
+If you want to check for an absolute amount of experience points by converting it to levels.
+The objective is checked every time the player gets experience by a natural way, such as killing mobs or mining blocks
+or if the player reaches a new level, also by a command or other plugin.
+You can use the `notify` keyword to display a message each
 time the player advances the objective, optionally with the notification interval after a colon.
 
-This objective has three properties: `amount`, `left` and `total`. `amount` is the current amount of experience,
-`left` is the amount of experience still needed and `total` is the amount of experience required.
+This objective has three properties: `amount`, `left` and `total`. `amount` is the current amount of experience levels,
+`left` is the amount of experience levels still needed and `total` is the amount of experience required.
 
 !!! example
     ```YAML

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -158,7 +158,7 @@ with a colon. If you need to check for multiple enchantments you can add a list 
 
 This objective can be completed by reaching the specified amount of experience levels.
 You can also define decimal numbers, for example `experience 1.5` will complete when the player reaches 1.5 experience levels or more.
-If you want to check for an absolute amount of experience points by converting it to levels.
+If you want to check for an absolute amount of experience points you can convert it to decimal levels.
 The objective is checked every time the player gets experience naturally, such as killing mobs or mining blocks.
 Additionally, it is checked if the player reaches a new level in any way (vanilla level up, commands or other plugins).
 You can use the `notify` keyword to display a message each

--- a/docs/Documentation/Objectives-List.md
+++ b/docs/Documentation/Objectives-List.md
@@ -156,7 +156,7 @@ with a colon. If you need to check for multiple enchantments you can add a list 
 
 ## Experience: `experience`
 
-This objective can by completed by reaching specified amount of experience levels.
+This objective can be completed by reaching the specified amount of experience levels.
 You can also define decimal numbers, for example `experience 1.5` will complete when the player reaches 1.5 experience levels or more.
 If you want to check for an absolute amount of experience points by converting it to levels.
 The objective is checked every time the player gets experience by a natural way, such as killing mobs or mining blocks

--- a/src/main/java/org/betonquest/betonquest/conditions/ExperienceCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/ExperienceCondition.java
@@ -3,35 +3,35 @@ package org.betonquest.betonquest.conditions;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
-import org.bukkit.entity.Player;
 
 /**
- * Requires the player to have specified level of experience (or more)
+ * Requires the player to have specified level of experience or more.
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class ExperienceCondition extends Condition {
 
+    /**
+     * The experience level the player needs to get.
+     * The decimal part of the number is a percentage of the next level.
+     */
     private final VariableNumber amount;
-    private final boolean checkForLevel;
 
     public ExperienceCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         this.amount = instruction.getVarNum();
-        this.checkForLevel = instruction.hasArgument("level");
     }
 
     @Override
     protected Boolean execute(final Profile profile) throws QuestRuntimeException {
-        final Player player = profile.getOnlineProfile().get().getPlayer();
-        final int amount = this.amount.getInt(profile);
-        if (checkForLevel) {
-            return player.getLevel() >= amount;
-        } else {
-            return player.getTotalExperience() >= amount;
-        }
+        final double amount = this.amount.getDouble(profile);
+        return profile.getOnlineProfile()
+                .map(OnlineProfile::getPlayer)
+                .map(player -> player.getLevel() + player.getExp() >= amount)
+                .orElse(false);
     }
 
 }

--- a/src/main/java/org/betonquest/betonquest/events/ExperienceEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/ExperienceEvent.java
@@ -19,12 +19,12 @@ public class ExperienceEvent extends QuestEvent {
      * The decimal part of the number is a percentage of the next level.
      */
     private final VariableNumber amount;
-    private final boolean checkForLevel;
+    private final boolean useLevels;
 
     public ExperienceEvent(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         this.amount = instruction.getVarNum();
-        this.checkForLevel = instruction.hasArgument("level");
+        this.useLevels = instruction.hasArgument("level");
     }
 
     @Override
@@ -34,7 +34,7 @@ public class ExperienceEvent extends QuestEvent {
         profile.getOnlineProfile()
                 .map(OnlineProfile::getPlayer)
                 .ifPresent(player -> {
-                    if (checkForLevel) {
+                    if (useLevels) {
                         final double current = player.getLevel() + player.getExp();
                         final double amountToAdd = current + amount;
                         player.setLevel((int) amountToAdd);

--- a/src/main/java/org/betonquest/betonquest/objectives/ExperienceObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ExperienceObjective.java
@@ -17,6 +17,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerExpChangeEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLevelChangeEvent;
 
 import java.util.Locale;
@@ -71,6 +72,17 @@ public class ExperienceObjective extends Objective implements Listener {
     }
 
     @Override
+    public void start(final Profile profile) {
+        super.start(profile);
+        profile.getOnlineProfile()
+                .ifPresent(onlineProfile -> {
+                    final Player player = onlineProfile.getPlayer();
+                    final double newAmount = player.getLevel() + player.getExp();
+                    onExperienceChange(onlineProfile, newAmount, false);
+                });
+    }
+
+    @Override
     public String getDefaultDataInstruction() {
         return "";
     }
@@ -116,5 +128,13 @@ public class ExperienceObjective extends Objective implements Listener {
             final double newAmount = player.getLevel() + player.getExp();
             onExperienceChange(PlayerConverter.getID(player), newAmount, false);
         });
+    }
+
+    @EventHandler
+    public void onPlayerJoin(final PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final double newAmount = player.getLevel() + player.getExp();
+        onExperienceChange(onlineProfile, newAmount, false);
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -33,6 +33,7 @@ pl:
   items_to_pickup: '&2Pozostalo {1} przedmiotow do podniesienia'
   items_to_smelt: '&2{1} items left to smelt' # TODO: missing translation
   items_to_craft: '&2{1} items left to craft' # TODO: missing translation
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cNie mozesz rozmawiac w trakcie walki.'
   quest_canceled: '&2Zadanie {1}&2 anulowane!'
   cancel: '&cAnuluj zadanie'
@@ -90,6 +91,7 @@ en:
   items_to_pickup: '&2{1} items left to pickup'
   items_to_smelt: '&2{1} items left to smelt'
   items_to_craft: '&2{1} items left to craft'
+  level_to_gain: '&2{1} level left to gain'
   busy: '&cYou can''t talk while fighting.'
   quest_canceled: '&2Quest {1}&2 canceled!'
   cancel: '&cCancel the quest'
@@ -108,7 +110,6 @@ en:
   minutes_singular: 'minute'
   seconds: 'seconds'
   seconds_singular: 'second'
-
   password: 'password: '
   condition_variable_met: 'yes'
   condition_variable_not_met: 'no'
@@ -148,6 +149,7 @@ de:
   items_to_pickup: '&2Noch {1} Dinge einzusammeln'
   items_to_smelt: '&2Noch {1} Dinge zu schmelzen'
   items_to_craft: '&2Noch {1} Dinge herzustellen'
+  level_to_gain: '&2Noch {1} Level zu sammeln'
   busy: '&cDu kannst dich nicht während eines Kampfes unterhalten.'
   quest_canceled: '&2Quest {1}&2 abgebrochen!'
   cancel: '&cQuest abbrechen'
@@ -205,6 +207,7 @@ fr:
   items_to_pickup: '&2{1} objets restant à ramasser'
   items_to_smelt: '&2{1} objets restant à cuire'
   items_to_craft: '&2{1} objets restant à fabriquer'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cVous ne pouvez pas parler pendant un combat.'
   quest_canceled: '&2Quête {1}&2 annulée!'
   cancel: '&cAnnuler cette quête'
@@ -262,6 +265,7 @@ cn:
   items_to_pickup: '&2{1} 个物品需要拾取'
   items_to_smelt: '&2{1} 个物品需要熔炼'
   items_to_craft: '&2{1} 个物品需要制作'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&c你还在战斗中'
   quest_canceled: '&2任务 {1}&2 已取消!'
   cancel: '&c取消任务'
@@ -319,6 +323,7 @@ es:
   items_to_pickup: '&2{1} objetos restantes para recoger'
   items_to_smelt: '&2{1} objetos restantes para fundir'
   items_to_craft: '&2{1} objetos restantes para crear'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cNo puedes hablar mientras luchas!'
   quest_canceled: '&2Mision {1}&2 cancelada!'
   cancel: '&cCancelar la mision'
@@ -376,6 +381,7 @@ nl:
   items_to_pickup: '&2{1} items over om op te pakken'
   items_to_smelt: '&2{1} items over om te smelten'
   items_to_craft: '&2{1} items over om te craften'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cJe kunt niet praten tijdens het vechten.'
   quest_canceled: '&2Quest {1}&2 geannuleerd!'
   cancel: '&cAnnuleer de quest'
@@ -433,6 +439,7 @@ it:
   items_to_pickup: '&2{1} oggetti rimasti da raccogliere'
   items_to_smelt: '&2{1} oggetti rimasti da cuocere'
   items_to_craft: '&2{1} oggetti da creare'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cNon puoi parlare mentre stai combattendo.'
   quest_canceled: '&2Quest {1}&2 annullata!'
   cancel: '&cAnnulla quest'
@@ -490,6 +497,7 @@ hu:
   items_to_pickup: '&2{1} items left to pickup' # TODO: missing translation
   items_to_smelt: '&2{1} items left to smelt' # TODO: missing translation
   items_to_craft: '&2{1} items left to craft' # TODO: missing translation
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cNem harcolhat harc közben.'
   quest_canceled: '&2Küldetés {1}&2 törölve!'
   cancel: '&cTörölje a küldetést'
@@ -547,6 +555,7 @@ vi:
   items_to_pickup: '&2{1} vật phẩm cần nhặt lên còn lại'
   items_to_smelt: '&2{1} vật phẩm cần nung chảy còn lại'
   items_to_craft: '&2{1} vật phẩm cần chế tạo còn lại'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cBạn không được nói khi đang đánh nhau.'
   quest_canceled: '&2Nhiệm vụ {1}&2 đã bị hủy!'
   cancel: '&cHủy nhiệm vụ'
@@ -603,6 +612,7 @@ pt-br:
   items_to_pickup: '&2{1} itens restantes para pegar'
   items_to_smelt: '&2{1} itens restantes para derreter'
   items_to_craft: '&2{1} itens restantes para construir'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cVocê não pode conversar enquanto luta.'
   quest_canceled: '&2Missão {1}&2 cancelada!'
   cancel: '&cCancelar a Missão'
@@ -656,6 +666,7 @@ pt-pt:
   items_to_pickup: '&2{1} itens restantes para coletar'
   items_to_smelt: '&2{1} itens restantes para fundir'
   items_to_craft: '&2{1} items restantes para criar'
+  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
   busy: '&cNão podes falar enquanto lutas!'
   quest_canceled: '&2Missão {1}&2 cancelada!'
   cancel: '&cCancelar a missão'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -33,7 +33,7 @@ pl:
   items_to_pickup: '&2Pozostalo {1} przedmiotow do podniesienia'
   items_to_smelt: '&2{1} items left to smelt' # TODO: missing translation
   items_to_craft: '&2{1} items left to craft' # TODO: missing translation
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cNie mozesz rozmawiac w trakcie walki.'
   quest_canceled: '&2Zadanie {1}&2 anulowane!'
   cancel: '&cAnuluj zadanie'
@@ -91,7 +91,7 @@ en:
   items_to_pickup: '&2{1} items left to pickup'
   items_to_smelt: '&2{1} items left to smelt'
   items_to_craft: '&2{1} items left to craft'
-  level_to_gain: '&2{1} level left to gain'
+  level_to_gain: '&2{1} levels left to gain'
   busy: '&cYou can''t talk while fighting.'
   quest_canceled: '&2Quest {1}&2 canceled!'
   cancel: '&cCancel the quest'
@@ -207,7 +207,7 @@ fr:
   items_to_pickup: '&2{1} objets restant à ramasser'
   items_to_smelt: '&2{1} objets restant à cuire'
   items_to_craft: '&2{1} objets restant à fabriquer'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cVous ne pouvez pas parler pendant un combat.'
   quest_canceled: '&2Quête {1}&2 annulée!'
   cancel: '&cAnnuler cette quête'
@@ -265,7 +265,7 @@ cn:
   items_to_pickup: '&2{1} 个物品需要拾取'
   items_to_smelt: '&2{1} 个物品需要熔炼'
   items_to_craft: '&2{1} 个物品需要制作'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&c你还在战斗中'
   quest_canceled: '&2任务 {1}&2 已取消!'
   cancel: '&c取消任务'
@@ -323,7 +323,7 @@ es:
   items_to_pickup: '&2{1} objetos restantes para recoger'
   items_to_smelt: '&2{1} objetos restantes para fundir'
   items_to_craft: '&2{1} objetos restantes para crear'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cNo puedes hablar mientras luchas!'
   quest_canceled: '&2Mision {1}&2 cancelada!'
   cancel: '&cCancelar la mision'
@@ -381,7 +381,7 @@ nl:
   items_to_pickup: '&2{1} items over om op te pakken'
   items_to_smelt: '&2{1} items over om te smelten'
   items_to_craft: '&2{1} items over om te craften'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cJe kunt niet praten tijdens het vechten.'
   quest_canceled: '&2Quest {1}&2 geannuleerd!'
   cancel: '&cAnnuleer de quest'
@@ -439,7 +439,7 @@ it:
   items_to_pickup: '&2{1} oggetti rimasti da raccogliere'
   items_to_smelt: '&2{1} oggetti rimasti da cuocere'
   items_to_craft: '&2{1} oggetti da creare'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cNon puoi parlare mentre stai combattendo.'
   quest_canceled: '&2Quest {1}&2 annullata!'
   cancel: '&cAnnulla quest'
@@ -497,7 +497,7 @@ hu:
   items_to_pickup: '&2{1} items left to pickup' # TODO: missing translation
   items_to_smelt: '&2{1} items left to smelt' # TODO: missing translation
   items_to_craft: '&2{1} items left to craft' # TODO: missing translation
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cNem harcolhat harc közben.'
   quest_canceled: '&2Küldetés {1}&2 törölve!'
   cancel: '&cTörölje a küldetést'
@@ -555,7 +555,7 @@ vi:
   items_to_pickup: '&2{1} vật phẩm cần nhặt lên còn lại'
   items_to_smelt: '&2{1} vật phẩm cần nung chảy còn lại'
   items_to_craft: '&2{1} vật phẩm cần chế tạo còn lại'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cBạn không được nói khi đang đánh nhau.'
   quest_canceled: '&2Nhiệm vụ {1}&2 đã bị hủy!'
   cancel: '&cHủy nhiệm vụ'
@@ -612,7 +612,7 @@ pt-br:
   items_to_pickup: '&2{1} itens restantes para pegar'
   items_to_smelt: '&2{1} itens restantes para derreter'
   items_to_craft: '&2{1} itens restantes para construir'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cVocê não pode conversar enquanto luta.'
   quest_canceled: '&2Missão {1}&2 cancelada!'
   cancel: '&cCancelar a Missão'
@@ -666,7 +666,7 @@ pt-pt:
   items_to_pickup: '&2{1} itens restantes para coletar'
   items_to_smelt: '&2{1} itens restantes para fundir'
   items_to_craft: '&2{1} items restantes para criar'
-  level_to_gain: '&2{1} level left to gain' # TODO: missing translation
+  level_to_gain: '&2{1} levels left to gain' # TODO: missing translation
   busy: '&cNão podes falar enquanto lutas!'
   quest_canceled: '&2Missão {1}&2 cancelada!'
   cancel: '&cCancelar a missão'


### PR DESCRIPTION
condition and objective do not support raw experience anymore all allow decimal level and variables now

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
