### PR TITLE
static events now respect conditions, if they are static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - added `fakeblock` event that has the arguments `showgroup` and `hidegroup` to show and hide FakeBlock groups
     - added `hook.fake-block` config option, default: `true`
 - added Event Schedules to replace old static-events system
+    - static events from schedulers now respect static conditions
 - added support for Base64 encode custom heads
     - can be created from items in inventory using the BetonQuest `item` command (Paper only, Bukkit/Spigot can be configured manually)
     - can be given to players using the BetonQuest `give` command

--- a/docs/Documentation/Scripting/Schedules.md
+++ b/docs/Documentation/Scripting/Schedules.md
@@ -6,24 +6,20 @@ Schedules allow you to run events periodically at specific times for the entire 
 
 ## Static Events
 When running events from a schedule it is unclear how events should behave:  
-Should an event be run once for each player on the server?  
-For events like `setblock` this would mean that the event is executed 20 times if 20 players are online. 
+Should an event be run once for each player on the server? 
+For events like `setblock` this would mean that the event is executed 20 times if 20 players are online.
+And what about offline players?    
 
 This problem is solved by dividing all events into two categories:
 
 1. **Static events** are not tied to a specific player, meaning they can be run independent.  
    `setblock` for example always changes the same block, no matter for who it was called.  
-   When run by a schedule a static event will fire exactly once.
+   When run by a schedule a static event will fire exactly once. You can only assign conditions that are static as well to such events.
 
 2. **Non-static events** are always tied to a specific player.
-   They will be run once for each online player.
+   They will be run once for each online player. You can assign both non-static and static conditions to such events.
 
-!!! warning
-
-    **Static events used by schedules can only have static conditions defined,
-    as the plugin cannot check any condition which requires a player when run by the server.**
-
-All static events have a static flag in the docs, so you can easily distinguish them from non-static ones.
+All static events and conditions have a static flag in the docs, so you can easily distinguish them from non-static ones.
 
 !!! example
 

--- a/docs/Documentation/Scripting/Schedules.md
+++ b/docs/Documentation/Scripting/Schedules.md
@@ -20,8 +20,8 @@ This problem is solved by dividing all events into two categories:
 
 !!! warning
 
-    **Static events used by schedules cannot have conditions defined,
-    as the plugin cannot check any condition for a player who is offline.**
+    **Static events used by schedules can only have static conditions defined,
+    as the plugin cannot check any condition which requires a player when run by the server.**
 
 All static events have a static flag in the docs, so you can easily distinguish them from non-static ones.
 

--- a/src/main/java/org/betonquest/betonquest/api/QuestEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/QuestEvent.java
@@ -119,6 +119,10 @@ public abstract class QuestEvent extends ForceSyncHandler<Void> {
     private void handleNullProfile() throws QuestRuntimeException {
         if (staticness) {
             LOG.debug(instruction.getPackage(), "Static event will be fired without a profile.");
+            if (!BetonQuest.conditions(null, conditions)) {
+                LOG.debug(instruction.getPackage(), "Event conditions were not met");
+                return;
+            }
             handle(null);
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/conditions/GlobalPointCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/GlobalPointCondition.java
@@ -15,6 +15,8 @@ public class GlobalPointCondition extends PointCondition {
 
     public GlobalPointCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction);
+        staticness = true;
+        persistent = true;
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
@@ -115,13 +115,13 @@ abstract class AbstractData<T extends Cloneable> {
     }
 
     private T parseVariableObject(final Profile profile) throws QuestRuntimeException {
-        if (profile == null) {
-            throw new QuestRuntimeException("Variable cannot be accessed without the player."
-                    + " Consider changing it to absolute coordinates");
-        }
         final String[] variables = new String[this.objectVariables.size()];
         for (int i = 0; i < this.objectVariables.size(); i++) {
             final Variable var = this.objectVariables.get(i);
+            if (profile == null && !var.isStaticness()) {
+                throw new QuestRuntimeException("Variable cannot be accessed without the player."
+                        + " Consider changing it to absolute coordinates");
+            }
             variables[i] = var.getValue(profile);
         }
         final String result = String.format(objectFormatted, (Object[]) variables);

--- a/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
+++ b/src/main/java/org/betonquest/betonquest/utils/location/AbstractData.java
@@ -119,7 +119,7 @@ abstract class AbstractData<T extends Cloneable> {
         for (int i = 0; i < this.objectVariables.size(); i++) {
             final Variable var = this.objectVariables.get(i);
             if (profile == null && !var.isStaticness()) {
-                throw new QuestRuntimeException("Variable cannot be accessed without the player."
+                throw new QuestRuntimeException("Variable " + var + " cannot be accessed without the player."
                         + " Consider changing it to absolute coordinates");
             }
             variables[i] = var.getValue(profile);


### PR DESCRIPTION
and Location/Vector can use static variables in a static context too, GlobalPointCondition is now static and persistent like the docs says

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
