### PR TITLE
Fix building on Java 19 by updating all maven plugins that we use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -818,7 +818,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.projectlombok</groupId>
@@ -828,17 +828,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.3.1-SNAPSHOT</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.17.0</version>
+          <version>3.19.0</version>
           <dependencies>
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
@@ -862,7 +862,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.5.2.0</version>
+          <version>4.7.3.0</version>
           <configuration>
             <excludeFilterFile>config/spotbugs-exclude.xml</excludeFilterFile>
             <effort>max</effort>
@@ -872,7 +872,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.0</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -894,12 +894,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -909,7 +909,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
           <configuration>
             <!-- This is disabled because Java 16 has a stricter police for missing comments which the project does not meet yet. -->
             <failOnWarnings>false</failOnWarnings>
@@ -920,12 +920,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M7</version>
           <configuration>
             <reuseForks>false</reuseForks>
             <forkCount>0.5C</forkCount>
@@ -935,17 +935,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.9.1</version>
+          <version>4.0.0-M4</version>
         </plugin>
         <plugin>
           <groupId>org.ec4j.maven</groupId>
@@ -955,12 +955,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -970,7 +970,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M7</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -980,12 +980,12 @@
         <plugin>
           <groupId>org.pitest</groupId>
           <artifactId>pitest-maven</artifactId>
-          <version>1.7.3</version>
+          <version>1.10.3</version>
           <dependencies>
             <dependency>
               <groupId>org.pitest</groupId>
               <artifactId>pitest-junit5-plugin</artifactId>
-              <version>0.16</version>
+              <version>1.1.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
The broken plugin was `com.github.spotbugs:spotbugs-maven-plugin`, but when I'm updating maven plugins then I can just do all of them.

I did not touch any dependencies or tool versions, so that the build itself doesn't change in any way.

The error looks like this, just that the first exception is repeated (for different classes) thousands of times (I had to increase my line buffer in my terminal from 10,000 to 100,000 lines to be able to see the top):
```log
     [java]   Couldn't get class info for java/util/Set
     [java]     java.lang.IllegalArgumentException: Unsupported class file major version 63
     [java]       At org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
     [java]       At org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
     [java]       At org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
     [java]       At edu.umd.cs.findbugs.asm.FBClassReader.<init>(FBClassReader.java:35)
     [java]       At edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:48)
     [java]       At edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:34)
     [java]       At edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java]       At edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:75)
     [java]       At edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:38)
     [java]       At edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java]       At edu.umd.cs.findbugs.ba.XFactory.getXClass(XFactory.java:693)
     [java]       At edu.umd.cs.findbugs.ba.AnalysisContext.setAppClassList(AnalysisContext.java:975)
     [java]       At edu.umd.cs.findbugs.FindBugs2.setAppClassList(FindBugs2.java:909)
     [java]       At edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:252)
     [java]       At edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:395)
     [java]       At edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1231)
     [java]   Unable to construct type qualifier checker javax/annotation/Nonnull$Checker
     [java]     java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
     [java]       At java.base/java.lang.System.setSecurityManager(System.java:425)
     [java]       At edu.umd.cs.findbugs.ba.jsr305.TypeQualifierValue.<init>(TypeQualifierValue.java:157)
     [java]       At edu.umd.cs.findbugs.ba.jsr305.TypeQualifierValue.getValue(TypeQualifierValue.java:298)
     [java]       At edu.umd.cs.findbugs.ba.jsr305.TypeQualifierValue.getValue(TypeQualifierValue.java:306)
     [java]       At edu.umd.cs.findbugs.ba.npe.TypeQualifierNullnessAnnotationDatabase.<init>(TypeQualifierNullnessAnnotationDatabase.java:70)
     [java]       At edu.umd.cs.findbugs.ba.AnalysisContext.getNullnessAnnotationDatabase(AnalysisContext.java:1055)
     [java]       At edu.umd.cs.findbugs.ba.AnalysisContext.updateDatabases(AnalysisContext.java:1008)
     [java]       At edu.umd.cs.findbugs.FindBugs2.analyzeApplication(FindBugs2.java:1061)
     [java]       At edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:309)
     [java]       At edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:395)
     [java]       At edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1231)
     [java] Exception in thread "main" java.lang.IllegalArgumentException: Unsupported class file major version 63
     [java]     at org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
     [java]     at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
     [java]     at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
     [java]     at edu.umd.cs.findbugs.asm.FBClassReader.<init>(FBClassReader.java:35)
     [java]     at edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:48)
     [java]     at edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:34)
     [java]     at edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java]     at edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:75)
     [java]     at edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:38)
     [java]     at edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java]     at edu.umd.cs.findbugs.ba.XFactory.getXClass(XFactory.java:693)
     [java]     at edu.umd.cs.findbugs.ba.AnalysisContext.setAppClassList(AnalysisContext.java:975)
     [java]     at edu.umd.cs.findbugs.FindBugs2.setAppClassList(FindBugs2.java:909)
     [java]     at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:252)
     [java]     at edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:395)
     [java]     at edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1231)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:55 min
[INFO] Finished at: 2022-12-22T10:07:32+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.5.2.0:spotbugs (spotbugs) on project betonquest: Execution spotbugs of goal com.github.spotbugs:spotbugs-maven-plugin:4.5.2.0:spotbugs failed: Java returned: 1 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
