### PR TITLE
Correctly handle failure of parsing a double as value of a VariableNumber

### DIFF
--- a/src/main/java/org/betonquest/betonquest/VariableNumber.java
+++ b/src/main/java/org/betonquest/betonquest/VariableNumber.java
@@ -10,34 +10,34 @@ import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 /**
  * Represents a number which might also be a variable.
  */
-@SuppressWarnings("PMD.CommentRequired")
 @CustomLog
 public class VariableNumber {
 
+    /**
+     * The constant value of this variable number if no variable was set.
+     */
     private final double number;
-    private Variable variable;
 
     /**
-     * Parses the string as a number or saves it as a variable if it's not a
-     * number.
+     * The variable to parse to get the value of the variable number.
+     * If {@code null} then {@link #number} will be used.
+     */
+    private final Variable variable;
+
+    /**
+     * Parses the string as a variable or as a number if it's not a variable.
      *
      * @param packName the package in which the variable is defined
-     * @param variable the string to parse
+     * @param tmp the string to parse
      * @throws InstructionParseException If the variable could not be created.
      */
-    public VariableNumber(final String packName, final String variable) throws InstructionParseException {
-        if (variable.length() > 2 && variable.charAt(0) == '%' && variable.endsWith("%")) {
-            try {
-                this.variable = BetonQuest.createVariable(Config.getPackages().get(packName), variable);
-            } catch (final InstructionParseException e) {
-                throw new InstructionParseException("Could not create variable: " + e.getMessage(), e);
-            }
-            if (this.variable == null) {
-                throw new InstructionParseException("Could not create variable");
-            }
-            number = 0.0;
+    public VariableNumber(final String packName, final String tmp) throws InstructionParseException {
+        if (tmp.length() > 2 && tmp.charAt(0) == '%' && tmp.endsWith("%")) {
+            this.variable = parseAsVariable(packName, tmp);
+            this.number = 0.0;
         } else {
-            number = Double.parseDouble(variable);
+            this.variable = null;
+            this.number = parseAsNumber(tmp);
         }
     }
 
@@ -48,6 +48,7 @@ public class VariableNumber {
      */
     public VariableNumber(final int number) {
         this.number = number;
+        this.variable = null;
     }
 
     /**
@@ -57,6 +58,28 @@ public class VariableNumber {
      */
     public VariableNumber(final double number) {
         this.number = number;
+        this.variable = null;
+    }
+
+    private Variable parseAsVariable(final String packName, final String variable) throws InstructionParseException {
+        final Variable parsed;
+        try {
+            parsed = BetonQuest.createVariable(Config.getPackages().get(packName), variable);
+        } catch (final InstructionParseException e) {
+            throw new InstructionParseException("Could not create variable: " + e.getMessage(), e);
+        }
+        if (parsed == null) {
+            throw new InstructionParseException("Could not create variable");
+        }
+        return parsed;
+    }
+
+    private double parseAsNumber(final String variable) throws InstructionParseException {
+        try {
+            return Double.parseDouble(variable);
+        } catch (NumberFormatException e) {
+            throw new InstructionParseException("Not a number: " + variable, e);
+        }
     }
 
     /**


### PR DESCRIPTION
Print a useful error message instead of this error:
```
[05:08:43 ERROR]: [BetonQuest] This is an exception that should never occur. If you don't know why this occurs please report it to the author.
java.lang.reflect.InvocationTargetException: null
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at org.betonquest.betonquest.BetonQuest.loadData(BetonQuest.java:1120) ~[BetonQuest.jar:?]
        at org.betonquest.betonquest.BetonQuest.reload(BetonQuest.java:1190) ~[BetonQuest.jar:?]
        at org.betonquest.betonquest.commands.QuestCommand.onCommand(QuestCommand.java:286) ~[BetonQuest.jar:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:168) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.dispatchCommand(CraftServer.java:962) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at org.bukkit.craftbukkit.v1_19_R1.command.BukkitCommandWrapper.run(BukkitCommandWrapper.java:64) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:264) ~[purpur-1.19.2.jar:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:313) ~[?:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:297) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.performChatCommand(ServerGamePacketListenerImpl.java:2386) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$21(ServerGamePacketListenerImpl.java:2340) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:59) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1368) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1345) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1338) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1316) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1204) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1858]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NumberFormatException: For input string: "events:foldetpLibrary1"
        at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2054) ~[?:?]
        at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
        at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
        at org.betonquest.betonquest.VariableNumber.<init>(VariableNumber.java:40) ~[BetonQuest.jar:?]
        at org.betonquest.betonquest.Instruction.getVarNum(Instruction.java:172) ~[BetonQuest.jar:?]
        at org.betonquest.betonquest.Instruction.getVarNum(Instruction.java:164) ~[BetonQuest.jar:?]
        at org.betonquest.betonquest.objectives.LocationObjective.<init>(LocationObjective.java:39) ~[BetonQuest.jar:?]
        ... 32 more
```

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
