### PR TITLE
Fix conversation start race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - 1.19 ProtocolLib warnings about deprecated packages
     - conversation IO chest did not show the correct NPC heads
     - conversation could have a deadlock and a player can get stuck in a conversation
+    - conversation could not be canceled due to a race condition
     - `npcrange` objective - is triggered at wrong time
     - `command` event - includes 'conditions:...' into the command
     - `craft` objective - multi-craft, drop-craft, hotbar/offhand-craft, shift-Q-craft and any illegal crafting is

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -569,12 +569,14 @@ public class Conversation implements Listener {
                 state = ConversationState.ACTIVE;
                 // the conversation start event must be run on next tick
                 final PlayerConversationStartEvent event = new PlayerConversationStartEvent(onlineProfile, conv);
+                // blocks this thread until the conversation start event is fully dispatched
                 final CompletableFuture<?> blocking = new CompletableFuture<>();
                 new BukkitRunnable() {
 
                     @Override
                     public void run() {
                         Bukkit.getServer().getPluginManager().callEvent(event);
+                        // allows this function to continue
                         blocking.complete(null);
                     }
                 }.runTask(BetonQuest.getInstance());


### PR DESCRIPTION
Fixes a race condition that occurs when a conversation is bound to start.

Replaces #2494 by cleaning up the commit history and fixing found issues.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2494

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
