### PR TITLE
fixed `menu` conversation IO kicked players when conversation started…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Notification categories could be modified during runtime with the notify event
 - Leading spaces are now preserved in conversation messages and journal entries 
 - giving `air` with the give command or the give event crashes the server
+- `menu` conversation IO kicked players when conversation started in the air caused by flying detection
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -25,6 +25,10 @@ import org.betonquest.betonquest.utils.LocalChatPaginator;
 import org.betonquest.betonquest.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -212,8 +216,15 @@ public class MenuConvIO extends ChatConvIO {
             }
             state = ConversationState.ACTIVE;
 
-            // Create something painful looking for the player to sit on and make it invisible.
-            stand = player.getWorld().spawn(player.getLocation().clone().add(0, -1.1, 0), ArmorStand.class);
+            final World world = player.getWorld();
+            final Location location = player.getLocation();
+            final Location target = location.clone();
+            target.setY(world.getHighestBlockYAt(location));
+            final BlockData blockData = target.getBlock().getBlockData();
+            if (blockData instanceof final Slab slab && slab.getType() == Slab.Type.BOTTOM) {
+                target.add(0, -0.5, 0);
+            }
+            stand = world.spawn(target.add(0, -0.375, 0), ArmorStand.class);
 
             stand.setGravity(false);
             stand.setVisible(false);

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -26,7 +26,6 @@ import org.betonquest.betonquest.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Slab;
@@ -217,10 +216,8 @@ public class MenuConvIO extends ChatConvIO {
             }
             state = ConversationState.ACTIVE;
 
-            final World world = player.getWorld();
-            final Location location = player.getLocation();
-            final Location target = getBlockBelowPlayer(location);
-            stand = world.spawn(target.add(0, -0.375, 0), ArmorStand.class);
+            final Location target = getBlockBelowPlayer(player);
+            stand = player.getWorld().spawn(target.add(0, -0.375, 0), ArmorStand.class);
 
             stand.setGravity(false);
             stand.setVisible(false);
@@ -246,12 +243,19 @@ public class MenuConvIO extends ChatConvIO {
         }
     }
 
-    private Location getBlockBelowPlayer(final Location location) {
+    private Location getBlockBelowPlayer(final Player player) {
+        final Location location = player.getLocation();
+        if (player.isFlying()) {
+            return location.add(0, -1, 0);
+        }
         final Location target = location.clone();
         Block block = target.getBlock();
         while (!block.isSolid()) {
             target.add(0, -1, 0);
             block = target.getBlock();
+            if (target.getY() < target.getWorld().getMinHeight()) {
+                return location;
+            }
         }
         target.setY(block.getY());
         final BlockData blockData = block.getBlockData();

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -27,6 +27,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Slab;
 import org.bukkit.configuration.ConfigurationSection;
@@ -218,12 +219,7 @@ public class MenuConvIO extends ChatConvIO {
 
             final World world = player.getWorld();
             final Location location = player.getLocation();
-            final Location target = location.clone();
-            target.setY(world.getHighestBlockYAt(location));
-            final BlockData blockData = target.getBlock().getBlockData();
-            if (blockData instanceof final Slab slab && slab.getType() == Slab.Type.BOTTOM) {
-                target.add(0, -0.5, 0);
-            }
+            final Location target = getBlockBelowPlayer(location);
             stand = world.spawn(target.add(0, -0.375, 0), ArmorStand.class);
 
             stand.setGravity(false);
@@ -248,6 +244,21 @@ public class MenuConvIO extends ChatConvIO {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    private Location getBlockBelowPlayer(final Location location) {
+        final Location target = location.clone();
+        Block block = target.getBlock();
+        while (!block.isSolid()) {
+            target.add(0, -1, 0);
+            block = target.getBlock();
+        }
+        target.setY(block.getY());
+        final BlockData blockData = block.getBlockData();
+        if (blockData instanceof final Slab slab && slab.getType() == Slab.Type.BOTTOM) {
+            target.add(0, -0.5, 0);
+        }
+        return target;
     }
 
     /**


### PR DESCRIPTION
… in the air caused by flying detection

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2554

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
