### PR TITLE
Item durability for vanilla items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `give` event - new `backpack` argument to place items in the backpack (if a valid QuestItem)
 - `party` event - new optional `amount` of maximal affected players
 - `drop` event
+- `itemdurability` event
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `give` event - new `backpack` argument to place items in the backpack (if a valid QuestItem)
 - `party` event - new optional `amount` of maximal affected players
 - `drop` event
-- `itemdurability` event
+- `itemdurability` event, condition and variable
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
@@ -246,6 +246,20 @@ This condition requires the player to have all specified items in his inventory 
     item emerald:5,gold:10
     ```
 
+## Durability of item: `itemdurability`
+
+This condition requires the player to have a certain amount of durability on an item.
+The first argument is the slot, the second the amount.
+Optional `relative` argument sets 0 to broken and 1 to the maximum durability the item can have.
+This condition returns false when no item is in the given slot or does not have durability, like stone or sticks.
+Available slot types: `HAND`, `OFF_HAND`, `HEAD`, `CHEST`, `LEGS`, `FEET`.
+
+!!! example
+    ```YAML
+    itemdurability HAND 50
+    itemdurability CHEST 0.5 relative
+    ```
+
 ## Journal entry: `journal`
 
 This condition will return true if the player has specified entry in his journal (internal name of the entry, like in _journal_ section). The only argument is name of the entry.

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -313,9 +313,13 @@ string is `if condition event1 else event2`, where `condition` is a condition ID
 
 Adds or removes durability from an item in the slot.
 The first argument is the slot, the second the change of durability and the third the amount.
-Optional arguments are `ignoreUnbreakable` to ignore the unbreakable flag and durability/unbreaking enchantment
+Optional arguments are `ignoreUnbreakable` to ignore the unbreakable flag and unbreaking enchantment
 and `ignoreEvents` to bypass event logic, so other plugins will not be able to interfere.
 Available slot types: `HAND`, `OFF_HAND`, `HEAD`, `CHEST`, `LEGS`, `FEET`.
+
+!!! info
+    Both increasing and decreasing durability will be affected by the unbreaking enchantment.
+    To prevent this behaviour use the `ignoreUnbreakable` argument.
 
 !!! example
     ```YAML

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -309,6 +309,20 @@ string is `if condition event1 else event2`, where `condition` is a condition ID
     if sun rain else sun
     ```
 
+## Item durability: `itemdurability`
+
+Adds or removes durability from an item in the slot.
+The first argument is the slot, the second the change of durability and the third the amount.
+Optional arguments are `ignoreUnbreakable` to ignore the unbreakable flag and durability/unbreaking enchantment
+and `ignoreEvents` to bypass event logic, so other plugins will not be able to interfere.
+Available slot types: `HAND`, `OFF_HAND`, `HEAD`, `CHEST`, `LEGS`, `FEET`.
+
+!!! example
+    ```YAML
+    itemdurability HAND ADD 1
+    itemdurability CHEST SUBTRACT %randomnumber.whole.15~30% ignoreUnbreakable ignoreEvents
+    ```
+
 ## Journal: `journal`
 
 **static**

--- a/docs/Documentation/Scripting/Building-Blocks/Variables-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Variables-List.md
@@ -127,6 +127,22 @@ Both `name` and `lore` supports the `raw` subargument to get the text without fo
 %item.epic_sword.lore:0.raw%
 ```
 
+### Item durability variable
+
+With this variable you can display the durability of an item.
+The first argument is the slot.
+An optional argument is `relative` which will display the durability of the item relative to the maximum
+from 0 to 1, where 1 is the maximum. You can specify the amount of digits with the argument `digits:x`,
+where `x` is a whole number. This default is 2 digits.
+Additionally, you get the output in percent (inclusive the '%' symbol).
+
+```
+%itemdurability.HAND%
+%itemdurability.CHEST.relative%
+%itemdurability.CHEST.relative.percent%
+%itemdurability.HEAD.relative.digits:5%
+```
+
 ### Location Variable
 
 This variable resolves to all aspects of the player's location. The x, y and z coordinates, the world name, the yaw and pitch (head rotation).

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -58,6 +58,7 @@ import org.betonquest.betonquest.conditions.HeightCondition;
 import org.betonquest.betonquest.conditions.HungerCondition;
 import org.betonquest.betonquest.conditions.InConversationCondition;
 import org.betonquest.betonquest.conditions.ItemCondition;
