### PR TITLE
Delete Point Event:  clarification of wording

### DIFF
--- a/docs/Documentation/Events-List.md
+++ b/docs/Documentation/Events-List.md
@@ -129,7 +129,7 @@ Damages the player by specified amount of damage. The only argument is a number 
 
 **persistent**, **static**
 
-Delete the player points in a specified category.
+Clear all player points in a specified category.
 
 !!! example
     ```YAML


### PR DESCRIPTION
Deleting points is confusing and has lead some users to think this can be a specified number of subtracted points from the category. Cleared or removed points and category hopefully adds a little more clarification.


---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
