### PR TITLE
fixed LastExecutionCacheTest#testCacheStartup() by allowing the cache…

### DIFF
--- a/src/test/java/org/betonquest/betonquest/modules/schedule/LastExecutionCacheTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/LastExecutionCacheTest.java
@@ -181,7 +181,7 @@ class LastExecutionCacheTest {
         final Instant end = Instant.now();
         final ArgumentMatcher<String> isCurrentTime = value -> {
             final Instant cachedTime = Instant.parse(value);
-            return cachedTime.isAfter(start) && cachedTime.isBefore(end);
+            return !cachedTime.isBefore(start) && !cachedTime.isAfter(end);
         };
         verify(cacheContent).set(eq("test-package.testCacheStartup-newSchedule"), argThat(isCurrentTime));
         verify(cacheContent, never()).set(eq("test-package.testCacheStartup-cachedSchedule"), anyString());


### PR DESCRIPTION
… time to be equivalent to the start and/or end time for environments with slow clocks

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
