### PR TITLE
Add workaround for SporBugs to work with Java 21 class files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -879,6 +879,33 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.7.3.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>9.5</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-analysis</artifactId>
+              <version>9.5</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-commons</artifactId>
+              <version>9.5</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-tree</artifactId>
+              <version>9.5</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-util</artifactId>
+              <version>9.5</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <excludeFilterFile>${basedir}/config/spotbugs-exclude.xml</excludeFilterFile>
             <effort>max</effort>


### PR DESCRIPTION
<!-- Please describe your changes here. -->
SpotBugs uses `org.ow2.asm` internally to read bytecode. To successfully read bytecode created with a Java 21 compiler this library needs to be updated to the most recent release. This is the official workaround to solve this issue (described in spotbugs/spotbugs#2567) until they release a new version with the updated dependency included.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
