### PR TITLE
fixed legacy `§x` HEX color format not working in some contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `pickrandom` event - did not allowed dashes in event names
 - `action` objective - ignored offhand at all
 - Things that are also fixed in 1.12.X:
+    - legacy `§x` HEX color format not working in some contexts
     - ProtocolLib's based `packet` interceptor was fixed for MC 1.19, now ProtocolLib 5.0.0 is required
     - parsing of math variable
     - Citizens compatibility for not spawned NPCs

--- a/src/main/java/org/betonquest/betonquest/utils/LocalChatPaginator.java
+++ b/src/main/java/org/betonquest/betonquest/utils/LocalChatPaginator.java
@@ -3,10 +3,8 @@ package org.betonquest.betonquest.utils;
 import org.bukkit.ChatColor;
 import org.bukkit.util.ChatPaginator;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -36,53 +34,6 @@ public class LocalChatPaginator extends ChatPaginator {
                 {'p', 6}, {'q', 6}, {'r', 6}, {'s', 6}, {'t', 4}, {'u', 6}, {'v', 6}, {'w', 6},
                 {'x', 6}, {'y', 6}, {'z', 6}, {'{', 5}, {'|', 2}, {'}', 5}, {'~', 7}
         }).collect(Collectors.toMap(data -> (Character) data[0], data -> (Integer) data[1]));
-    }
-
-    /**
-     * Takes a string and returns the last colors that can be copied to a new line
-     *
-     * @param input the input string.
-     * @return last colors that can be copied to a new line
-     */
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
-    public static String getLastColors(final String input) {
-        ChatColor lastColor = null;
-        final List<ChatColor> lastFormats = new ArrayList<>();
-
-        final int length = input.length();
-
-        for (int index = length - 1; index > -1; --index) {
-            final char section = input.charAt(index);
-            if (section != 167 || index >= length - 1) {
-                continue;
-            }
-            final char colorChar = input.charAt(index + 1);
-            final ChatColor color = ChatColor.getByChar(colorChar);
-
-            if (color != null) {
-                if (color.equals(ChatColor.RESET)) {
-                    break;
-                }
-
-                if (color.isColor() && lastColor == null) {
-                    lastColor = color;
-                    continue;
-                }
-
-                if (color.isFormat() && !lastFormats.contains(color)) {
-                    lastFormats.add(color);
-                }
-            }
-        }
-
-        String result = lastFormats.stream()
-                .map(ChatColor::toString)
-                .collect(Collectors.joining(""));
-
-        if (lastColor != null) {
-            result = lastColor + result;
-        }
-        return result;
     }
 
     public static String[] wordWrap(final String rawString, final int lineLength) {
@@ -131,7 +82,7 @@ public class LocalChatPaginator extends ChatPaginator {
                 if (rawChars.length <= i + 1) {
                     break;
                 }
-                word.append(ChatColor.getByChar(String.valueOf(rawChars[i + 1]).toLowerCase(Locale.ROOT)));
+                word.append(ChatColor.COLOR_CHAR).append(rawChars[i + 1]);
                 i++; // Eat the next character as we have already processed it
                 continue;
             }
@@ -192,7 +143,7 @@ public class LocalChatPaginator extends ChatPaginator {
             final String subLine = lines.get(i);
 
             //char color = pLine.charAt(pLine.lastIndexOf(ChatColor.COLOR_CHAR) + 1);
-            lines.set(i, wrapPrefix + getLastColors(pLine) + subLine);
+            lines.set(i, wrapPrefix + ChatColor.getLastColors(pLine) + subLine);
         }
 
         return lines.toArray(new String[0]);

--- a/src/main/java/org/betonquest/betonquest/utils/Utils.java
+++ b/src/main/java/org/betonquest/betonquest/utils/Utils.java
@@ -436,7 +436,7 @@ public final class Utils {
         while (iterator.hasNext()) {
             final String line = iterator.next();
             result.add(lastCodes + replaceReset(line, def));
-            lastCodes = LocalChatPaginator.getLastColors(line);
+            lastCodes = ChatColor.getLastColors(line);
         }
 
         return result;


### PR DESCRIPTION
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