+import org.betonquest.betonquest.conditions.ItemDurabilityCondition;
 import org.betonquest.betonquest.conditions.JournalCondition;
 import org.betonquest.betonquest.conditions.LanguageCondition;
 import org.betonquest.betonquest.conditions.LocationCondition;
@@ -831,6 +832,7 @@ public class BetonQuest extends JavaPlugin {
         registerConditions("burning", BurningCondition.class);
         registerConditions("inconversation", InConversationCondition.class);
         registerConditions("hunger", HungerCondition.class);
+        registerConditions("itemdurability", ItemDurabilityCondition.class);
 
         registerEvents("objective", ObjectiveEvent.class);
         registerEvents("command", CommandEvent.class);

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -885,6 +885,7 @@ public class BetonQuest extends JavaPlugin {
         registerNonStaticEvent("cancelconversation", new CancelConversationEventFactory(loggerFactory));
         registerEvent("deleteglobalpoint", new DeleteGlobalPointEventFactory());
         registerEvent("drop", new DropEventFactory(getServer(), getServer().getScheduler(), this));
+        registerNonStaticEvent("itemdurability", new ItemDamageEventFactory(loggerFactory, getServer(), getServer().getScheduler(), this));
 
         registerObjectives("location", LocationObjective.class);
         registerObjectives("block", BlockObjective.class);

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -211,6 +211,7 @@ import org.betonquest.betonquest.quest.event.experience.ExperienceEventFactory;
 import org.betonquest.betonquest.quest.event.explosion.ExplosionEventFactory;
 import org.betonquest.betonquest.quest.event.give.GiveEventFactory;
 import org.betonquest.betonquest.quest.event.hunger.HungerEventFactory;
+import org.betonquest.betonquest.quest.event.item.ItemDurabilityEventFactory;
 import org.betonquest.betonquest.quest.event.journal.GiveJournalEventFactory;
 import org.betonquest.betonquest.quest.event.journal.JournalEventFactory;
 import org.betonquest.betonquest.quest.event.kill.KillEventFactory;
@@ -888,7 +889,7 @@ public class BetonQuest extends JavaPlugin {
         registerNonStaticEvent("cancelconversation", new CancelConversationEventFactory(loggerFactory));
         registerEvent("deleteglobalpoint", new DeleteGlobalPointEventFactory());
         registerEvent("drop", new DropEventFactory(getServer(), getServer().getScheduler(), this));
-        registerNonStaticEvent("itemdurability", new ItemDamageEventFactory(loggerFactory, getServer(), getServer().getScheduler(), this));
+        registerNonStaticEvent("itemdurability", new ItemDurabilityEventFactory(loggerFactory, getServer(), getServer().getScheduler(), this));
 
         registerObjectives("location", LocationObjective.class);
         registerObjectives("block", BlockObjective.class);

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -243,6 +243,7 @@ import org.betonquest.betonquest.utils.PlayerConverter;
 import org.betonquest.betonquest.variables.ConditionVariable;
 import org.betonquest.betonquest.variables.GlobalPointVariable;
 import org.betonquest.betonquest.variables.GlobalTagVariable;
+import org.betonquest.betonquest.variables.ItemDurabilityVariable;
 import org.betonquest.betonquest.variables.ItemVariable;
 import org.betonquest.betonquest.variables.LocationVariable;
 import org.betonquest.betonquest.variables.MathVariable;
@@ -955,6 +956,7 @@ public class BetonQuest extends JavaPlugin {
         registerVariable("location", LocationVariable.class);
         registerVariable("math", MathVariable.class);
         registerVariable("randomnumber", RandomNumberVariable.class);
+        registerVariable("itemdurability", ItemDurabilityVariable.class);
 
         registerScheduleType("realtime-daily", RealtimeDailySchedule.class, new RealtimeDailyScheduler(loggerFactory.create(RealtimeDailyScheduler.class, "Schedules"), lastExecutionCache));
         registerScheduleType("realtime-cron", RealtimeCronSchedule.class, new RealtimeCronScheduler(loggerFactory.create(RealtimeCronScheduler.class, "Schedules"), lastExecutionCache));

--- a/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
@@ -12,26 +12,26 @@ import org.bukkit.inventory.meta.Damageable;
 
 /**
  * To check durability on the item on a specific slot,
- * in opposite to {@link QuestItem#getDurability()}
+ * in opposite to {@link QuestItem#getDurability()}.
  */
 public class ItemDurabilityCondition extends Condition {
     /**
-     * The slot to check
+     * The slot to check.
      */
     private final EquipmentSlot slot;
 
     /**
-     * The durability needed
+     * The durability needed.
      */
     private final VariableNumber amount;
 
     /**
-     * If the durability should be handled as value from 0 to 1
+     * If the durability should be handled as value from 0 to 1.
      */
     private final boolean relative;
 
     /**
-     * Creates an item durability condition
+     * Creates an item durability condition.
      */
     public ItemDurabilityCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, false);

--- a/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
@@ -1,0 +1,63 @@
+package org.betonquest.betonquest.conditions;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.Condition;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.item.QuestItem;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * To check durability on the item on a specific slot,
+ * in opposite to {@link QuestItem#getDurability()}
+ */
+public class ItemDurabilityCondition extends Condition {
+    /**
+     * The slot to check
+     */
+    private final EquipmentSlot slot;
+
+    /**
+     * The durability needed
+     */
+    private final VariableNumber amount;
+
+    /**
+     * If the durability should be handled as value from 0 to 1
+     */
+    private final boolean relative;
+
+    /**
+     * Creates an item durability condition
+     */
+    public ItemDurabilityCondition(@NotNull final Instruction instruction) throws InstructionParseException {
+        super(instruction, false);
+        this.slot = instruction.getEnum(EquipmentSlot.class);
+        this.amount = instruction.getVarNum();
+        this.relative = instruction.hasArgument("relative");
+    }
+
+    @Override
+    protected Boolean execute(@NotNull final Profile profile) {
+        final ItemStack itemStack = profile.getOnlineProfile().get().getPlayer().getEquipment().getItem(slot);
+        if (itemStack.getType().isAir() || !(itemStack.getItemMeta() instanceof final Damageable damageable)) {
+            return false;
+        }
+        final int maxDurability = itemStack.getType().getMaxDurability();
+        if (maxDurability == 0) {
+            return false;
+        }
+        final int actualDurability = maxDurability - damageable.getDamage();
+        final double requiredAmount = amount.getDouble(profile);
+        if (relative) {
+            final double relativeValue = (double) actualDurability / (double) maxDurability;
+            return relativeValue >= requiredAmount;
+        } else {
+            return actualDurability >= requiredAmount;
+        }
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/ItemDurabilityCondition.java
@@ -9,7 +9,6 @@ import org.betonquest.betonquest.item.QuestItem;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * To check durability on the item on a specific slot,
@@ -34,7 +33,7 @@ public class ItemDurabilityCondition extends Condition {
     /**
      * Creates an item durability condition
      */
-    public ItemDurabilityCondition(@NotNull final Instruction instruction) throws InstructionParseException {
+    public ItemDurabilityCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, false);
         this.slot = instruction.getEnum(EquipmentSlot.class);
         this.amount = instruction.getVarNum();
@@ -42,7 +41,7 @@ public class ItemDurabilityCondition extends Condition {
     }
 
     @Override
-    protected Boolean execute(@NotNull final Profile profile) {
+    protected Boolean execute(final Profile profile) {
         final ItemStack itemStack = profile.getOnlineProfile().get().getPlayer().getEquipment().getItem(slot);
         if (itemStack.getType().isAir() || !(itemStack.getItemMeta() instanceof final Damageable damageable)) {
             return false;

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDamageEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDamageEventFactory.java
@@ -1,0 +1,68 @@
+package org.betonquest.betonquest.quest.event.item;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.api.quest.event.EventFactory;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.quest.event.OnlineProfileRequiredEvent;
+import org.betonquest.betonquest.quest.event.PrimaryServerThreadEvent;
+import org.betonquest.betonquest.quest.event.point.Point;
+import org.bukkit.Server;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+
+/**
+ * Factory for the item durability event.
+ */
+public class ItemDamageEventFactory implements EventFactory {
+    /**
+     * Factory to create custom {@link BetonQuestLogger} instance for the event.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    /**
+     * Server to use for syncing to the primary server thread.
+     */
+    private final Server server;
+
+    /**
+     * Scheduler to use for syncing to the primary server thread.
+     */
+    private final BukkitScheduler scheduler;
+
+    /**
+     * Plugin to use for syncing to the primary server thread.
+     */
+    private final Plugin plugin;
+
+    /**
+     * Create the item damage event factory.
+     *
+     * @param loggerFactory logger factory to use
+     * @param server        server to use
+     * @param scheduler     scheduler to use
+     * @param plugin        plugin to use
+     */
+    public ItemDamageEventFactory(final BetonQuestLoggerFactory loggerFactory, final Server server, final BukkitScheduler scheduler, final Plugin plugin) {
+        this.loggerFactory = loggerFactory;
+        this.server = server;
+        this.scheduler = scheduler;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Event parseEvent(final Instruction instruction) throws InstructionParseException {
+        final EquipmentSlot slot = instruction.getEnum(EquipmentSlot.class);
+        final Point operation = instruction.getEnum(Point.class);
+        final VariableNumber amount = instruction.getVarNum();
+        final boolean ignoreUnbreakable = instruction.hasArgument("ignoreUnbreakable");
+        final boolean ignoreEvents = instruction.hasArgument("ignoreEvents");
+        final ItemDurabilityEvent event = new ItemDurabilityEvent(slot, operation, amount, ignoreUnbreakable, ignoreEvents);
+        return new PrimaryServerThreadEvent(new OnlineProfileRequiredEvent(loggerFactory.create(event.getClass()), event, instruction.getPackage()),
+                server, scheduler, plugin);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
@@ -1,0 +1,156 @@
+package org.betonquest.betonquest.quest.event.item;
+
+import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.quest.event.point.Point;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * The item durability event, to modify the durability of an item
+ */
+public class ItemDurabilityEvent implements Event {
+    /**
+     * The slot to target
+     */
+    private final EquipmentSlot slot;
+
+    /**
+     * The point type, how the durability should be modified
+     */
+    private final Point modification;
+
+    /**
+     * The amount of the modification
+     */
+    private final VariableNumber amount;
+
+    /**
+     * To ignore {@link ItemMeta#isUnbreakable()} and {@link Enchantment#DURABILITY}
+     */
+    private final boolean ignoreUnbreakable;
+
+    /**
+     * To ignore bukkit event logic
+     */
+    private final boolean ignoreEvents;
+
+    /**
+     * Creates a new item durability event
+     *
+     * @param slot              of the item
+     * @param modification      on the durability
+     * @param amount            argument of the modification
+     * @param ignoreUnbreakable whether if the enchantment and tag should be ignored or respected
+     * @param ignoreEvents      whether the bukkit events should be ignored or called
+     */
+    public ItemDurabilityEvent(final EquipmentSlot slot, final Point modification, final VariableNumber amount, final boolean ignoreUnbreakable, final boolean ignoreEvents) {
+        this.slot = slot;
+        this.modification = modification;
+        this.amount = amount;
+        this.ignoreUnbreakable = ignoreUnbreakable;
+        this.ignoreEvents = ignoreEvents;
+    }
+
+    @Override
+    public void execute(final Profile profile) {
+        final Player player = profile.getOnlineProfile().get().getPlayer();
+        final EntityEquipment equipment = player.getEquipment();
+        final ItemStack itemStack = equipment.getItem(slot);
+        if (itemStack.getType().isAir() || !(itemStack.getItemMeta() instanceof final Damageable damageable)) {
+            return;
+        }
+        if (damageable.isUnbreakable() && !ignoreUnbreakable) {
+            return;
+        }
+        final int value = amount.getInt(profile);
+        if (value == 0) {
+            return;
+        }
+        processDamage(player, itemStack, damageable, value);
+    }
+
+    private void processDamage(final Player player, final ItemStack itemStack, final Damageable damageable, final double value) {
+        final int maxDurability = itemStack.getType().getMaxDurability();
+        final int oldDamage = damageable.getDamage();
+        final int actualDurability = maxDurability - oldDamage;
+
+        final int newDurability = modification.modify(actualDurability, value);
+        final int newDamage = maxDurability - newDurability;
+        final int damageDifference = newDamage - oldDamage;
+
+        final int durabilityModifiedDamage;
+        if (damageDifference < 0) {
+            durabilityModifiedDamage = -getDurabilityModifiedDamage(damageable, -damageDifference);
+        } else if (damageDifference > 0) {
+            durabilityModifiedDamage = getDurabilityModifiedDamage(damageable, damageDifference);
+        } else {
+            return;
+        }
+
+        final int actualDifference;
+        if (ignoreEvents) {
+            actualDifference = durabilityModifiedDamage;
+        } else {
+            final PlayerItemDamageEvent event = new PlayerItemDamageEvent(player, itemStack, durabilityModifiedDamage, damageDifference);
+            Bukkit.getPluginManager().callEvent(event);
+            if (event.isCancelled()) {
+                return;
+            }
+            actualDifference = event.getDamage();
+        }
+
+        final int actualNewDamage = oldDamage + actualDifference;
+        damageable.setDamage(actualNewDamage);
+
+        if (maxDurability - actualNewDamage <= 0) {
+            processBreak(player, itemStack, damageable);
+        }
+
+        itemStack.setItemMeta(damageable);
+    }
+
+    private int getDurabilityModifiedDamage(final ItemMeta meta, final int damageDifference) {
+        if (ignoreUnbreakable) {
+            return damageDifference;
+        }
+        final int level = meta.getEnchantLevel(Enchantment.DURABILITY);
+        if (level == 0) {
+            return damageDifference;
+        }
+        final int levelPlusOne = level + 1;
+        // TODO Armor gets less damage reduction according to the wiki
+        //  https://minecraft.fandom.com/wiki/Unbreaking#Usage
+        int damage = 0;
+        final int chance = 100 / levelPlusOne;
+        for (int i = 0; i < damageDifference; i++) {
+            final int random = ThreadLocalRandom.current().nextInt(100);
+            if (random >= chance) {
+                damage++;
+            }
+        }
+        return damage;
+    }
+
+    private void processBreak(final Player player, final ItemStack itemStack, final Damageable damageable) {
+        if (!ignoreEvents) {
+            final PlayerItemBreakEvent event = new PlayerItemBreakEvent(player, itemStack);
+            Bukkit.getPluginManager().callEvent(event);
+        }
+        itemStack.subtract();
+        damageable.setDamage(0);
+        player.playSound(player, Sound.ENTITY_ITEM_BREAK, 1, 1);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
@@ -9,7 +9,6 @@ import org.bukkit.Sound;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerItemBreakEvent;
-import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -100,19 +99,7 @@ public class ItemDurabilityEvent implements Event {
             return;
         }
 
-        final int actualDifference;
-        if (ignoreEvents) {
-            actualDifference = durabilityModifiedDamage;
-        } else {
-            final PlayerItemDamageEvent event = new PlayerItemDamageEvent(player, itemStack, durabilityModifiedDamage, damageDifference);
-            Bukkit.getPluginManager().callEvent(event);
-            if (event.isCancelled()) {
-                return;
-            }
-            actualDifference = event.getDamage();
-        }
-
-        final int actualNewDamage = oldDamage + actualDifference;
+        final int actualNewDamage = oldDamage + durabilityModifiedDamage;
         damageable.setDamage(actualNewDamage);
 
         if (maxDurability - actualNewDamage <= 0) {

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
@@ -74,8 +74,11 @@ public class ItemDurabilityEvent implements Event {
         if (damageable.isUnbreakable() && !ignoreUnbreakable) {
             return;
         }
-        final int value = amount.getInt(profile);
+        final double value = amount.getDouble(profile);
         if (value == 0) {
+            if (modification == Point.SET || modification == Point.MULTIPLY) {
+                processBreak(player, itemStack, damageable);
+            }
             return;
         }
         processDamage(player, itemStack, damageable, value);
@@ -136,7 +139,7 @@ public class ItemDurabilityEvent implements Event {
             final PlayerItemBreakEvent event = new PlayerItemBreakEvent(player, itemStack);
             Bukkit.getPluginManager().callEvent(event);
         }
-        itemStack.subtract();
+        itemStack.setAmount(itemStack.getAmount() - 1);
         damageable.setDamage(0);
         player.playSound(player, Sound.ENTITY_ITEM_BREAK, 1, 1);
     }

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
@@ -18,36 +18,36 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * The item durability event, to modify the durability of an item
+ * The item durability event, to modify the durability of an item.
  */
 public class ItemDurabilityEvent implements Event {
     /**
-     * The slot to target
+     * The slot to target.
      */
     private final EquipmentSlot slot;
 
     /**
-     * The point type, how the durability should be modified
+     * The point type, how the durability should be modified.
      */
     private final Point modification;
 
     /**
-     * The amount of the modification
+     * The amount of the modification.
      */
     private final VariableNumber amount;
 
     /**
-     * To ignore {@link ItemMeta#isUnbreakable()} and {@link Enchantment#DURABILITY}
+     * To ignore {@link ItemMeta#isUnbreakable()} and {@link Enchantment#DURABILITY}.
      */
     private final boolean ignoreUnbreakable;
 
     /**
-     * To ignore bukkit event logic
+     * To ignore bukkit event logic.
      */
     private final boolean ignoreEvents;
 
     /**
-     * Creates a new item durability event
+     * Creates a new item durability event.
      *
      * @param slot              of the item
      * @param modification      on the durability

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEvent.java
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 
 /**
  * The item durability event, to modify the durability of an item.
@@ -47,6 +47,11 @@ public class ItemDurabilityEvent implements Event {
     private final boolean ignoreEvents;
 
     /**
+     * The random instance to use.
+     */
+    private final Random random;
+
+    /**
      * Creates a new item durability event.
      *
      * @param slot              of the item
@@ -54,13 +59,15 @@ public class ItemDurabilityEvent implements Event {
      * @param amount            argument of the modification
      * @param ignoreUnbreakable whether if the enchantment and tag should be ignored or respected
      * @param ignoreEvents      whether the bukkit events should be ignored or called
+     * @param random            to use for the durability calculation
      */
-    public ItemDurabilityEvent(final EquipmentSlot slot, final Point modification, final VariableNumber amount, final boolean ignoreUnbreakable, final boolean ignoreEvents) {
+    public ItemDurabilityEvent(final EquipmentSlot slot, final Point modification, final VariableNumber amount, final boolean ignoreUnbreakable, final boolean ignoreEvents, final Random random) {
         this.slot = slot;
         this.modification = modification;
         this.amount = amount;
         this.ignoreUnbreakable = ignoreUnbreakable;
         this.ignoreEvents = ignoreEvents;
+        this.random = random;
     }
 
     @Override
@@ -128,7 +135,7 @@ public class ItemDurabilityEvent implements Event {
         } else {
             chance = 100 / levelPlusOne;
         }
-        return (int) ThreadLocalRandom.current().ints(damageDifference).filter(random -> random >= chance).count();
+        return (int) random.ints(damageDifference).filter(random -> random >= chance).count();
     }
 
     private void processBreak(final Player player, final ItemStack itemStack, final Damageable damageable) {

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEventFactory.java
@@ -18,7 +18,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 /**
  * Factory for the item durability event.
  */
-public class ItemDamageEventFactory implements EventFactory {
+public class ItemDurabilityEventFactory implements EventFactory {
     /**
      * Factory to create custom {@link BetonQuestLogger} instance for the event.
      */
@@ -40,14 +40,14 @@ public class ItemDamageEventFactory implements EventFactory {
     private final Plugin plugin;
 
     /**
-     * Create the item damage event factory.
+     * Create the item durability event factory.
      *
      * @param loggerFactory logger factory to use
      * @param server        server to use
      * @param scheduler     scheduler to use
      * @param plugin        plugin to use
      */
-    public ItemDamageEventFactory(final BetonQuestLoggerFactory loggerFactory, final Server server, final BukkitScheduler scheduler, final Plugin plugin) {
+    public ItemDurabilityEventFactory(final BetonQuestLoggerFactory loggerFactory, final Server server, final BukkitScheduler scheduler, final Plugin plugin) {
         this.loggerFactory = loggerFactory;
         this.server = server;
         this.scheduler = scheduler;

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/ItemDurabilityEventFactory.java
@@ -15,6 +15,8 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
 
+import java.util.Random;
+
 /**
  * Factory for the item durability event.
  */
@@ -61,7 +63,7 @@ public class ItemDurabilityEventFactory implements EventFactory {
         final VariableNumber amount = instruction.getVarNum();
         final boolean ignoreUnbreakable = instruction.hasArgument("ignoreUnbreakable");
         final boolean ignoreEvents = instruction.hasArgument("ignoreEvents");
-        final ItemDurabilityEvent event = new ItemDurabilityEvent(slot, operation, amount, ignoreUnbreakable, ignoreEvents);
+        final ItemDurabilityEvent event = new ItemDurabilityEvent(slot, operation, amount, ignoreUnbreakable, ignoreEvents, new Random());
         return new PrimaryServerThreadEvent(new OnlineProfileRequiredEvent(loggerFactory.create(event.getClass()), event, instruction.getPackage()),
                 server, scheduler, plugin);
     }

--- a/src/main/java/org/betonquest/betonquest/quest/event/item/package-info.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/item/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@link org.betonquest.betonquest.api.quest.event.Event Event} implementation for item related events.
+ */
+package org.betonquest.betonquest.quest.event.item;

--- a/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
@@ -8,7 +8,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Returns the durability of a vanilla item
@@ -43,7 +42,7 @@ public class ItemDurabilityVariable extends Variable {
     /**
      * Creates a new item durability variable
      */
-    public ItemDurabilityVariable(@NotNull final Instruction instruction) throws InstructionParseException {
+    public ItemDurabilityVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.slot = instruction.getEnum(EquipmentSlot.class);
         this.relative = instruction.hasArgument("relative");
@@ -51,7 +50,7 @@ public class ItemDurabilityVariable extends Variable {
         this.inPercent = instruction.hasArgument("percent");
     }
 
-    private int digits(@NotNull final Instruction instruction) throws InstructionParseException {
+    private int digits(final Instruction instruction) throws InstructionParseException {
         if (instruction.hasArgument("digits")) {
             for (int i = instruction.size() - 2; i >= 0; i--) {
                 final String part = instruction.getPart(i);
@@ -64,7 +63,7 @@ public class ItemDurabilityVariable extends Variable {
     }
 
     @Override
-    public String getValue(@NotNull final Profile profile) {
+    public String getValue(final Profile profile) {
         final Player player = profile.getOnlineProfile().get().getPlayer();
         final ItemStack itemStack = player.getEquipment().getItem(slot);
         final int maxDurability = itemStack.getType().getMaxDurability();

--- a/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
@@ -1,0 +1,86 @@
+package org.betonquest.betonquest.variables;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.Variable;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Returns the durability of a vanilla item
+ */
+public class ItemDurabilityVariable extends Variable {
+    /**
+     * The default amount of digits after comma
+     */
+    private static final int DEFAULT_DIGITS = 2;
+
+    /**
+     * The slot of the item
+     */
+    private final EquipmentSlot slot;
+
+    /**
+     * If the durability should be displayed relative to maximum,
+     * where 1 is max
+     */
+    private final boolean relative;
+
+    /**
+     * The amount of digits displayed after comma
+     */
+    private final int digitsAfter;
+
+    /**
+     * If the output should be multiplied with 100 and with a '%' in the end
+     */
+    private final boolean inPercent;
+
+    /**
+     * Creates a new item durability variable
+     */
+    public ItemDurabilityVariable(@NotNull final Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        this.slot = instruction.getEnum(EquipmentSlot.class);
+        this.relative = instruction.hasArgument("relative");
+        this.digitsAfter = digits(instruction);
+        this.inPercent = instruction.hasArgument("percent");
+    }
+
+    private int digits(@NotNull final Instruction instruction) throws InstructionParseException {
+        if (instruction.hasArgument("digits")) {
+            for (int i = instruction.size() - 2; i >= 0; i--) {
+                final String part = instruction.getPart(i);
+                if ("digits".equalsIgnoreCase(part)) {
+                    return instruction.getInt(instruction.getPart(i + 1), DEFAULT_DIGITS);
+                }
+            }
+        }
+        return DEFAULT_DIGITS;
+    }
+
+    @Override
+    public String getValue(@NotNull final Profile profile) {
+        final Player player = profile.getOnlineProfile().get().getPlayer();
+        final ItemStack itemStack = player.getEquipment().getItem(slot);
+        final int maxDurability = itemStack.getType().getMaxDurability();
+        if (!(itemStack.getItemMeta() instanceof final Damageable damageable)) {
+            return String.valueOf(maxDurability);
+        }
+        final int durability = maxDurability - damageable.getDamage();
+        if (relative && maxDurability != 0) {
+            String format = "%." + digitsAfter + 'f';
+            double value = (double) durability / (double) maxDurability;
+            if (inPercent) {
+                format += "%%";
+                value *= 100;
+            }
+            return String.format(player.locale(), format, value);
+        }
+        return String.valueOf(durability);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
@@ -78,7 +78,7 @@ public class ItemDurabilityVariable extends Variable {
                 format += "%%";
                 value *= 100;
             }
-            return String.format(player.locale(), format, value);
+            return String.format(format, value);
         }
         return String.valueOf(durability);
     }

--- a/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/ItemDurabilityVariable.java
@@ -10,37 +10,37 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 
 /**
- * Returns the durability of a vanilla item
+ * Returns the durability of a vanilla item.
  */
 public class ItemDurabilityVariable extends Variable {
     /**
-     * The default amount of digits after comma
+     * The default amount of digits after comma.
      */
     private static final int DEFAULT_DIGITS = 2;
 
     /**
-     * The slot of the item
+     * The slot of the item.
      */
     private final EquipmentSlot slot;
 
     /**
-     * If the durability should be displayed relative to maximum,
-     * where 1 is max
+     * If the durability should be displayed relative to maximum.
+     * Maximum is 1.
      */
     private final boolean relative;
 
     /**
-     * The amount of digits displayed after comma
+     * The amount of digits displayed after comma.
      */
     private final int digitsAfter;
 
     /**
-     * If the output should be multiplied with 100 and with a '%' in the end
+     * If the output should be multiplied with 100 and with a '%' in the end.
      */
     private final boolean inPercent;
 
     /**
-     * Creates a new item durability variable
+     * Creates a new item durability variable.
      */
     public ItemDurabilityVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Migrated the stuff around durability of vanilla items from my AddOn to the main plugin.
The event is a mess because the method does not exist in 1.18.
I hope I have nowhere used Paper API.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
