### PR TITLE
fixed concurrency issue during conversation start by preventing endin…

### DIFF
--- a/src/main/java/org/betonquest/betonquest/conversation/ChatConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ChatConvIO.java
@@ -94,7 +94,7 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
         if (!event.getTo().getWorld().equals(conv.getLocation().getWorld()) || event.getTo()
                 .distance(conv.getLocation()) > maxNpcDistance) {
             // we can stop the player or end conversation
-            if (conv.isMovementBlock()) {
+            if (conv.isMovementBlock() || !conv.state.isStarted()) {
                 moveBack(event);
             } else {
                 conv.endConversation();


### PR DESCRIPTION
…g of the conversation until the startup is completed

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
