### PR TITLE
fixed giving `air` with the give command or the give event crashes the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Journal entries did count color codes as line length, affecting the formatting of pages
 - Notification categories could be modified during runtime with the notify event
 - Leading spaces are now preserved in conversation messages and journal entries 
+- giving `air` with the give command or the give event crashes the server
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/src/main/java/org/betonquest/betonquest/quest/event/give/GiveEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/give/GiveEvent.java
@@ -64,7 +64,7 @@ public class GiveEvent implements Event {
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
         final Player player = profile.getOnlineProfile().get().getPlayer();
-        Arrays.stream(questItems).toList().forEach(item -> {
+        for (final Item item : questItems) {
             final QuestItem questItem = item.getItem();
             final int amount = item.getAmount().getInt(profile);
             giveItems(profile, player, questItem, amount);
@@ -72,15 +72,20 @@ public class GiveEvent implements Event {
                     ? questItem.getMaterial().toString().toLowerCase(Locale.ROOT).replace("_", " ")
                     : questItem.getName();
             itemsGivenSender.sendNotification(profile, questItemName, String.valueOf(amount));
-        });
+        }
     }
 
-    private void giveItems(final Profile profile, final Player player, final QuestItem questItem, final int totalAmount) {
+    @SuppressWarnings("PMD.CognitiveComplexity")
+    private void giveItems(final Profile profile, final Player player, final QuestItem questItem, final int totalAmount)
+            throws QuestRuntimeException {
         int amount = totalAmount;
         while (amount > 0) {
-            boolean fullInventory = false;
             final ItemStack itemStackTemplate = questItem.generate(1, profile);
             final int stackSize = Math.min(amount, itemStackTemplate.getMaxStackSize());
+            if (stackSize <= 0) {
+                throw new QuestRuntimeException("Item stack size is 0 or less!");
+            }
+            boolean fullInventory = false;
             ItemStack itemStack = itemStackTemplate.clone();
             itemStack.setAmount(stackSize);
             if (!backpack) {


### PR DESCRIPTION
ItemStack Air has a `getMaxStackSize` of `0` so the give algorithm runs for ever. So now <= 0 stacks will immediately return.

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
