### PR TITLE
add depenizen integration to the docs

### DIFF
--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -18,6 +18,7 @@ Skript, Vault, WorldEdit, FastAsyncWorldEdit and WorldGuard._
 Some plugins also hook into BetonQuest and provide support by themselves:  
 [nuNPCDestinations](https://www.spigotmc.org/resources/13863/),
 [CalebCompass](https://www.spigotmc.org/resources/82674/),
+[Depenizen](https://github.com/DenizenScript/Depenizen),
 [NotQuests](https://www.spigotmc.org/resources/95872/),
 [HonnyCompass](https://github.com/honnisha/HonnyCompass)
 [MythicDungeons](https://www.spigotmc.org/resources/102699/)
@@ -267,16 +268,18 @@ BetonQuest [Unified Location Formatting](../Data-Formats.md#unified-location-for
 
 ## Denizen[](http://dev.bukkit.org/bukkit-plugins/denizen/)
 
+
+Depenizen is also integrated with BetonQuest! Discover available features on the [meta documentation](https://meta.denizenscript.com/Docs/Search/BetonQuest).
+
 ### Events
 
 #### Script: `script`
 
 With this event you can fire Denizen task scripts. Don't confuse it with `skript` event, these are different. The first and only argument is the name of the script.
 
-!!! example
-    ```YAML
-    script beton
-    ```
+```YAML title="Example"
+runDenizenScript: "script beton"
+```
 
 ## EffectLib[](http://dev.bukkit.org/bukkit-plugins/effectlib/)
 

--- a/docs/_snippets/constants.yml
+++ b/docs/_snippets/constants.yml
@@ -1,1 +1,1 @@
-totalIntegratedPluginsNumber: "34"
+totalIntegratedPluginsNumber: "35"


### PR DESCRIPTION
Since more BQ integration is currently added by Alen from the discord, we should list Depenizen as integrated!

### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
