### PR TITLE
fixed double quotes "some string" does not work in the discord.sh scr…

### DIFF
--- a/.github/scripts/discord.sh
+++ b/.github/scripts/discord.sh
@@ -23,7 +23,11 @@ echo "[Webhook]: Preparing git related variables...";
 AUTHOR_NAME="$(git log -1 "$GITHUB_SHA" --pretty="%aN")"
 COMMITTER_NAME="$(git log -1 "$GITHUB_SHA" --pretty="%cN")"
 COMMIT_SUBJECT="$(git log -1 "$GITHUB_SHA" --pretty="%s")"
-COMMIT_MESSAGE="$(git log -1 "$GITHUB_SHA" --pretty="%b" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g; s/"/\\"/g')"
+COMMIT_MESSAGE="$(git log -1 "$GITHUB_SHA" --pretty="%b")"
+#Replace newlines with literal \n
+COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g;')
+#Replace double quotes with literal \"
+COMMIT_MESSAGE="${COMMIT_MESSAGE//\"/\\\"}"
 COMMIT_URL="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
 BRANCH_NAME="${GITHUB_REF#*/*/}"
 REPO_URL="https://github.com/$GITHUB_REPOSITORY"


### PR DESCRIPTION
…ipt to announce a new build to Discord

<!-- Please describe your changes here. -->
Please keep an eye on that the actual merge message also contains a double quote and new lines to test if this now finally works
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
