### PR TITLE
ProtocolLib's based `packet` interceptor was fixed for MC 1.19, now ProtocolLib 5.0.0 is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `pickrandom` event - did not allowed dashes in event names
 - `action` objective - ignored offhand at all
 - Things that are also fixed in 1.12.X:
+    - ProtocolLib's based `packet` interceptor was fixed for MC 1.19, now ProtocolLib 5.0.0 is required
     - parsing of math variable
     - Citizens compatibility for not spawned NPCs
     - NotifyIOs are case-sensitive

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.7.0</version>
+      <version>5.0.0-SNAPSHOT</version>
       <scope>provided</scope>
       <optional>true</optional>
       <exclusions>

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
@@ -32,8 +32,8 @@ public class ProtocolLibIntegrator implements Integrator {
         final Plugin protocolLib = Bukkit.getPluginManager().getPlugin("ProtocolLib");
         final Version protocolLibVersion = new Version(protocolLib.getDescription().getVersion());
         final VersionComparator comparator = new VersionComparator(UpdateStrategy.MAJOR, "SNAPSHOT-b");
-        if (comparator.isOtherNewerThanCurrent(protocolLibVersion, new Version("4.7.1-SNAPSHOT-b531"))) {
-            throw new UnsupportedVersionException(protocolLib, "4.7.1-SNAPSHOT-b531");
+        if (comparator.isOtherNewerThanCurrent(protocolLibVersion, new Version("5.0.0-SNAPSHOT-b610"))) {
+            throw new UnsupportedVersionException(protocolLib, "5.0.0-SNAPSHOT-b610");
         }
         // if Citizens is hooked, start NPCHider
         if (Compatibility.getHooked().contains("Citizens")) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
@@ -1,6 +1,5 @@
 package org.betonquest.betonquest.compatibility.protocollib.conversation;
 
-import com.comphenix.packetwrapper.WrapperPlayServerChat;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.async.AsyncListenerHandler;
@@ -8,6 +7,7 @@ import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -28,7 +28,6 @@ import java.util.List;
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class PacketInterceptor implements Interceptor, Listener {
-
     /**
      * A prefix that marks messages to be ignored by this interceptor.
      * To be invisible if the interceptor was closed before the message was sent the tag is a color code.
@@ -38,7 +37,7 @@ public class PacketInterceptor implements Interceptor, Listener {
 
     protected final Conversation conv;
     protected final Player player;
-    private final List<WrapperPlayServerChat> messages = new ArrayList<>();
+    private final List<PacketContainer> messages;
     private final PacketAdapter packetAdapter;
     private int baseComponentIndex = -1;
 
@@ -46,20 +45,27 @@ public class PacketInterceptor implements Interceptor, Listener {
     public PacketInterceptor(final Conversation conv, final OnlineProfile onlineProfile) {
         this.conv = conv;
         this.player = onlineProfile.getPlayer();
+        this.messages = new ArrayList<>();
 
-        // Intercept Packets
-        packetAdapter = new PacketAdapter(BetonQuest.getInstance(), ListenerPriority.HIGHEST,
-                PacketType.Play.Server.CHAT
-
-        ) {
+        final PacketType[] packets = MinecraftVersion.WILD_UPDATE.atOrAbove()
+                ? new PacketType[]{PacketType.Play.Server.CHAT, PacketType.Play.Server.SYSTEM_CHAT, PacketType.Play.Server.DISGUISED_CHAT}
+                : new PacketType[]{PacketType.Play.Server.CHAT};
+        packetAdapter = new PacketAdapter(BetonQuest.getInstance(), ListenerPriority.HIGHEST, packets) {
             @Override
             public void onPacketSending(final PacketEvent event) {
                 if (!event.getPlayer().equals(player)) {
                     return;
                 }
-
-                if (event.getPacketType().equals(PacketType.Play.Server.CHAT)) {
-                    final PacketContainer packet = event.getPacket();
+                final PacketContainer packet = event.getPacket();
+                final PacketType packetType = packet.getType();
+                if (MinecraftVersion.WILD_UPDATE.atOrAbove()) {
+                    if (packetType.equals(PacketType.Play.Server.SYSTEM_CHAT)) {
+                        final String message = packet.getStrings().read(0);
+                        if (message != null && message.contains("{\"extra\":[{\"text\":\"" + MESSAGE_PASSTHROUGH_TAG + "\"}")) {
+                            return;
+                        }
+                    }
+                } else {
                     if (baseComponentIndex == -1) {
                         if (packet.getModifier().read(1) instanceof BaseComponent[]) {
                             baseComponentIndex = 1;
@@ -71,15 +77,12 @@ public class PacketInterceptor implements Interceptor, Listener {
                     if (components != null && components.length > 0 && ((TextComponent) components[0]).getText().contains(MESSAGE_PASSTHROUGH_TAG)) {
                         return;
                     }
-
-                    final WrapperPlayServerChat chat = new WrapperPlayServerChat(packet);
-                    if (chat.getChatType() == EnumWrappers.ChatType.GAME_INFO) {
+                    if (packet.getChatTypes().read(0) == EnumWrappers.ChatType.GAME_INFO) {
                         return;
                     }
-
-                    event.setCancelled(true);
-                    messages.add(chat);
                 }
+                event.setCancelled(true);
+                messages.add(packet);
             }
         };
 
@@ -108,8 +111,8 @@ public class PacketInterceptor implements Interceptor, Listener {
         ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandler(packetAdapter);
 
         //Send all messages to player
-        for (final WrapperPlayServerChat message : messages) {
-            message.sendPacket(player);
+        for (final PacketContainer message : messages) {
+            ProtocolLibrary.getProtocolManager().sendServerPacket(player, message);
         }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
@@ -23,7 +23,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.plugin.Plugin;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -297,13 +296,7 @@ public class EntityHider implements Listener {
             } else {
                 destroyEntity.getIntegerArrays().write(0, new int[]{entity.getEntityId()});
             }
-
-            // Make the entity disappear
-            try {
-                manager.sendServerPacket(observer.getPlayer(), destroyEntity);
-            } catch (final InvocationTargetException e) {
-                throw new RuntimeException("Cannot send server packet.", e);
-            }
+            manager.sendServerPacket(observer.getPlayer(), destroyEntity);
         }
         return visibleBefore;
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/wrappers/DefaultPacketHandler.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/wrappers/DefaultPacketHandler.java
@@ -6,8 +6,6 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.google.common.base.Objects;
 import org.bukkit.entity.Player;
 
-import java.lang.reflect.InvocationTargetException;
-
 @SuppressWarnings("PMD.CommentRequired")
 public final class DefaultPacketHandler implements PacketHandler {
 
@@ -65,11 +63,7 @@ public final class DefaultPacketHandler implements PacketHandler {
 
     @Override
     public void sendPacket(final Player receiver) {
-        try {
-            ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, getHandle());
-        } catch (final InvocationTargetException e) {
-            throw new UncheckedPacketException("Cannot send packet.", e);
-        }
+        ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, getHandle());
     }
 
     @Override
@@ -79,10 +73,6 @@ public final class DefaultPacketHandler implements PacketHandler {
 
     @Override
     public void receivePacket(final Player sender) {
-        try {
-            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender, getHandle());
-        } catch (final InvocationTargetException | IllegalAccessException e) {
-            throw new UncheckedPacketException("Cannot receive packet.", e);
-        }
+        ProtocolLibrary.getProtocolManager().receiveClientPacket(sender, getHandle());
     }
 }


### PR DESCRIPTION


<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
