### PR TITLE
updated links reffering to 2.0.0-DEV instead of DEV

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
         Please make sure you use the latest version.
         Also ensure that our problem hasn't already been reported.
       options:
-        - label: "I use the latest release or dev-build. I also checked that this problem hasn't already been fixed in a newer [dev-build](https://dev.betonquest.org/)."
+        - label: "I use the latest release or dev-build. I also checked that this problem hasn't already been fixed in a newer [dev-build](https://docs.betonquest.org/DEV/Downloads/)."
           required: true
         - label: "There are no open or closed issues that are related to my problem."
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,19 +7,19 @@
 Closes #XXXX
 
 ### Requirements
-- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).
+- [ ] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).
 
 ### Reviewer's checklist
 <!-- DON'T DO ANYTHING HERE -->
 <!-- This is a checklist for the reviewers, and will be checked by them! -->
 Did the contributor...
 - [ ]  ... test their changes?
-- [ ]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
-- [ ]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
-- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
+- [ ]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
+- [ ]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
+- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
 - [ ]  ... solve all TODOs?
 - [ ]  ... remove any commented out code?
-- [ ]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
+- [ ]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
 - [ ]  ... clean the commit history?
 
 Check if the build pipeline succeeded for this PR!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://docs.betonquest.org/2.0.0-DEV/"><img src="https://github.com/BetonQuest/BetonQuest/blob/main/docs/_media/brand/Logo/LogoChainless1K.png?raw=true" alt="BetonQuest-Logo"/></a>
+  <a href="https://docs.betonquest.org/DEV/"><img src="https://github.com/BetonQuest/BetonQuest/blob/main/docs/_media/brand/Logo/LogoChainless1K.png?raw=true" alt="BetonQuest-Logo"/></a>
   <br>
   <a href="https://bstats.org/plugin/bukkit/BetonQuest/551/" title="See how many servers run this plugin.">
       <img src="https://img.shields.io/bstats/servers/551?style=plastic"/>
@@ -22,8 +22,8 @@
   <hr/>
       <p>BetonQuest is an advanced and powerful quest plugin. It offers RPG-style conversations with NPCs and a very flexible quest system.</p>
   <br>
-  <a href="https://docs.betonquest.org/2.0.0-DEV/">Website</a> |  
-  <a href="https://docs.betonquest.org/2.0.0-DEV/API/Overview/">API Documentation</a> | 
-  <a href="https://docs.betonquest.org/2.0.0-DEV/Participate/Overview/">Contributing Documentation</a> |  
+  <a href="https://docs.betonquest.org/DEV/">Website</a> |  
+  <a href="https://docs.betonquest.org/DEV/API/Overview/">API Documentation</a> | 
+  <a href="https://docs.betonquest.org/DEV/Participate/Overview/">Contributing Documentation</a> |  
   <a href="https://discord.com/invite/rK6mfHq">Discord</a> 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,8 +167,6 @@ extra:
       link: https://spigotmc.org/resources/2117/
     - icon: fontawesome/brands/github
       link: https://github.com/BetonQuest/BetonQuest
-    - icon: material/file-download
-      link: https://dev.betonquest.org
     - icon: brands/mail
       link: mailto://contact@betonquest.org
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
There are some links refering to 2.0.0-DEV instead of DEV causing to break when BQ 2.0.0 is released

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
