### PR TITLE
Added FlagHandler for QuestItem management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - menus now support global variables
 - menus now support string with newline or string list text values for lore
 - amount of objectives now support variables
+- added quest item flag recording and restore
 - `freeze` event - ProtocolLib compatibility feature: Blocks the player from moving for the specified amount of ticks
 - `block` objective - properties: `absoluteAmount`, `absoluteLeft` and `absoluteTotal`
 - `command` objective

--- a/docs/Documentation/Features/Items.md
+++ b/docs/Documentation/Features/Items.md
@@ -32,6 +32,15 @@ These are arguments that can be applied to every item:
 
 - `custom-model-data` - set the custom model data of the item. You have to specify the data value: `custom-model-data:3`. To check that an item does not have custom model data set `no-custom-model-data`.
 
+- `flags` - item flags that govern the visibility of some item info (comma delimited) including:
+    - HIDE_ENCHANTS: Hide the ItemStack enchants
+    - HIDE_ATTRIBUTES: Hide attributes like damage
+    - HIDE_UNBREAKABLE: Hide unbreakable state
+    - HIDE_DESTROYS: Hide what the ItemStack can break or destroy
+    - HIDE_PLACED_ON: Hide where the ItemStack can be placed
+    - HIDE_POTION_EFFECTS: Hide potion effects, book and firework info, map tool tips, banner patters, and enchantments
+    - HIDE_DYE: Hide the dye labels on colored leather armor
+
 ```YAML title="Examples"
 name:&4Sword_made_of_Holy_Concrete
 name:none
@@ -43,6 +52,7 @@ enchants:power:? enchants-containing
 enchants:none
 unbreakable
 unbreakable:false
+flags:HIDE_ENCHANTS,HIDE_ATTRIBUTES,HIDE_UNBREAKABLE
 ```
 
 ## Special Item Types

--- a/docs/Documentation/Features/Items.md
+++ b/docs/Documentation/Features/Items.md
@@ -33,11 +33,11 @@ These are arguments that can be applied to every item:
 - `custom-model-data` - set the custom model data of the item. You have to specify the data value: `custom-model-data:3`. To check that an item does not have custom model data set `no-custom-model-data`.
 
 - `flags` - item flags that govern the visibility of some item info (comma delimited) including:
-    - HIDE_ENCHANTS: Hide the ItemStack enchants
+    - HIDE_ENCHANTS: Hide the item's enchants
     - HIDE_ATTRIBUTES: Hide attributes like damage
-    - HIDE_UNBREAKABLE: Hide unbreakable state
-    - HIDE_DESTROYS: Hide what the ItemStack can break or destroy
-    - HIDE_PLACED_ON: Hide where the ItemStack can be placed
+    - HIDE_UNBREAKABLE: Hide the unbreakable of the item state
+    - HIDE_DESTROYS: Hide what the item can break or destroy
+    - HIDE_PLACED_ON: Hide where the item can be placed
     - HIDE_POTION_EFFECTS: Hide potion effects, book and firework info, map tool tips, banner patters, and enchantments
     - HIDE_DYE: Hide the dye labels on colored leather armor
 

--- a/src/main/java/org/betonquest/betonquest/item/QuestItem.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItem.java
@@ -493,7 +493,9 @@ public class QuestItem {
         meta.setDisplayName(name.get());
         meta.setLore(lore.get());
         meta.setUnbreakable(unbreakable.isUnbreakable());
-        if (flags.get() != null) flags.get().forEach(meta::addItemFlags);
+        if (flags.get() != null) {
+            flags.get().forEach(meta::addItemFlags);
+        }
         if (customModelData.getExistence() == Existence.REQUIRED) {
             meta.setCustomModelData(customModelData.get());
         }

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/FlagHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/FlagHandler.java
@@ -1,0 +1,78 @@
+package org.betonquest.betonquest.item.typehandler;
+
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.item.QuestItem;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Handles metadata about item flags.
+ */
+public class FlagHandler {
+    /**
+     * Set of ItemFlags on the ItemStack.
+     */
+    private Set<ItemFlag> itemFlags;
+
+    /**
+     * Existence of the flags.
+     */
+    private final QuestItem.Existence existence = QuestItem.Existence.WHATEVER;
+
+    /**
+     * Construct a new FlagHandler.
+     */
+    public FlagHandler() {
+    }
+
+    /**
+     * Parse a String into the Set of ItemFlags.
+     *
+     * @param data The Set of ItemFlags.
+     * @throws InstructionParseException If there is an error parsing.
+     */
+    public void parse(final String data) throws InstructionParseException {
+        this.itemFlags = Arrays.stream(data.split(",")).map(ItemFlag::valueOf).collect(Collectors.toSet());
+    }
+
+    /**
+     * Set the Set of ItemFlags in this handler.
+     *
+     * @param itemFlags The ItemFlags, or null if not set.
+     * @throws InstructionParseException If there is an error setting the flags.
+     */
+    public void set(final Set<ItemFlag> itemFlags) throws InstructionParseException {
+        if (itemFlags == null || itemFlags.isEmpty()) {
+            this.itemFlags = Set.of();
+        } else {
+            this.itemFlags = new HashSet<>(itemFlags);
+        }
+    }
+
+    /**
+     * Get the Set of ItemFlags.
+     *
+     * @return The Set of ItemFlags.
+     */
+    public Set<ItemFlag> get() {
+        return itemFlags;
+    }
+
+    /**
+     * Check to see if the specified ItemMeta matches this FlagHandler.
+     *
+     * @param data The ItemMeta to check.
+     * @return True if this metadata is required or matches, false otherwise.
+     */
+    public boolean check(final ItemMeta data) {
+        return existence == QuestItem.Existence.WHATEVER
+                || existence == QuestItem.Existence.FORBIDDEN && data.getItemFlags().isEmpty()
+                || existence == QuestItem.Existence.REQUIRED && (data.getItemFlags().size() > 0) && itemFlags.equals(data.getItemFlags());
+    }
+
+}


### PR DESCRIPTION
Added FlagHandler to save and restore ItemStack ItemFlags on created QuestItems. This supports hiding different item information about Items, including:
    - HIDE_ENCHANTS: Hide the ItemStack enchants
    - HIDE_ATTRIBUTES: Hide attributes like damage
    - HIDE_UNBREAKABLE: Hide unbreakable state
    - HIDE_DESTROYS: Hide what the ItemStack can break or destroy
    - HIDE_PLACED_ON: Hide where the ItemStack can be placed
    - HIDE_POTION_EFFECTS: Hide potion effects, book and firework info, map tool tips, banner patters, and enchantments
    - HIDE_DYE: Hide the dye labels on colored leather armor

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
