### PR TITLE
Modrinth rollback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,32 +289,6 @@ jobs:
           REPOSITORY_URL: ${{ vars.REPOSITORY_URL }}
           REPOSITORY_USER: ${{ secrets.REPOSITORY_USER }}
           REPOSITORY_PASS: ${{ secrets.REPOSITORY_PASS }}
-      - name: Extract supported Minecraft versions
-        uses: mikefarah/yq@v4.30.8
-        id: supported-versions
-        with:
-          cmd: yq eval -r '.supportedVersions[]' ./mcinfo.yml
-      - name: Determine version type
-        run: |
-          if [ "$VERSION_TYPE" == development ]; then
-            echo "MODRINTH_VERSION_TYPE=beta" >> $GITHUB_ENV
-          else
-            echo "MODRINTH_VERSION_TYPE=release" >> $GITHUB_ENV
-          fi
-      - uses: Kir-Antipov/mc-publish@v3.2
-        name: Deploy to Modrinth
-        with:
-          modrinth-id: ${{ vars.MODRINTH_ID }}
-          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
-          modrinth-unfeature-mode: version-subset
-
-          github-prerelease: false
-
-          files: target/artifacts/BetonQuest.jar
-          name: ${{ env.VERSION }}
-          version: ${{ env.VERSION }}
-          version-type: ${{ env.MODRINTH_VERSION_TYPE }}
-          game-versions: ${{ steps.supported-versions.outputs.result }}
 
       - name: Get upload URL from deploy log
         id: save_upload_path

--- a/mcinfo.yml
+++ b/mcinfo.yml
@@ -1,3 +1,0 @@
-supportedVersions:
-  - 1.18.2
-  - 1.19.3


### PR DESCRIPTION
Plugins are not supported by `mc-publish` so far, they are working on a v4 that allows it: https://github.com/Kir-Antipov/mc-publish/issues/23


### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
