### PR TITLE
Fix performance for resolving existing quest primitives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Hologram topX line not working with profiles
 - the craft objective could be completed without consuming materials
 - LocationObjective resolves variable for a player who does not have the objective, and so maybe also dont have the variable
+- performance when using many conditions / events / ... repeatedly
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -465,13 +465,7 @@ public class BetonQuest extends JavaPlugin {
             getInstance().log.debug("Null condition ID!");
             return false;
         }
-        Condition condition = null;
-        for (final Entry<ConditionID, Condition> e : CONDITIONS.entrySet()) {
-            if (e.getKey().equals(conditionID)) {
-                condition = e.getValue();
-                break;
-            }
-        }
+        final Condition condition = CONDITIONS.get(conditionID);
         if (condition == null) {
             getInstance().log.warn(conditionID.getPackage(), "The condition " + conditionID + " is not defined!");
             return false;
@@ -510,13 +504,7 @@ public class BetonQuest extends JavaPlugin {
             getInstance().log.debug("Null event ID!");
             return;
         }
-        QuestEvent event = null;
-        for (final Entry<EventID, QuestEvent> e : EVENTS.entrySet()) {
-            if (e.getKey().equals(eventID)) {
-                event = e.getValue();
-                break;
-            }
-        }
+        final QuestEvent event = EVENTS.get(eventID);
         if (event == null) {
             getInstance().log.warn(eventID.getPackage(), "Event " + eventID + " is not defined");
             return;
@@ -546,13 +534,7 @@ public class BetonQuest extends JavaPlugin {
             getInstance().log.debug(objectiveID.getPackage(), "Null arguments for the objective!");
             return;
         }
-        Objective objective = null;
-        for (final Entry<ObjectiveID, Objective> e : OBJECTIVES.entrySet()) {
-            if (e.getKey().equals(objectiveID)) {
-                objective = e.getValue();
-                break;
-            }
-        }
+        final Objective objective = OBJECTIVES.get(objectiveID);
         if (objective.containsPlayer(profile)) {
             getInstance().log.debug(objectiveID.getPackage(), profile + " already has the " + objectiveID + " objective");
             return;
@@ -572,13 +554,7 @@ public class BetonQuest extends JavaPlugin {
             getInstance().log.debug("Null arguments for the objective!");
             return;
         }
-        Objective objective = null;
-        for (final Entry<ObjectiveID, Objective> e : OBJECTIVES.entrySet()) {
-            if (e.getKey().equals(objectiveID)) {
-                objective = e.getValue();
-                break;
-            }
-        }
+        final Objective objective = OBJECTIVES.get(objectiveID);
         if (objective == null) {
             getInstance().log.warn(objectiveID.getPackage(), "Objective " + objectiveID + " does not exist");
             return;
@@ -609,10 +585,9 @@ public class BetonQuest extends JavaPlugin {
             throw new InstructionParseException("Could not load variable: " + e.getMessage(), e);
         }
         // no need to create duplicated variables
-        for (final Entry<VariableID, Variable> e : VARIABLES.entrySet()) {
-            if (e.getKey().equals(variableID)) {
-                return e.getValue();
-            }
+        final Variable existingVariable = VARIABLES.get(variableID);
+        if (existingVariable != null) {
+            return existingVariable;
         }
         final Instruction instructionVar = variableID.generateInstruction();
         final Class<? extends Variable> variableClass = VARIABLE_TYPES.get(instructionVar.getPart(0));
@@ -1596,12 +1571,7 @@ public class BetonQuest extends JavaPlugin {
      * @return Objective object or null if it does not exist
      */
     public Objective getObjective(final ObjectiveID objectiveID) {
-        for (final Entry<ObjectiveID, Objective> e : OBJECTIVES.entrySet()) {
-            if (e.getKey().equals(objectiveID)) {
-                return e.getValue();
-            }
-        }
-        return null;
+        return OBJECTIVES.get(objectiveID);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/id/ID.java
+++ b/src/main/java/org/betonquest/betonquest/id/ID.java
@@ -166,12 +166,16 @@ public abstract class ID {
     }
 
     @Override
-    public boolean equals(final Object other) {
-        if (other instanceof final ID identifier) {
-            return identifier.identifier.equals(this.identifier)
-                    && identifier.pack.getQuestPath().equals(this.pack.getQuestPath());
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
         }
-        return false;
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ID other = (ID) obj;
+        return Objects.equals(identifier, other.identifier)
+                && Objects.equals(pack.getQuestPath(), other.pack.getQuestPath());
     }
 
     @Override


### PR DESCRIPTION
Replaced inefficient looping over HashMap EntrySets by actually using hashes to find values fast.

---

### Related Issues
[Low tps with BQ + HolographicDisplays Discord Thread](https://discord.com/channels/407221862980911105/1138212479445504020)

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
