### PR TITLE
fixed unwanted editorconfig override of Intellij Formatting and fixed…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ indent_size = 4
 
 [*.java]
 indent_size = 4
+ij_continuation_indent_size = 8
 trim_trailing_whitespace = true
 max_line_length = 120
 curly_bracket_next_line = false

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -41,6 +41,7 @@
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />
+      <option name="REPORT_IMPLICIT_FINALS" value="false" />
     </inspection_tool>
   </profile>
 </component>


### PR DESCRIPTION
… inspection for possible final

There's an IDEA issue ([https://youtrack.jetbrains.com/issue/IDEA-254520/Continuation-indent-should-not-be-overriden-by-editorconfig\](https://youtrack.jetbrains.com/issue/IDEA-254520/Continuation-indent-should-not-be-overriden-by-editorconfig%5C)) about that, and IDEA supports a custom ij_continuation_indent_size option (cp. https://www.jetbrains.com/help/idea/editorconfig.html). A standard EditorConfig setting has been proposed as well: https://github.com/editorconfig/editorconfig/issues/412

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
