### PR TITLE
fix using of "action" in GlobalPoint and ScoreboardEvent

### DIFF
--- a/src/main/java/org/betonquest/betonquest/quest/event/point/GlobalPointEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/point/GlobalPointEventFactory.java
@@ -27,11 +27,8 @@ public class GlobalPointEventFactory implements EventFactory, StaticEventFactory
     public Event parseEvent(final Instruction instruction) throws InstructionParseException {
         final String category = Utils.addPackage(instruction.getPackage(), instruction.next());
         final String number = instruction.next();
-        if (instruction.hasArgument("action")) {
-            final String action = instruction.getOptional("action");
-            if (action == null) {
-                throw new InstructionParseException("Missing modification action: " + instruction.current());
-            }
+        final String action = instruction.getOptional("action");
+        if (action != null) {
             try {
                 final Point type = Point.valueOf(action.toUpperCase(Locale.ROOT));
                 return new GlobalPointEvent(category, new VariableNumber(instruction.getPackage(), number), type);

--- a/src/main/java/org/betonquest/betonquest/quest/event/scoreboard/ScoreboardEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/scoreboard/ScoreboardEventFactory.java
@@ -45,15 +45,11 @@ public class ScoreboardEventFactory implements EventFactory {
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public Event parseEvent(final Instruction instruction) throws InstructionParseException {
         final String objective = instruction.next();
         final String number = instruction.next();
-        if (instruction.hasArgument("action")) {
-            final String action = instruction.getOptional("action");
-            if (action == null) {
-                throw new InstructionParseException("Missing modification action: " + instruction.current());
-            }
+        final String action = instruction.getOptional("action");
+        if (action != null) {
             try {
                 final ScoreModification type = ScoreModification.valueOf(action.toUpperCase(Locale.ROOT));
                 return new PrimaryServerThreadEvent(


### PR DESCRIPTION
in the factories introduced in the migration

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
