### PR TITLE
Fix Schedules `catchup` does not work for the first time when missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `title` event
 - `playsound` event
 ### Fixed
+- catchup now works even if schedule was never executed before
 - q version now works again
 - RPGMenu error when teleport events are used as click events
 - RPGMenu bound items not always working

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/LastExecutionCache.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/LastExecutionCache.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -133,6 +134,21 @@ public class LastExecutionCache {
      */
     public boolean isCached(final ScheduleID scheduleID) {
         return getRawLastExecutionTime(scheduleID).isPresent();
+    }
+
+    /**
+     * For all schedules that are not in the cache, cache the current time as last execution time.
+     * This allows to find missed schedules during shutdown.
+     *
+     * @param schedules ids of the schedules to cache
+     */
+    public void cacheStartupTime(final Collection<ScheduleID> schedules) {
+        final Instant startupTime = Instant.now();
+        for (final ScheduleID schedule : schedules) {
+            if (!isCached(schedule)) {
+                cacheExecutionTime(schedule, startupTime);
+            }
+        }
     }
 
 }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronScheduler.java
@@ -65,6 +65,7 @@ public class RealtimeCronScheduler extends ExecutorServiceScheduler<RealtimeCron
 
     @Override
     public void start() {
+        lastExecutionCache.cacheStartupTime(schedules.keySet());
         log.debug("Starting realtime scheduler.");
         if (reboot) {
             reboot = false;

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedule.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedule.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
@@ -56,14 +57,25 @@ public class RealtimeDailySchedule extends Schedule {
     /**
      * Get the next execution time as instant.
      *
+     * @param startTime the time to start searching for the next execution
      * @return instant when the next run of this schedule will be
      */
-    public Instant getNextExecution() {
-        final OffsetDateTime now = OffsetDateTime.now();
+    public Instant getNextExecution(final Instant startTime) {
+        final OffsetDateTime now = OffsetDateTime.ofInstant(startTime, ZoneId.systemDefault());
         OffsetDateTime targetTime = getTimeToRun().atOffset(now.getOffset()).atDate(now.toLocalDate());
         if (targetTime.isBefore(now)) {
             targetTime = targetTime.plusDays(1);
         }
         return targetTime.toInstant();
+    }
+
+    /**
+     * Get the next execution time as instant.
+     * This method uses {@link Instant#now()} as the start time.
+     *
+     * @return instant when the next run of this schedule will be
+     */
+    public Instant getNextExecution() {
+        return getNextExecution(Instant.now());
     }
 }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
@@ -58,6 +58,7 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
 
     @Override
     public void start() {
+        lastExecutionCache.cacheStartupTime(schedules.keySet());
         log.debug("Starting simple scheduler.");
         catchupMissedSchedules();
         super.start();
@@ -134,7 +135,7 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
             if (schedule.getCatchup() != CatchupStrategy.NONE) {
                 final Optional<Instant> lastExecutionTime = lastExecutionCache.getLastExecutionTime(schedule.getId());
                 if (lastExecutionTime.isPresent()
-                        && lastExecutionTime.get().plus(1, ChronoUnit.DAYS).isBefore(Instant.now())) {
+                        && schedule.getNextExecution(lastExecutionTime.get()).isBefore(Instant.now())) {
                     missedRuns.add(new MissedRun(schedule, lastExecutionTime.get().plus(1, ChronoUnit.DAYS)));
                 }
             }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
@@ -134,9 +134,9 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
         for (final RealtimeDailySchedule schedule : schedules.values()) {
             if (schedule.getCatchup() != CatchupStrategy.NONE) {
                 final Optional<Instant> lastExecutionTime = lastExecutionCache.getLastExecutionTime(schedule.getId());
-                if (lastExecutionTime.isPresent()
-                        && schedule.getNextExecution(lastExecutionTime.get()).isBefore(Instant.now())) {
-                    missedRuns.add(new MissedRun(schedule, lastExecutionTime.get().plus(1, ChronoUnit.DAYS)));
+                final Optional<Instant> nextExecution = lastExecutionTime.map(schedule::getNextExecution);
+                if (nextExecution.isPresent() && nextExecution.get().isBefore(Instant.now())) {
+                    missedRuns.add(new MissedRun(schedule, nextExecution.get()));
                 }
             }
         }

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedulerTest.java
@@ -55,6 +55,7 @@ class RealtimeDailySchedulerTest {
         final RealtimeDailyScheduler scheduler = spy(new RealtimeDailyScheduler(logger, cache));
         scheduler.start();
 
+        verify(cache).cacheStartupTime(any());
         verify(logger, times(1)).debug("Starting simple scheduler.");
         verify(logger, times(1)).debug("Collecting missed schedules...");
         verify(logger, times(1)).debug("Found 0 missed schedule runs that will be caught up.");
@@ -161,6 +162,7 @@ class RealtimeDailySchedulerTest {
         scheduler.addSchedule(schedule);
         scheduler.start();
 
+        verify(cache).cacheStartupTime(any());
         verify(logger, times(1)).debug("Starting simple scheduler.");
         verify(logger, times(1)).debug("Collecting missed schedules...");
         verify(logger, times(1)).debug("Found 0 missed schedule runs that will be caught up.");

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedulerTest.java
@@ -72,6 +72,7 @@ class RealtimeDailySchedulerTest {
         @SuppressWarnings("PMD.CloseResource") final ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
         final RealtimeDailyScheduler scheduler = new RealtimeDailyScheduler(logger, () -> executorService, cache);
         final RealtimeDailySchedule schedule = getSchedule(CatchupStrategy.ONE);
+        when(schedule.getNextExecution(any())).thenReturn(nextMissedExecution);
         when(schedule.getNextExecution()).thenReturn(Instant.now());
         scheduler.addSchedule(schedule);
         scheduler.start();
@@ -98,6 +99,7 @@ class RealtimeDailySchedulerTest {
         @SuppressWarnings("PMD.CloseResource") final ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
         final RealtimeDailyScheduler scheduler = new RealtimeDailyScheduler(logger, () -> executorService, cache);
         final RealtimeDailySchedule schedule = getSchedule(CatchupStrategy.ALL);
+        when(schedule.getNextExecution(any())).thenReturn(nextMissedExecution1, nextMissedExecution2, nextMissedExecution3);
         when(schedule.getNextExecution()).thenReturn(Instant.now());
         scheduler.addSchedule(schedule);
         scheduler.start();


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Current progress on fixing this issue:
* [X] Updated LastExecutionTest & Schedulers to cache initial value
* [X] Made sure Schedulers can handle times in the cache that aren't actuall execution times
* [x] Updated unit-tests
* [x] Tested on live server

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2497

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
