### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/docs/Documentation/Features/Menus/Menu.md
+++ b/docs/Documentation/Features/Menus/Menu.md
@@ -30,7 +30,7 @@ These are general settings for customizing a menu.
 
 | Setting Name | <div style="width:160px">Example</div> | Description                                                                                                                                                                     |
 |:------------:|:---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   `title`    | `title: "&6&lQuests"`                  | Will be displayed in the top left corner of your menu. You can use [color codes](https://minecraft.gamepedia.com/Formatting_codes) to color the title. Variables are supported. |
+|   `title`    | `title: "&6&lQuests"`                  | Will be displayed in the top left corner of your menu. You can use [color codes](https://minecraft.wiki/w/Formatting_codes) to color the title. Variables are supported. |
 |   `height`   | `height: 3`                            | How many lines of slots your menu will have. Minimum 1, Maximum 6.                                                                                                              |
 
 #### Optional Settings
@@ -76,7 +76,7 @@ The three basic optional settings.
 ### The optional `text` setting
 By default, the name and description of the quest item is displayed when hovering over the item.
 You can overwrite this by using the `text` setting.
-Both [color codes](https://minecraft.gamepedia.com/Formatting_codes) and [variables](../../Scripting/Building-Blocks/Variables-List.md) are supported.
+Both [color codes](https://minecraft.wiki/w/Formatting_codes) and [variables](../../Scripting/Building-Blocks/Variables-List.md) are supported.
 The text can be provided as a single string with newlines, a multi-line string, or a list of strings, see examples.
 
 ``` YAML title="List Example"

--- a/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
@@ -7,7 +7,7 @@ icon: octicons/question-16
 
 This condition checks if the player has specified advancement. The only argument is the full name of the advancement.
 This includes the namespace, the tab and the name of the advancement as configured on your server. 
-[List of all vanilla advancements](https://minecraft.gamepedia.com/Advancement#List_of_advancements).
+[List of all vanilla advancements](https://minecraft.wiki/w/Advancement#List_of_advancements).
 
 !!! example
     ```YAML
@@ -298,7 +298,7 @@ Checks if the player is looking at a block with the given location or material. 
 
 ## Moon Cycle: `mooncycle`
 
-This condition checks the players moon cycle (1 is full moon, 8 is Waxing Gibbous) and returns if the player is under that moon. A list of phases can be found [here](https://minecraft.gamepedia.com/Moon).
+This condition checks the players moon cycle (1 is full moon, 8 is Waxing Gibbous) and returns if the player is under that moon. A list of phases can be found [here](https://minecraft.wiki/w/Moon).
 
 !!! example
     ```YAML

--- a/docs/Documentation/Scripting/Data-Formats.md
+++ b/docs/Documentation/Scripting/Data-Formats.md
@@ -44,12 +44,12 @@ Where:
   It can be a [regex](#regex-regular-expressions).
   If the regex ends with square brackets you have to add another pair of empty square brackets even if you don't want to 
   use the state argument (`[regex][]`).  
-  Instead of using a regex to match multiple materials you can also define a [tag](https://minecraft.gamepedia.com/Tag).
+  Instead of using a regex to match multiple materials you can also define a [tag](https://minecraft.wiki/w/Tag).
   Every tag matches a special group of blocks or items that can be grouped together logically. They can be used using this format `:blocks:flowers` or `minecraft:blocks:flowers`.
   Be aware that a tag always starts with either `:` or a namespace. 
   
   - `state` - (optional) The block states can be provided in a comma separated `key=value` list surrounded by square brackets.
-   You can look up states in the Minecraft [wiki](https://minecraft.gamepedia.com/Block_states).
+   You can look up states in the Minecraft [wiki](https://minecraft.wiki/w/Block_states).
    Any states left out will be ignored when matching.
    *Values* can be a [regex](#regex-regular-expressions).
 

--- a/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
+++ b/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
@@ -122,7 +122,7 @@ during the animation.
 
 ### Sound
 This IO just plays a sound. You can use its options in any other IO.
-You should read the [wiki page](https://minecraft.gamepedia.com/Commands/playsound) of the playsound command
+You should read the [wiki page](https://minecraft.wiki/w/Commands/playsound) of the playsound command
 as Minecraft's sound system is kinda strange. Just one example: Sound never moves in Minecraft. It's totally static.
 Keep that in mind when creating sounds close to a player. They can move around the sound and make it louder or quieter by walking towards / away from it.
 
@@ -130,7 +130,7 @@ Keep that in mind when creating sounds close to a player. They can move around t
 |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | sound             | Sound to play. If blank, no sound. Either vanilla Minecraft sounds (get them using /playsound autocompletion) or the name of a sound from a resource pack. |
 | soundcategory     | The [category](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/SoundCategory.html) in which the sound will be played.                                  |
-| soundvolume       | Minecraft's [special sound volume](https://minecraft.gamepedia.com/Commands/playsound#Arguments). Default: _1_                                             |
+| soundvolume       | Minecraft's [special sound volume](https://minecraft.wiki/w/Commands/playsound#Arguments). Default: _1_                                             |
 | soundpitch        | Pitch of the sound. Default: _1_ Min: _0_ Max: _2_                                                                                                         |
 | soundlocation     | Default: The player's location. A location using the BetonQuest [ULF](../../Scripting/Data-Formats.md#unified-location-formating). Can include variables.  |
 | soundplayeroffset | This option is special. See below.                                                                                                                         |


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.

Let me know if I should open a PR for other branches!

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
