### PR TITLE
fix `journal delete` does not work anymore

### DIFF
--- a/src/main/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactory.java
@@ -78,7 +78,7 @@ public class JournalEventFactory implements EventFactory, StaticEventFactory {
 
     @NotNull
     private JournalEvent createJournalDeleteEvent(final Instruction instruction) throws InstructionParseException {
-        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.next());
+        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.getPart(2));
         final JournalChanger journalChanger = new RemoveEntryJournalChanger(entryName);
         final NotificationSender notificationSender = new NoNotificationSender();
         return new JournalEvent(betonQuest, journalChanger, notificationSender);
@@ -86,7 +86,7 @@ public class JournalEventFactory implements EventFactory, StaticEventFactory {
 
     @NotNull
     private JournalEvent createJournalAddEvent(final Instruction instruction) throws InstructionParseException {
-        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.next());
+        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.getPart(2));
         final JournalChanger journalChanger = new AddEntryJournalChanger(instantSource, entryName);
         final NotificationSender notificationSender = new InfoNotificationSender("new_journal_entry", instruction.getPackage(), instruction.getID().getFullID());
         return new JournalEvent(betonQuest, journalChanger, notificationSender);
@@ -102,7 +102,7 @@ public class JournalEventFactory implements EventFactory, StaticEventFactory {
     @NotNull
     private StaticEvent createStaticJournalDeleteEvent(final Instruction instruction) throws InstructionParseException {
         final JournalEvent journalDeleteEvent = createJournalDeleteEvent(instruction.copy());
-        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.next());
+        final String entryName = Utils.addPackage(instruction.getPackage(), instruction.getPart(2));
         return new SequentialStaticEvent(
                 new OnlineProfileGroupStaticEventAdapter(PlayerConverter::getOnlineProfiles, journalDeleteEvent),
                 new DatabaseSaverStaticEvent(saver, () -> new Saver.Record(UpdateType.REMOVE_ALL_ENTRIES, entryName))


### PR DESCRIPTION
<!-- Please describe your changes here. -->
An event `journal delete myEntry` instruction read by `instruction.next()` actually returns delete not myEntry
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/2.0.0-DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/2.0.0-DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/2.0.0-DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
