### PR TITLE
Variable Util classes now use the QuestPackage object instead of the packageName as String

### DIFF
--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -154,7 +154,7 @@ public class Instruction {
             return null;
         }
         try {
-            return new CompoundLocation(pack.getQuestPath(), string);
+            return new CompoundLocation(pack, string);
         } catch (final InstructionParseException e) {
             throw new PartParseException("Error while parsing location: " + e.getMessage(), e);
         }
@@ -169,7 +169,7 @@ public class Instruction {
             return null;
         }
         try {
-            return new VariableNumber(pack.getQuestPath(), string);
+            return new VariableNumber(pack, string);
         } catch (final InstructionParseException e) {
             throw new PartParseException("Could not parse a number: " + e.getMessage(), e);
         }

--- a/src/main/java/org/betonquest/betonquest/VariableNumber.java
+++ b/src/main/java/org/betonquest/betonquest/VariableNumber.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest;
 
 import lombok.CustomLog;
 import org.betonquest.betonquest.api.Variable;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -27,18 +28,31 @@ public class VariableNumber {
     /**
      * Parses the string as a variable or as a number if it's not a variable.
      *
-     * @param packName the package in which the variable is defined
-     * @param tmp the string to parse
+     * @param pack the package in which the variable is defined
+     * @param tmp  the string to parse
      * @throws InstructionParseException If the variable could not be created.
      */
-    public VariableNumber(final String packName, final String tmp) throws InstructionParseException {
+    public VariableNumber(final QuestPackage pack, final String tmp) throws InstructionParseException {
         if (tmp.length() > 2 && tmp.charAt(0) == '%' && tmp.endsWith("%")) {
-            this.variable = parseAsVariable(packName, tmp);
+            this.variable = parseAsVariable(pack, tmp);
             this.number = 0.0;
         } else {
             this.variable = null;
             this.number = parseAsNumber(tmp);
         }
+    }
+
+    /**
+     * Parses the string as a variable or as a number if it's not a variable.
+     *
+     * @param packName the package in which the variable is defined
+     * @param tmp      the string to parse
+     * @throws InstructionParseException If the variable could not be created.
+     * @deprecated Use {@link #VariableNumber(QuestPackage, String)} instead.
+     */
+    @Deprecated
+    public VariableNumber(final String packName, final String tmp) throws InstructionParseException {
+        this(Config.getPackages().get(packName), tmp);
     }
 
     /**
@@ -61,10 +75,10 @@ public class VariableNumber {
         this.variable = null;
     }
 
-    private Variable parseAsVariable(final String packName, final String variable) throws InstructionParseException {
+    private Variable parseAsVariable(final QuestPackage pack, final String variable) throws InstructionParseException {
         final Variable parsed;
         try {
-            parsed = BetonQuest.createVariable(Config.getPackages().get(packName), variable);
+            parsed = BetonQuest.createVariable(pack, variable);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Could not create variable: " + e.getMessage(), e);
         }
@@ -77,7 +91,7 @@ public class VariableNumber {
     private double parseAsNumber(final String variable) throws InstructionParseException {
         try {
             return Double.parseDouble(variable);
-        } catch (NumberFormatException e) {
+        } catch (final NumberFormatException e) {
             throw new InstructionParseException("Not a number: " + variable, e);
         }
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
@@ -118,7 +118,7 @@ public class HologramLoop {
             LOG.warn(pack, "Location is not specified in " + key + " hologram");
         } else {
             try {
-                location = new CompoundLocation(pack.getQuestPath(), pack.subst(rawLocation)).getLocation(null);
+                location = new CompoundLocation(pack, pack.subst(rawLocation)).getLocation(null);
             } catch (QuestRuntimeException | InstructionParseException e) {
                 LOG.warn(pack, "Could not parse location in " + key + " hologram: " + e.getMessage(), e);
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/magic/WandCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/magic/WandCondition.java
@@ -54,7 +54,7 @@ public class WandCondition extends Condition {
                     final VariableNumber level;
                     final String[] spellParts = spell.split(":");
                     try {
-                        level = new VariableNumber(instruction.getPackage().getQuestPath(), spellParts[1]);
+                        level = new VariableNumber(instruction.getPackage(), spellParts[1]);
                     } catch (final InstructionParseException e) {
                         throw new InstructionParseException("Could not parse spell level", e);
                     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.CountingObjective;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -78,10 +79,10 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
 
         final String unsafeMinMobLevel = instruction.getOptional("minLevel");
         final String unsafeMaxMobLevel = instruction.getOptional("maxLevel");
-        final String packName = instruction.getPackage().getQuestPath();
+        final QuestPackage pack = instruction.getPackage();
 
-        minMobLevel = unsafeMinMobLevel == null ? new VariableNumber(Double.NEGATIVE_INFINITY) : new VariableNumber(packName, unsafeMinMobLevel);
-        maxMobLevel = unsafeMaxMobLevel == null ? new VariableNumber(Double.POSITIVE_INFINITY) : new VariableNumber(packName, unsafeMaxMobLevel);
+        minMobLevel = unsafeMinMobLevel == null ? new VariableNumber(Double.NEGATIVE_INFINITY) : new VariableNumber(pack, unsafeMinMobLevel);
+        maxMobLevel = unsafeMaxMobLevel == null ? new VariableNumber(Double.POSITIVE_INFINITY) : new VariableNumber(pack, unsafeMaxMobLevel);
         marked = instruction.getOptional("marked");
         if (marked != null) {
             marked = Utils.addPackage(instruction.getPackage(), marked);

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/MoneyEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/MoneyEvent.java
@@ -33,7 +33,7 @@ public class MoneyEvent extends QuestEvent {
             multi = false;
         }
         try {
-            amount = new VariableNumber(instruction.getPackage().getQuestPath(), string);
+            amount = new VariableNumber(instruction.getPackage(), string);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Could not parse money amount", e);
         }

--- a/src/main/java/org/betonquest/betonquest/conditions/EntityCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/EntityCondition.java
@@ -69,7 +69,7 @@ public class EntityCondition extends Condition {
 
     private VariableNumber getAmount(final String typePart) throws InstructionParseException {
         try {
-            return new VariableNumber(instruction.getPackage().getQuestPath(), typePart);
+            return new VariableNumber(instruction.getPackage(), typePart);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Could not parse amount", e);
         }

--- a/src/main/java/org/betonquest/betonquest/conditions/HeightCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/HeightCondition.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.conditions;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -19,16 +20,16 @@ public class HeightCondition extends Condition {
     public HeightCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         final String string = instruction.next();
-        final String packName = instruction.getPackage().getQuestPath();
+        final QuestPackage pack = instruction.getPackage();
         if (string.matches("\\-?\\d+\\.?\\d*")) {
             try {
-                height = new VariableNumber(packName, string);
+                height = new VariableNumber(pack, string);
             } catch (final InstructionParseException e) {
                 throw new InstructionParseException("Could not parse height", e);
             }
         } else {
             try {
-                height = new VariableNumber(new CompoundLocation(packName, string).getLocation(null).getY());
+                height = new VariableNumber(new CompoundLocation(pack, string).getLocation(null).getY());
             } catch (final QuestRuntimeException e) {
                 throw new InstructionParseException("Could not parse height", e);
             }

--- a/src/main/java/org/betonquest/betonquest/conditions/RandomCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/RandomCondition.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.conditions;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -28,10 +29,10 @@ public class RandomCondition extends Condition {
         if (values.length != 2) {
             throw new InstructionParseException("Wrong randomness format");
         }
-        final String packName = instruction.getPackage().getQuestPath();
+        final QuestPackage pack = instruction.getPackage();
         try {
-            valueMax = new VariableNumber(packName, values[0]);
-            rangeOfRandom = new VariableNumber(packName, values[1]);
+            valueMax = new VariableNumber(pack, values[0]);
+            rangeOfRandom = new VariableNumber(pack, values[1]);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Cannot parse randomness values", e);
         }

--- a/src/main/java/org/betonquest/betonquest/conditions/WorldCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/WorldCondition.java
@@ -23,7 +23,7 @@ public class WorldCondition extends Condition {
         world = Bukkit.getWorld(name);
         if (world == null) {
             try {
-                world = new CompoundLocation(instruction.getPackage().getQuestPath(), name).getLocation(null).getWorld();
+                world = new CompoundLocation(instruction.getPackage(), name).getLocation(null).getWorld();
             } catch (InstructionParseException | QuestRuntimeException e) {
                 throw new InstructionParseException("There is no such world: " + name, e);
             }

--- a/src/main/java/org/betonquest/betonquest/events/CompassEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/CompassEvent.java
@@ -40,7 +40,7 @@ public class CompassEvent extends QuestEvent {
         for (final QuestPackage pack : Config.getPackages().values()) {
             final ConfigurationSection section = pack.getConfig().getConfigurationSection("compass");
             if (section != null && section.contains(compass)) {
-                compassLocation = new CompoundLocation(pack.getQuestPath(), pack.getString("compass." + compass + ".location"));
+                compassLocation = new CompoundLocation(pack, pack.getString("compass." + compass + ".location"));
                 break;
             }
         }

--- a/src/main/java/org/betonquest/betonquest/events/PickRandomEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/PickRandomEvent.java
@@ -53,7 +53,7 @@ public class PickRandomEvent extends QuestEvent {
                 } catch (final ObjectNotFoundException e) {
                     throw new InstructionParseException("Error while loading event: " + e.getMessage(), e);
                 }
-                final VariableNumber chance = new VariableNumber(instruction.getPackage().getQuestPath(), parts[0]);
+                final VariableNumber chance = new VariableNumber(instruction.getPackage(), parts[0]);
                 return new RandomEvent(eventID, chance);
             } else if (count == 3) {
                 try {
@@ -61,7 +61,7 @@ public class PickRandomEvent extends QuestEvent {
                 } catch (final ObjectNotFoundException e) {
                     throw new InstructionParseException("Error while loading event: " + e.getMessage(), e);
                 }
-                final VariableNumber chance = new VariableNumber(instruction.getPackage().getQuestPath(), "%" + parts[1] + "%");
+                final VariableNumber chance = new VariableNumber(instruction.getPackage(), "%" + parts[1] + "%");
                 return new RandomEvent(eventID, chance);
             }
             throw new InstructionParseException("Error while loading event: '" + instruction.getEvent().getFullID() + "'. Wrong number of % detected. Check your event.");

--- a/src/main/java/org/betonquest/betonquest/events/PointEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/PointEvent.java
@@ -39,7 +39,7 @@ public class PointEvent extends QuestEvent {
             multi = false;
         }
         try {
-            count = new VariableNumber(instruction.getPackage().getQuestPath(), number);
+            count = new VariableNumber(instruction.getPackage(), number);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Could not parse point count", e);
         }

--- a/src/main/java/org/betonquest/betonquest/events/ScoreboardEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/ScoreboardEvent.java
@@ -34,7 +34,7 @@ public class ScoreboardEvent extends QuestEvent {
             multi = false;
         }
         try {
-            count = new VariableNumber(instruction.getPackage().getQuestPath(), number);
+            count = new VariableNumber(instruction.getPackage(), number);
         } catch (final InstructionParseException e) {
             throw new InstructionParseException("Could not parse score count", e);
         }

--- a/src/main/java/org/betonquest/betonquest/menu/MenuItem.java
+++ b/src/main/java/org/betonquest/betonquest/menu/MenuItem.java
@@ -95,7 +95,7 @@ public class MenuItem extends SimpleYMLSection {
             //load item
             final ItemID itemID = new ItemID(pack, getString("item").trim());
             final VariableNumber amount;
-            amount = new VariableNumber(pack.getQuestPath(), new DefaultSetting<>("1") {
+            amount = new VariableNumber(pack, new DefaultSetting<>("1") {
                 @Override
                 @SuppressWarnings("PMD.ShortMethodName")
                 protected String of() throws Missing {

--- a/src/main/java/org/betonquest/betonquest/notify/BossBarNotifyIO.java
+++ b/src/main/java/org/betonquest/betonquest/notify/BossBarNotifyIO.java
@@ -62,7 +62,7 @@ public class BossBarNotifyIO extends NotifyIO {
 
         progress = normalizeBossBarProgress(getFloatData("progress", 1));
         final String stayString = data.get("stay");
-        stayVariable = stayString == null ? new VariableNumber(70) : new VariableNumber(pack.getQuestPath(), stayString);
+        stayVariable = stayString == null ? new VariableNumber(70) : new VariableNumber(pack, stayString);
         countdown = getIntegerData("countdown", 0);
     }
 

--- a/src/main/java/org/betonquest/betonquest/notify/NotifyIO.java
+++ b/src/main/java/org/betonquest/betonquest/notify/NotifyIO.java
@@ -65,7 +65,7 @@ public abstract class NotifyIO {
         if (dataString == null) {
             return defaultData;
         } else if (dataString.startsWith("%")) {
-            return (float) new VariableNumber(pack.getQuestPath(), dataString).getDouble(PlayerConverter.getID(player));
+            return (float) new VariableNumber(pack, dataString).getDouble(PlayerConverter.getID(player));
         }
         try {
             return Float.parseFloat(dataString);

--- a/src/main/java/org/betonquest/betonquest/notify/NotifySound.java
+++ b/src/main/java/org/betonquest/betonquest/notify/NotifySound.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.notify;
 
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -115,7 +116,7 @@ class NotifySound {
 
     private CompoundLocation getCompoundLocation(final Map<String, String> data) throws InstructionParseException {
         final String locationString = data.get(KEY_SOUND_LOCATION);
-        return locationString == null ? null : new CompoundLocation(null, locationString);
+        return locationString == null ? null : new CompoundLocation((QuestPackage) null, locationString);
     }
 
     private SoundCategory getSoundCategory(final Map<String, String> data) throws InstructionParseException {
@@ -130,7 +131,7 @@ class NotifySound {
     private VectorData getPlayerOffset(final String playerOffsetString) throws InstructionParseException {
         if (playerOffsetString != null) {
             try {
-                return new VectorData(null, playerOffsetString);
+                return new VectorData((QuestPackage) null, playerOffsetString);
             } catch (final InstructionParseException exception) {
                 throw new InstructionParseException(String.format("%s '%s' couldn't be parsed, it is not a valid vector or a floating point number!", KEY_SOUND_PLAYER_OFFSET, playerOffsetString), exception);
             }

--- a/src/main/java/org/betonquest/betonquest/objectives/DelayObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/DelayObjective.java
@@ -49,7 +49,7 @@ public class DelayObjective extends Objective {
     private void parseDelay() throws InstructionParseException {
         final String doubleOrVar = instruction.next();
         if (doubleOrVar.startsWith("%")) {
-            delay = new VariableNumber(instruction.getPackage().getQuestPath(), doubleOrVar);
+            delay = new VariableNumber(instruction.getPackage(), doubleOrVar);
         } else {
             final double time = Double.parseDouble(doubleOrVar);
             if (time < 0) {

--- a/src/main/java/org/betonquest/betonquest/objectives/FishObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/FishObjective.java
@@ -6,6 +6,7 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.CountingObjective;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -41,7 +42,7 @@ public class FishObjective extends CountingObjective implements Listener {
         blockSelector = new BlockSelector(instruction.next());
         targetAmount = instruction.getInt();
 
-        final String pack = instruction.getPackage().getQuestPath();
+        final QuestPackage pack = instruction.getPackage();
         final String loc = instruction.getOptional("hookLocation");
         final String range = instruction.getOptional("range");
         if (loc != null && range != null) {

--- a/src/main/java/org/betonquest/betonquest/quest/event/velocity/VelocityEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/velocity/VelocityEventFactory.java
@@ -47,7 +47,7 @@ public class VelocityEventFactory implements EventFactory {
         if (rawVector == null) {
             throw new InstructionParseException("A 'vector' is required");
         }
-        final VectorData vector = new VectorData(instruction.getPackage().getQuestPath(), rawVector);
+        final VectorData vector = new VectorData(instruction.getPackage(), rawVector);
         final VectorDirection direction = instruction.getEnum(instruction.getOptional("direction"), VectorDirection.class, VectorDirection.ABSOLUTE);
         final VectorModification modification = instruction.getEnum(instruction.getOptional("modification"), VectorModification.class, VectorModification.SET);
         return new PrimaryServerThreadEvent(

--- a/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
@@ -4,7 +4,6 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
-import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 
@@ -53,12 +52,12 @@ abstract class AbstractData<T extends Cloneable> {
      * This class parses a string into a object.
      * Each part of the input string can be a {@link Variable}s instead of an {@link Integer} or {@link String}.
      *
-     * @param packName Name of the {@link QuestPackage} - required for
-     *                 {@link Variable} resolution
-     * @param data     string containing raw object in the defined format
+     * @param pack the {@link QuestPackage} - required for
+     *             {@link Variable} resolution
+     * @param data string containing raw object in the defined format
      * @throws InstructionParseException Is thrown when an error appears while parsing the {@link Variable}s or the object
      */
-    public AbstractData(final String packName, final String data) throws InstructionParseException {
+    public AbstractData(final QuestPackage pack, final String data) throws InstructionParseException {
         final Matcher variableMatcher = PATTERN_VARIABLE.matcher(data);
         if (variableMatcher.find()) {
             objectVariables = new ArrayList<>();
@@ -66,7 +65,7 @@ abstract class AbstractData<T extends Cloneable> {
             final StringBuffer stringBuffer = new StringBuffer(data.length());
             do {
                 final String variable = variableMatcher.group(0);
-                final Variable var = BetonQuest.createVariable(Config.getPackages().get(packName), variable);
+                final Variable var = BetonQuest.createVariable(pack, variable);
                 objectVariables.add(var);
                 final String replacement = "%" + index++ + "$s";
                 variableMatcher.appendReplacement(stringBuffer, Matcher.quoteReplacement(replacement));

--- a/src/main/java/org/betonquest/betonquest/utils/location/CompoundLocation.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/CompoundLocation.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.utils.location;
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.Location;
@@ -22,21 +23,37 @@ public class CompoundLocation {
      * The last optional part is the {@link Vector} that will be added to the {@link Location} if specified.
      * Each part of the input string can be a {@link Variable} instead of an {@link Integer} or {@link String}.
      *
+     * @param pack Name of the {@link QuestPackage} - required for {@link Variable} resolution
+     * @param data string containing raw location in the defined format
+     * @throws InstructionParseException Is thrown when an error appears while parsing {@link LocationData}
+     *                                   or {@link VectorData}
+     */
+    public CompoundLocation(final QuestPackage pack, final String data) throws InstructionParseException {
+        if (data.contains("->")) {
+            final String[] parts = data.split("->");
+            locationData = new LocationData(pack, parts[0]);
+            vectorData = new VectorData(pack, parts[1]);
+        } else {
+            locationData = new LocationData(pack, data);
+            vectorData = null;
+        }
+    }
+
+    /**
+     * This class parses a string into a {@link Location} and a {@link Vector}. The input string has
+     * to be in the format 'x;y;z;world[;yaw;pitch][-&gt; (x;y;z)]'. All elements in square brackets are optional.
+     * The last optional part is the {@link Vector} that will be added to the {@link Location} if specified.
+     * Each part of the input string can be a {@link Variable} instead of an {@link Integer} or {@link String}.
+     *
      * @param packName Name of the {@link QuestPackage} - required for {@link Variable} resolution
      * @param data     string containing raw location in the defined format
      * @throws InstructionParseException Is thrown when an error appears while parsing {@link LocationData}
      *                                   or {@link VectorData}
+     * @deprecated Use {@link #CompoundLocation(QuestPackage, String)} instead
      */
+    @Deprecated
     public CompoundLocation(final String packName, final String data) throws InstructionParseException {
-
-        if (data.contains("->")) {
-            final String[] parts = data.split("->");
-            locationData = new LocationData(packName, parts[0]);
-            vectorData = new VectorData(packName, parts[1]);
-        } else {
-            locationData = new LocationData(packName, data);
-            vectorData = null;
-        }
+        this(Config.getPackages().get(packName), data);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/utils/location/LocationData.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/LocationData.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.utils.location;
 
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -30,13 +31,29 @@ public class LocationData extends AbstractData<Location> {
      * The input string has to be in the format 'x;y;z;world[;yaw;pitch]'. All elements in square brackets are optional.
      * Each part of the input string can be a {@link Variable}s instead of an {@link Integer} or {@link String}.
      *
+     * @param pack the {@link QuestPackage} - required for {@link Variable} resolution
+     * @param data string containing raw {@link Location} in the defined format
+     * @throws InstructionParseException Is thrown when an error appears while parsing the {@link Variable}s or
+     *                                   {@link Location}
+     */
+    public LocationData(final QuestPackage pack, final String data) throws InstructionParseException {
+        super(pack, data);
+    }
+
+    /**
+     * This class parses a string into a {@link Location}.
+     * The input string has to be in the format 'x;y;z;world[;yaw;pitch]'. All elements in square brackets are optional.
+     * Each part of the input string can be a {@link Variable}s instead of an {@link Integer} or {@link String}.
+     *
      * @param packName Name of the {@link QuestPackage} - required for {@link Variable} resolution
      * @param data     string containing raw {@link Location} in the defined format
      * @throws InstructionParseException Is thrown when an error appears while parsing the {@link Variable}s or
      *                                   {@link Location}
+     * @deprecated Use {@link #LocationData(QuestPackage, String)} instead.
      */
+    @Deprecated
     public LocationData(final String packName, final String data) throws InstructionParseException {
-        super(packName, data);
+        this(Config.getPackages().get(packName), data);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/utils/location/VectorData.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/VectorData.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.utils.location;
 
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.bukkit.util.Vector;
 
@@ -27,12 +28,27 @@ public class VectorData extends AbstractData<Vector> {
      * The input string has to be in the format '(x;y;z)'.
      * Each part of the input string can be a {@link Variable}s instead of an {@link Integer} or {@link String}.
      *
+     * @param pack the {@link QuestPackage} - required for {@link Variable} resolution
+     * @param data string containing raw {@link Vector} in the defined format
+     * @throws InstructionParseException Is thrown when an error appears while parsing the {@link Variable}s or {@link Vector}
+     */
+    public VectorData(final QuestPackage pack, final String data) throws InstructionParseException {
+        super(pack, data);
+    }
+
+    /**
+     * This class parses a string into a {@link Vector}.
+     * The input string has to be in the format '(x;y;z)'.
+     * Each part of the input string can be a {@link Variable}s instead of an {@link Integer} or {@link String}.
+     *
      * @param packName Name of the {@link QuestPackage} - required for {@link Variable} resolution
      * @param data     string containing raw {@link Vector} in the defined format
      * @throws InstructionParseException Is thrown when an error appears while parsing the {@link Variable}s or {@link Vector}
+     * @deprecated Use {@link VectorData#VectorData(QuestPackage, String)} instead.
      */
+    @Deprecated
     public VectorData(final String packName, final String data) throws InstructionParseException {
-        super(packName, data);
+        this(Config.getPackages().get(packName), data);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/utils/math/Tokenizer.java
+++ b/src/main/java/org/betonquest/betonquest/utils/math/Tokenizer.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.utils.math;
 
 import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.utils.math.tokens.AbsoluteValue;
 import org.betonquest.betonquest.utils.math.tokens.Negation;
@@ -39,15 +40,15 @@ public class Tokenizer {
     /**
      * Name of the package in which the tokenizer is operating.
      */
-    private final String packageName;
+    private final QuestPackage pack;
 
     /**
      * Create a new Tokenizer in given package.
      *
-     * @param packageName name of the package
+     * @param pack name of the package
      */
-    public Tokenizer(final String packageName) {
-        this.packageName = packageName;
+    public Tokenizer(final QuestPackage pack) {
+        this.pack = pack;
     }
 
     /**
@@ -108,7 +109,7 @@ public class Tokenizer {
             final String variableName = ESCAPE_REGEX.matcher(rawVariableName).replaceAll("$1");
 
             try {
-                nextInLine = new Variable(new VariableNumber(packageName, "%" + variableName + "%"));
+                nextInLine = new Variable(new VariableNumber(pack, "%" + variableName + "%"));
             } catch (final InstructionParseException e) {
                 throw new InstructionParseException("invalid calculation (" + e.getMessage() + ")", e);
             }
@@ -155,7 +156,7 @@ public class Tokenizer {
                 }
             }
             try {
-                nextInLine = new Variable(new VariableNumber(packageName, "%" + val2.substring(start, index--) + "%"));
+                nextInLine = new Variable(new VariableNumber(pack, "%" + val2.substring(start, index--) + "%"));
             } catch (final InstructionParseException e) {
                 throw new InstructionParseException("invalid calculation (" + e.getMessage() + ")", e);
             }

--- a/src/main/java/org/betonquest/betonquest/variables/MathVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/MathVariable.java
@@ -27,7 +27,7 @@ public class MathVariable extends Variable {
             throw new InstructionParseException("invalid format");
         }
         final String expression = instructionString.substring("math.calc:".length());
-        this.calculation = new Tokenizer(instruction.getPackage().getQuestPath()).tokenize(expression);
+        this.calculation = new Tokenizer(instruction.getPackage()).tokenize(expression);
     }
 
     @Override


### PR DESCRIPTION
### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
