### PR TITLE
Replace variables inside NPC name while in conversation

### DIFF
--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.lang3.tuple.Pair;
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.ConversationOptionEvent;
 import org.betonquest.betonquest.api.PlayerConversationEndEvent;
 import org.betonquest.betonquest.api.PlayerConversationStartEvent;
@@ -207,7 +208,11 @@ public class Conversation implements Listener {
             text = text.replace(variable, plugin.getVariableValue(data.getPackName(), variable, onlineProfile));
         }
         // print option to the player
-        inOut.setNpcResponse(data.getQuester(language), text);
+        String npcName = data.getQuester(language);
+        for (final String variable : BetonQuest.resolveVariables(npcName)) {
+            npcName = npcName.replace(variable, plugin.getVariableValue(data.getPackName(), variable, onlineProfile));
+        }
+        inOut.setNpcResponse(npcName, text);
 
         new NPCEventRunner(option).runTask(BetonQuest.getInstance());
     }

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -6,7 +6,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.lang3.tuple.Pair;
 import org.betonquest.betonquest.BetonQuest;
-import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.ConversationOptionEvent;
 import org.betonquest.betonquest.api.PlayerConversationEndEvent;
 import org.betonquest.betonquest.api.PlayerConversationStartEvent;


### PR DESCRIPTION
<!-- Please describe your changes here. -->
This PR adds feature which replaces all variables in NPC names. So we can declare e.g. PAPI placeholder in quester name such as:
```yaml
conversations:
  Farell:
    quester: "%ph.oraxen_farell_avatar%"
    first: "firstGreeting"
```
I've tested it and it works just fine replacing variable above which was target of this PR :+1: 

---

### Related Issues
<!-- Issue number if existing. -->
None

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
