### PR TITLE
fix issue where clickable update in `/q version` does not work when `…

### DIFF
--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -53,6 +53,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
 
     @SuppressWarnings("PMD.NcssCount")
     @Override
-    public boolean onCommand(final CommandSender sender, final Command cmd, final String alias, final String... args) {
+    public boolean onCommand(@NotNull final CommandSender sender, final Command cmd, @NotNull final String alias, @NotNull final String... args) {
 
         if ("betonquest".equalsIgnoreCase(cmd.getName())) {
             LOG.debug("Executing /betonquest command for user " + sender.getName()
@@ -262,7 +263,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
                 case "version":
                 case "ver":
                 case "v":
-                    displayVersionInfo(sender);
+                    displayVersionInfo(sender, alias);
                     break;
                 case "purge":
                     LOG.debug("Loading data asynchronously");
@@ -1561,9 +1562,9 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    private void displayVersionInfo(final CommandSender sender) {
+    private void displayVersionInfo(final CommandSender sender, final String commandAlias) {
         final Updater updater = BetonQuest.getInstance().getUpdater();
-        final String updateCommand = "/q update";
+        final String updateCommand = "/" + commandAlias + " update";
 
         final String lang = sender instanceof Player
                 ? BetonQuest.getInstance().getPlayerData(PlayerConverter.getID((Player) sender)).getLanguage()


### PR DESCRIPTION
…/q` does not work

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
