### PR TITLE
Permission seperation for cancelquest and compass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,12 +132,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - all allow decimal level and variables now
 - changed backpack configuration. "" will hide the compass or canceler
 - `smelt` objective - now requires a QuestItem instead of a BlockSelector
+- `cancelquest` command - has its own permission now
+- `compass` command - has its own permission now
 - Things that are also changed in 1.12.X:
     - math variable now allows rounding output with the ~ operator
     - French translation has been updated
     - `action` objective - cancels now the event, before other plugins check for it (better third-party support)
-- `cancelquest` command - has its own permission now
-- `compass` command - has its own permission now
 ### Deprecated
 ### Removed
 - deprecated internals, code and old features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - math variable now allows rounding output with the ~ operator
     - French translation has been updated
     - `action` objective - cancels now the event, before other plugins check for it (better third-party support)
+- `cancelquest` command - has its own permission now
+- `compass` command - has its own permission now
 ### Deprecated
 ### Removed
 - deprecated internals, code and old features

--- a/docs/Documentation/Configuration/Commands-and-permissions.md
+++ b/docs/Documentation/Configuration/Commands-and-permissions.md
@@ -69,8 +69,8 @@ The server must be restarted to unregister command tab completions.
 * `betonquest.admin` - allows using admin commands (/q, /rpgmenu ...)
 * `betonquest.journal` - allows using /j command (default for players)
 * `betonquest.backpack` - allows using /backpack command (default for players)
-* `betonquest.cancelquest` - allows using /cancelquest command (default for players)
 * `betonquest.compass` - allows using /compass command (default for players)
+* `betonquest.cancelquest` - allows using /cancelquest command (default for players)
 * `betonquest.conversation` - allows talking with NPCs (default for players)
 * `betonquest.language` - allows changing the language (default for players)
 

--- a/docs/Documentation/Configuration/Commands-and-permissions.md
+++ b/docs/Documentation/Configuration/Commands-and-permissions.md
@@ -48,6 +48,7 @@ The server must be restarted to unregister command tab completions.
 * `/j`: bj, journal, bjournal, betonjournal, betonquestjournal
 * `/backpack`: b, bb, bbackpack, betonbackpack, betonquestbackpack
 * `/compass`: bc, bcompass, betoncompass, betonquestcompass
+* `/cancelquest`: bcq, bcancelquest, betoncancelquest, betonquestcancelquest
 * `/q`: bq, bquest, bquests, betonquest, betonquests, quest, quests
     * `objective`: o, objectives
     * `tag`: t, tags
@@ -68,6 +69,8 @@ The server must be restarted to unregister command tab completions.
 * `betonquest.admin` - allows using admin commands (/q, /rpgmenu ...)
 * `betonquest.journal` - allows using /j command (default for players)
 * `betonquest.backpack` - allows using /backpack command (default for players)
+* `betonquest.cancelquest` - allows using /cancelquest command (default for players)
+* `betonquest.compass` - allows using /compass command (default for players)
 * `betonquest.conversation` - allows talking with NPCs (default for players)
 * `betonquest.language` - allows changing the language (default for players)
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -53,12 +53,12 @@ commands:
   cancelquest:
     description: Opens the window with quest cancelers
     usage: /<command>
-    permission: betonquest.backpack
+    permission: betonquest.cancelquest
     aliases: [ bcq, bcancelquest, betoncancelquest, betonquestcancelquest ]
   compass:
     description: Opens the compass menu
     usage: /<command>
-    permission: betonquest.backpack
+    permission: betonquest.compass
     aliases: [ bc, bcompass, betoncompass, betonquestcompass ]
   questlang:
     description: Changes the language
@@ -72,8 +72,12 @@ permissions:
     default: true
   betonquest.backpack:
     default: true
+  betonquest.cancelquest:
+    default: true
+  betonquest.compass:
+    default: true
   betonquest.conversation:
     default: true
   betonquest.language:
     default: true
-  
+


### PR DESCRIPTION
<!-- Please describe your changes here. -->
gave cancelquest and compass their own permission and adjusted the docs

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
