### PR TITLE
fix no default version for messages.yml

### DIFF
--- a/docs/API/ConfigurationFile.md
+++ b/docs/API/ConfigurationFile.md
@@ -26,6 +26,10 @@ The `ConfigurationFile` extends `ConfigurationSection` and therefore provides al
 You can reload, save and delete the ConfigurationFile by calling it's corresponding `reload()`, `save()` and `delete()`
 methods.
 
+Make sure to add a `configVersion` key with an empty string as it's value when adding a new config resource file.
+The patcher will then automatically set the version to the newest available patch version.
+This frees you from the hassle of updating the `configVersion` key in the default resource file every time you add a patch.
+ 
 !!! warning "Reloading Behaviour"
     When reloading the `ConfigurationFile`, it loads a new `ConfigurationSection` from the related file and replaces the old root.
     This means that all references to old child `ConfigurationSection` in your code will be outdated and need to be updated.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,3 +1,4 @@
+configVersion: ""
 pl:
   conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bRozpoczales rozmowe z {1}&b!&e===='


### PR DESCRIPTION
This was an oversight when the first patches were added for this file.  Every patchable file needs an empty version string initially. This signals the patcher that the ressource file is up-to-date.

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
