### PR TITLE
Update RedisChat dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <dependency>
       <groupId>com.github.Emibergo02</groupId>
       <artifactId>RedisChat</artifactId>
-      <version>main-d1a2d70e05-1</version>
+      <version>4.0.6</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
* Updated RedisChat dependency to use the tagged version `4.0.6`.
* JitPack should not drop the artifacts for this build as it is a proper release, the previous "version" was dropped at one point as it was just a random build of a commit on the main branch.

---

### Related Issues
<!-- Issue number if existing. -->
Fixes failing daily dependency check.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
