### PR TITLE
Fix missing file ending for inter-documentation link.

### DIFF
--- a/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
+++ b/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
@@ -132,7 +132,7 @@ Keep that in mind when creating sounds close to a player. They can move around t
 | soundcategory     | The [category](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/SoundCategory.html) in which the sound will be played.                                  |
 | soundvolume       | Minecraft's [special sound volume](https://minecraft.gamepedia.com/Commands/playsound#Arguments). Default: _1_                                             |
 | soundpitch        | Pitch of the sound. Default: _1_ Min: _0_ Max: _2_                                                                                                         |
-| soundlocation     | Default: The player's location. A location using the BetonQuest [ULF](../../Scripting/Data-Formats#unified-location-formating). Can include variables.     |
+| soundlocation     | Default: The player's location. A location using the BetonQuest [ULF](../../Scripting/Data-Formats.md#unified-location-formating). Can include variables.  |
 | soundplayeroffset | This option is special. See below.                                                                                                                         |
 
 <h3>soundplayeroffset:</h3>


### PR DESCRIPTION
Might fix the failing "build docs" job, or at least the warning. But it does not fix that the actions fail when the docs job fails.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
