### PR TITLE
Fix FolderEvent minutes

### DIFF
--- a/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
+++ b/src/main/java/org/betonquest/betonquest/events/FolderEvent.java
@@ -114,8 +114,7 @@ public class FolderEvent extends QuestEvent {
 
         if (minutes) {
             time *= 20 * 60;
-        }
-        if (!ticks) {
+        } else if (!ticks) {
             time *= 20;
         }
         return time;


### PR DESCRIPTION
Fix that the minutes argument will result in 20x the time.
Made in https://github.com/BetonQuest/BetonQuest/commit/bd14c64a830d4970e09ca4d3f563f62130179320#diff-5a0938e948b2573113978e8753ebe3423b2180fbf9c2b75aefea630e1ec33c97L64

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
