### PR TITLE
Fix variable objective data storage (+ improvements)

### DIFF
--- a/src/main/java/org/betonquest/betonquest/objectives/VariableObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/VariableObjective.java
@@ -104,7 +104,7 @@ public class VariableObjective extends Objective implements Listener {
 
         public VariableData(final String instruction, final Profile profile, final String objID) {
             super(instruction, profile, objID);
-            final String[] rawVariables = instruction.split("(^)(?=\\S+:)");
+            final String[] rawVariables = instruction.split("(\n)(?=\\S+:)");
             for (final String rawVariable : rawVariables) {
                 if (rawVariable.contains(":")) {
                     final String[] parts = rawVariable.split(":", 2);

--- a/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
+++ b/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
@@ -1,0 +1,41 @@
+package org.betonquest.betonquest.objectives;
+
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class VariableObjectiveTest {
+    @ParameterizedTest
+    @MethodSource("serializedVariableObjectiveData")
+    void testLoadingVariable(final String serializedData, final String expectedKey, final String expectedValue, @Mock final Profile profile) {
+        final VariableObjective.VariableData data = new VariableObjective.VariableData(serializedData, profile, "");
+        final String value = data.get(expectedKey);
+        assertEquals(expectedValue, value, "Values from deserialized variable objective instruction should be correct.");
+    }
+
+    public static Stream<Arguments> serializedVariableObjectiveData() {
+        return Stream.of(
+                Arguments.of("", "any", null),
+                Arguments.of("test:data", "test", "data"),
+                Arguments.of("test:data", "missing", null),
+                Arguments.of("one:1\ntwo:22\nthree:333", "one", "1"),
+                Arguments.of("one:1\ntwo:22\nthree:333", "two", "22"),
+                Arguments.of("one:1\ntwo:22\nthree:333", "three", "333"),
+                Arguments.of("one:1\ntwo:22\nthree:333", "four", null),
+                Arguments.of("newline:This is a\nnewline test!", "newline", "This is a\nnewline test!"),
+                Arguments.of("newline:This is a\nnewline test!", "newline test!", null),
+                Arguments.of("multi-newline:This\nis\na\nmulti\nnewline\ntest!", "multi-newline", "This\nis\na\nmulti\nnewline\ntest!"),
+                Arguments.of("first-newliner:This is a\nnewline test!\nsecond-newliner:This also\ncontains a newline!", "first-newliner", "This is a\nnewline test!"),
+                Arguments.of("first-newliner:This is a\nnewline test!\nsecond-newliner:This also\ncontains a newline!", "second-newliner", "This also\ncontains a newline!")
+        );
+    }
+}

--- a/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
+++ b/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class VariableObjectiveTest {
     @ParameterizedTest
     @MethodSource("serializedVariableObjectiveData")
-    void testLoadingVariable(final String serializedData, final String expectedKey, final String expectedValue, @Mock final Profile profile) {
+    void loading_variables_from_serialized_data(final String serializedData, final String expectedKey, final String expectedValue, @Mock final Profile profile) {
         final VariableObjective.VariableData data = new VariableObjective.VariableData(serializedData, profile, "");
         final String value = data.get(expectedKey);
         assertEquals(expectedValue, value, "Values from deserialized variable objective instruction should be correct.");
@@ -27,7 +27,7 @@ class VariableObjectiveTest {
 
     @ParameterizedTest
     @MethodSource("serializableVariableObjectiveData")
-    void testStoringVariable(final Map<String, String> variables, final String expectedData) {
+    void storing_variables_as_serialized_data(final Map<String, String> variables, final String expectedData) {
         final String serialized = VariableObjective.VariableData.serializeData(variables);
         assertEquals(expectedData, serialized, "Serialized variable objective data instruction should be correct.");
     }

--- a/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
+++ b/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +25,13 @@ class VariableObjectiveTest {
         assertEquals(expectedValue, value, "Values from deserialized variable objective instruction should be correct.");
     }
 
+    @ParameterizedTest
+    @MethodSource("serializableVariableObjectiveData")
+    void testStoringVariable(final Map<String, String> variables, final String expectedData) {
+        final String serialized = VariableObjective.VariableData.serializeData(variables);
+        assertEquals(expectedData, serialized, "Serialized variable objective data instruction should be correct.");
+    }
+
     public static Stream<Arguments> serializedVariableObjectiveData() {
         return Stream.of(
                 Arguments.of("", "any", null),
@@ -31,11 +41,67 @@ class VariableObjectiveTest {
                 Arguments.of("one:1\ntwo:22\nthree:333", "two", "22"),
                 Arguments.of("one:1\ntwo:22\nthree:333", "three", "333"),
                 Arguments.of("one:1\ntwo:22\nthree:333", "four", null),
+                Arguments.of("newline:This is a\\nnewline test!", "newline", "This is a\nnewline test!"),
                 Arguments.of("newline:This is a\nnewline test!", "newline", "This is a\nnewline test!"),
                 Arguments.of("newline:This is a\nnewline test!", "newline test!", null),
+                Arguments.of("multi-newline:This\\nis\\na\\nmulti\\nnewline\\ntest!", "multi-newline", "This\nis\na\nmulti\nnewline\ntest!"),
                 Arguments.of("multi-newline:This\nis\na\nmulti\nnewline\ntest!", "multi-newline", "This\nis\na\nmulti\nnewline\ntest!"),
                 Arguments.of("first-newliner:This is a\nnewline test!\nsecond-newliner:This also\ncontains a newline!", "first-newliner", "This is a\nnewline test!"),
-                Arguments.of("first-newliner:This is a\nnewline test!\nsecond-newliner:This also\ncontains a newline!", "second-newliner", "This also\ncontains a newline!")
+                Arguments.of("first-newliner:This is a\nnewline test!\nsecond-newliner:This also\ncontains a newline!", "second-newliner", "This also\ncontains a newline!"),
+                Arguments.of("first-newliner:This is a\\nnewline test!\nsecond-newliner:This also\\ncontains a newline!", "first-newliner", "This is a\nnewline test!"),
+                Arguments.of("first-newliner:This is a\\nnewline test!\nsecond-newliner:This also\\ncontains a newline!", "second-newliner", "This also\ncontains a newline!"),
+                Arguments.of("contains_colon:This: Is a test.", "contains_colon", "This: Is a test."),
+                Arguments.of("contains_colon:This\\: Is a test.", "contains_colon", "This: Is a test."),
+                Arguments.of("rou\\ge:backslash", "rou\\ge", "backslash"),
+                Arguments.of("rou\\\\ge:backslash", "rou\\ge", "backslash"),
+                Arguments.of("rouge:back\\slash", "rouge", "back\\slash"),
+                Arguments.of("rouge:back\\\\slash", "rouge", "back\\slash"),
+                Arguments.of("evil\\:key:Should still work correctly.", "evil:key", "Should still work correctly."),
+                Arguments.of("space in key:Whyyouask?WhynotIanswer!", "space in key", "Whyyouask?WhynotIanswer!"),
+                Arguments.of("test:works\nspace in second key:Whyyouask?WhynotIanswer!", "test", "works"),
+                Arguments.of("test:works\nspace in second key:Whyyouask?WhynotIanswer!", "space in second key", "Whyyouask?WhynotIanswer!"),
+                Arguments.of("ending\\::\\:beginning", "ending:", ":beginning"),
+                Arguments.of("escaped_escape\\\\:does_not_escape", "escaped_escape\\", "does_not_escape"),
+                Arguments.of(" starts_with_space : ends with space ", " starts_with_space ", " ends with space "),
+                Arguments.of("newline\\nin_key?:That's fancy!", "newline\nin_key?", "That's fancy!"),
+                Arguments.of("test:works\nnewline_in\\nsecond_key?:That's fancy!", "test", "works"),
+                Arguments.of("test:works\nnewline_in\\nsecond_key?:That's fancy!", "newline_in\nsecond_key?", "That's fancy!"),
+                Arguments.of("test:works\n\\\\:Only backslash key!", "test", "works"),
+                Arguments.of("test:works\n\\\\:Only backslash key!", "\\", "Only backslash key!"),
+                Arguments.of("test:works\n\\\\\\\\\\\\:Multi backslash key!", "test", "works"),
+                Arguments.of("test:works\n\\\\\\\\\\\\:Multi backslash key!", "\\\\\\", "Multi backslash key!")
         );
+    }
+
+    public static Stream<Arguments> serializableVariableObjectiveData() {
+        return Stream.of(
+                Arguments.of(Collections.emptyMap(), ""),
+                Arguments.of(Collections.singletonMap("test", "data"), "test:data"),
+                Arguments.of(linkedMapOf("one", "1", "two", "22", "three", "333"), "one:1\ntwo:22\nthree:333"),
+                Arguments.of(Collections.singletonMap("newline", "This is a\nnewline test!"), "newline:This is a\\nnewline test!"),
+                Arguments.of(Collections.singletonMap("multi-newline", "This\nis\na\nmulti\nnewline\ntest!"), "multi-newline:This\\nis\\na\\nmulti\\nnewline\\ntest!"),
+                Arguments.of(linkedMapOf("first-newliner", "This is a\nnewline test!", "second-newliner", "This also\ncontains a newline!"), "first-newliner:This is a\\nnewline test!\nsecond-newliner:This also\\ncontains a newline!"),
+                Arguments.of(Collections.singletonMap("contains_colon", "This: Is a test."), "contains_colon:This\\: Is a test."),
+                Arguments.of(Collections.singletonMap("rouge", "back\\slash"), "rouge:back\\\\slash"),
+                Arguments.of(Collections.singletonMap("rou\\ge", "backslash"), "rou\\\\ge:backslash"),
+                Arguments.of(Collections.singletonMap("evil:key", "Should still work correctly."), "evil\\:key:Should still work correctly."),
+                Arguments.of(Collections.singletonMap("space in key", "Whyyouask?WhynotIanswer!"), "space in key:Whyyouask?WhynotIanswer!"),
+                Arguments.of(linkedMapOf("test", "works", "space in second key", "Whyyouask?WhynotIanswer!"), "test:works\nspace in second key:Whyyouask?WhynotIanswer!"),
+                Arguments.of(Collections.singletonMap("ending:", ":beginning"), "ending\\::\\:beginning"),
+                Arguments.of(Collections.singletonMap("escaped_escape\\", "does_not_escape"), "escaped_escape\\\\:does_not_escape"),
+                Arguments.of(Collections.singletonMap(" starts_with_space ", " ends with space "), " starts_with_space : ends with space "),
+                Arguments.of(Collections.singletonMap("newline\nin_key?", "That's fancy!"), "newline\\nin_key?:That's fancy!"),
+                Arguments.of(linkedMapOf("test", "works", "newline_in\nsecond_key?", "That's fancy!"), "test:works\nnewline_in\\nsecond_key?:That's fancy!"),
+                Arguments.of(linkedMapOf("test", "works", "\\", "Only backslash key!"), "test:works\n\\\\:Only backslash key!"),
+                Arguments.of(linkedMapOf("test", "works", "\\\\\\", "Multi backslash key!"), "test:works\n\\\\\\\\\\\\:Multi backslash key!")
+        );
+    }
+
+    private static Map<String, String> linkedMapOf(final String... values) {
+        final Map<String, String> map = new LinkedHashMap<>();
+        for (int index = 0; index < values.length - 1; index += 2) {
+            map.put(values[index], values[index + 1]);
+        }
+        return map;
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Storing multiple variables in one variable objective was broken since #2373 was merged. I've added tests to ensure that everything works correctly and fixed the bug.

While I was at it I made it possible to store virtually anything in variables with keys that now also can be virtually anything.
This second part (the second commit) can be safely omitted in case that we only want to merge the bugfix at first.

---

### Related Issues
<!-- Issue number if existing. -->
Closes Discord question thread [Variable objective bugged?](https://discord.com/channels/407221862980911105/1141848281580843048)

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
