### PR TITLE
fixed legacy `§x` HEX color format not working in some contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ProtocolLib's based `packet` interceptor was fixed for MC 1.19, now ProtocolLib 5.0.0 is required
 - conversation IO chest did not show the correct NPC heads
 - `objective` event - static calls did not remove the objective for online players
+- legacy `§x` HEX color format not working in some contexts
 ### Security
 
 ## [1.12.9] - 2022-06-22

--- a/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
@@ -3,7 +3,9 @@ package pl.betoncraft.betonquest.utils;
 import org.bukkit.ChatColor;
 import org.bukkit.util.ChatPaginator;
 
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,50 +36,6 @@ public class LocalChatPaginator extends ChatPaginator {
         }).collect(Collectors.toMap(data -> (Character) data[0], data -> (Integer) data[1]));
     }
 
-    /**
-     * Takes a string and returns the last colors that can be copied to a new line
-     */
-    @SuppressWarnings("PMD.CyclomaticComplexity")
-    public static String getLastColors(final String input) {
-        ChatColor lastColor = null;
-        final List<ChatColor> lastFormats = new ArrayList<>();
-
-        final int length = input.length();
-
-        for (int index = length - 1; index > -1; --index) {
-            final char section = input.charAt(index);
-            if (section != 167 || index >= length - 1) {
-                continue;
-            }
-            final char colorChar = input.charAt(index + 1);
-            final ChatColor color = ChatColor.getByChar(colorChar);
-
-            if (color != null) {
-                if (color.equals(ChatColor.RESET)) {
-                    break;
-                }
-
-                if (color.isColor() && lastColor == null) {
-                    lastColor = color;
-                    continue;
-                }
-
-                if (color.isFormat() && !lastFormats.contains(color)) {
-                    lastFormats.add(color);
-                }
-            }
-        }
-
-        String result = lastFormats.stream()
-                .map(ChatColor::toString)
-                .collect(Collectors.joining(""));
-
-        if (lastColor != null) {
-            result = lastColor.toString() + result;
-        }
-        return result;
-    }
-
     public static String[] wordWrap(final String rawString, final int lineLength) {
         return wordWrap(rawString, lineLength, "");
     }
@@ -91,7 +49,7 @@ public class LocalChatPaginator extends ChatPaginator {
      * @param wrapPrefix The string to prefix the wrapped line with
      * @return An array of word-wrapped lines.
      */
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.AvoidLiteralsInIfCondition"})
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.AvoidLiteralsInIfCondition", "PMD.CognitiveComplexity"})
     public static String[] wordWrap(final String rawString, final int lineLength, final String wrapPrefix) {
 
         // A null string is a single line
@@ -124,7 +82,7 @@ public class LocalChatPaginator extends ChatPaginator {
                 if (rawChars.length <= i + 1) {
                     break;
                 }
-                word.append(ChatColor.getByChar(String.valueOf(rawChars[i + 1]).toLowerCase(Locale.ROOT)));
+                word.append(ChatColor.COLOR_CHAR).append(rawChars[i + 1]);
                 i++; // Eat the next character as we have already processed it
                 continue;
             }
@@ -185,7 +143,7 @@ public class LocalChatPaginator extends ChatPaginator {
             final String subLine = lines.get(i);
 
             //char color = pLine.charAt(pLine.lastIndexOf(ChatColor.COLOR_CHAR) + 1);
-            lines.set(i, wrapPrefix + getLastColors(pLine) + subLine);
+            lines.set(i, wrapPrefix + ChatColor.getLastColors(pLine) + subLine);
         }
 
         return lines.toArray(new String[0]);
@@ -193,6 +151,9 @@ public class LocalChatPaginator extends ChatPaginator {
 
     /**
      * Return the width of text taking into account variable font size and ignoring hidden characters
+     *
+     * @param input the input string.
+     * @return width of text
      */
     public static int getWidth(final String input) {
         int ret = 0;
@@ -213,7 +174,10 @@ public class LocalChatPaginator extends ChatPaginator {
     }
 
     /**
-     * Return the length of the line minus hidden characters
+     * Returns the length of the line minus hidden characters.
+     *
+     * @param input the input string.
+     * @return the length of the line minus hidden characters.
      */
     public static int lineLength(final String input) {
         int ret = 0;
@@ -230,6 +194,9 @@ public class LocalChatPaginator extends ChatPaginator {
 
     /**
      * Return the number of hidden characters in input
+     *
+     * @param input the input string.
+     * @return number of hidden characters.
      */
     public static int hiddenCount(final String input) {
         final char[] rawChars = input.toCharArray();

--- a/src/main/java/pl/betoncraft/betonquest/utils/Utils.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/Utils.java
@@ -27,7 +27,13 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,7 +126,7 @@ public final class Utils {
                             try {
                                 final String value = res.getString(columnName);
                                 config.set(entry.getKey() + "." + counter + "." + columnName, value);
-                            } catch (SQLException e) {
+                            } catch (final SQLException e) {
                                 LogUtils.getLogger().log(Level.WARNING, "Could not read SQL: " + e.getMessage());
                                 LogUtils.logThrowable(e);
                                 done = false;
@@ -389,22 +395,22 @@ public final class Utils {
         }
         try {
             return Color.fromRGB(Integer.parseInt(string));
-        } catch (NumberFormatException e1) {
+        } catch (final NumberFormatException e1) {
             LogUtils.logThrowableIgnore(e1);
             // string is not a decimal number
             try {
                 return Color.fromRGB(Integer.parseInt(string.replace("#", ""), 16));
-            } catch (NumberFormatException e2) {
+            } catch (final NumberFormatException e2) {
                 LogUtils.logThrowableIgnore(e2);
                 // string is not a hexadecimal number, try dye color
                 try {
                     return DyeColor.valueOf(string.trim().toUpperCase(Locale.ROOT).replace(' ', '_')).getColor();
-                } catch (IllegalArgumentException e3) {
+                } catch (final IllegalArgumentException e3) {
                     // this was not a dye color name
                     throw new InstructionParseException("Dye color does not exist: " + string, e3);
                 }
             }
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             // string was a number, but incorrect
             throw new InstructionParseException("Incorrect RGB code: " + string, e);
         }
@@ -425,7 +431,7 @@ public final class Utils {
         while (iterator.hasNext()) {
             final String line = iterator.next();
             result.add(lastCodes + replaceReset(line, def));
-            lastCodes = LocalChatPaginator.getLastColors(line);
+            lastCodes = ChatColor.getLastColors(line);
         }
 
         return result;


### PR DESCRIPTION
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
