### PR TITLE
Docs/insiders inhertiance

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,13 +1,5 @@
 INHERIT: mkdocs.yml
 plugins:
-  - search
-  - snippets:
-      directory: "_snippets"
-      identifier: "snippet"
-  - exclude:
-      glob:
-        - _snippets/*
-        - _custom_theme/*
   - typeset
   - optimize:
       enabled: !ENV [ CI, false ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ theme:
     - navigation.tracking
     - navigation.sections
     - navigation.top
+    - navigation.path
     - search.share
     - search.suggest
     - content.tooltips

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,14 +110,14 @@ markdown_extensions:
       permalink: 🔗
 
 plugins:
-  - search
-  - snippets:
-      directory: "_snippets"
-      identifier: "snippet"
-  - exclude:
-      glob:
-        - _snippets/*
-        - _custom_theme/*
+  search: { }
+  snippets:
+    directory: "_snippets"
+    identifier: "snippet"
+  exclude:
+    glob:
+      - _snippets/*
+      - _custom_theme/*
 
 extra:
   version:


### PR DESCRIPTION
Enabled Breadcrumbs and used alternative plugin syntax so that the insiders config file only has the additional plugins.
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
