### PR TITLE
Add `log` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `numbercompare` condition
 - `cancelOnLogout` argument for `folder` event
 - `npcinteract` objective - now supports the argument `interaction` to choose between left, right or both clicks
+- `log` event
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -743,7 +743,7 @@ events:
 **persistent**, **static**  
 
 Prints a provided message to the server log. Any variables used in the message will be resolved. 
-Note that when used in static context (by schedules) replacing variables won't work as the event is player independent.
+Note that when used in static context (by schedules) replacing player dependent variables won't work as the event is player independent.
 
 | Parameter | Syntax           | Default Value | Explanation                                                                                                                               |
 |-----------|------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -738,3 +738,15 @@ events:
   events:
     cancel: "cancelconversation"
 ```
+## Log message to console: `log`
+
+**persistent**, **static**  
+
+Prints a provided message to the server log. Any variables used in the message will be resolved. 
+Note that when used in static context (by schedules) replacing variables won't work as the event is player independent.
+
+```YAML title="Example"
+  events:
+    logPlayer: "log %player% completed first quest."
+```
+

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -745,8 +745,13 @@ events:
 Prints a provided message to the server log. Any variables used in the message will be resolved. 
 Note that when used in static context (by schedules) replacing variables won't work as the event is player independent.
 
+| Parameter | Syntax           | Default Value | Explanation                                                                                                                               |
+|-----------|------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| _level_   | `level:logLevel` | `INFO`        | Optionally the log level can be specified but only **before** the message. <br>There are 4 levels: `debug`, `info`, `warning` and `error` |
+
 ```YAML title="Example"
   events:
     logPlayer: "log %player% completed first quest."
+    debug: "log level:DEBUG daily quests have been reset"
 ```
 

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -227,6 +227,7 @@ import org.betonquest.betonquest.quest.event.legacy.QuestEventFactory;
 import org.betonquest.betonquest.quest.event.legacy.QuestEventFactoryAdapter;
 import org.betonquest.betonquest.quest.event.lever.LeverEventFactory;
 import org.betonquest.betonquest.quest.event.lightning.LightningEventFactory;
+import org.betonquest.betonquest.quest.event.log.LogEventFactory;
 import org.betonquest.betonquest.quest.event.logic.IfElseEventFactory;
 import org.betonquest.betonquest.quest.event.notify.NotifyAllEventFactory;
 import org.betonquest.betonquest.quest.event.notify.NotifyEventFactory;
@@ -953,6 +954,7 @@ public class BetonQuest extends JavaPlugin {
         registerEvent("deleteglobalpoint", new DeleteGlobalPointEventFactory());
         registerEvent("drop", new DropEventFactory(getServer(), getServer().getScheduler(), this));
         registerNonStaticEvent("itemdurability", new ItemDurabilityEventFactory(loggerFactory, getServer(), getServer().getScheduler(), this));
+        registerEvent("log", new LogEventFactory(loggerFactory));
 
         registerObjectives("location", LocationObjective.class);
         registerObjectives("block", BlockObjective.class);

--- a/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
@@ -22,18 +22,25 @@ public class LogEvent implements Event {
     private final BetonQuestLogger logger;
 
     /**
+     * Level to log the message at.
+     */
+    private final LogEventLevel level;
+
+    /**
      * Create a new {@link LogEvent}
      *
-     * @param logger logger used for logging messages.
+     * @param logger  logger used for logging messages.
+     * @param level   level to log the message at.
      * @param message message that should be printed to the server log.
      */
-    public LogEvent(final BetonQuestLogger logger, final VariableString message) {
+    public LogEvent(final BetonQuestLogger logger, final LogEventLevel level, final VariableString message) {
         this.logger = logger;
         this.message = message;
+        this.level = level;
     }
 
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
-        logger.info(message.getString(profile));
+        level.log(logger, message.getString(profile));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
@@ -1,0 +1,39 @@
+package org.betonquest.betonquest.quest.event.log;
+
+import org.betonquest.betonquest.VariableString;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+
+/**
+ * Prints a simple message to the server log.
+ */
+public class LogEvent implements Event {
+
+    /**
+     * Message to log.
+     */
+    private final VariableString message;
+
+    /**
+     * Logger to use.
+     */
+    private final BetonQuestLogger logger;
+
+    /**
+     * Create a new {@link LogEvent}
+     *
+     * @param logger logger used for logging messages.
+     * @param message message that should be printed to the server log.
+     */
+    public LogEvent(final BetonQuestLogger logger, final VariableString message) {
+        this.logger = logger;
+        this.message = message;
+    }
+
+    @Override
+    public void execute(final Profile profile) throws QuestRuntimeException {
+        logger.info(message.getString(profile));
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/log/LogEvent.java
@@ -27,7 +27,7 @@ public class LogEvent implements Event {
     private final LogEventLevel level;
 
     /**
-     * Create a new {@link LogEvent}
+     * Create a new {@link LogEvent}.
      *
      * @param logger  logger used for logging messages.
      * @param level   level to log the message at.

--- a/src/main/java/org/betonquest/betonquest/quest/event/log/LogEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/log/LogEventFactory.java
@@ -1,0 +1,58 @@
+package org.betonquest.betonquest.quest.event.log;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableString;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.api.quest.event.EventFactory;
+import org.betonquest.betonquest.api.quest.event.StaticEvent;
+import org.betonquest.betonquest.api.quest.event.StaticEventFactory;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.quest.event.NullStaticEventAdapter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Factory to parse new {@link LogEvent}s.
+ */
+public class LogEventFactory implements EventFactory, StaticEventFactory {
+
+    /**
+     * Regex used to detect a conditions statement at the end of the instruction.
+     */
+    private static final Pattern CONDITIONS_REGEX = Pattern.compile("conditions?:\\S*\\s*$");
+
+    /**
+     * Logger factory to create a logger for events.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    /**
+     * Create a new log event factory.
+     *
+     * @param loggerFactory BetonQuest logger factory used to retrieve the {@link BetonQuestLogger} for new events.
+     */
+    public LogEventFactory(final BetonQuestLoggerFactory loggerFactory) {
+        this.loggerFactory = loggerFactory;
+    }
+
+    @Override
+    public Event parseEvent(final Instruction instruction) throws InstructionParseException {
+        final String raw = instruction.getInstruction();
+        final Matcher matcher = CONDITIONS_REGEX.matcher(raw);
+        final VariableString message;
+        if (matcher.find()) {
+            message = new VariableString(instruction.getPackage(), raw.substring(0, matcher.start()));
+        } else {
+            message = new VariableString(instruction.getPackage(), raw);
+        }
+        return new LogEvent(loggerFactory.create(LogEvent.class), message);
+    }
+
+    @Override
+    public StaticEvent parseStaticEvent(final Instruction instruction) throws InstructionParseException {
+        return new NullStaticEventAdapter(parseEvent(instruction));
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/log/LogEventLevel.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/log/LogEventLevel.java
@@ -1,0 +1,60 @@
+package org.betonquest.betonquest.quest.event.log;
+
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Human-readable log level used by the {@link LogEvent}.
+ * <p>
+ * While there is already a ton of similar enums for log levels,
+ * they are all not really suitable for this use case for multiple reasons.
+ * Some of them use different names for the levels, some have different levels (e.g. TRACE, ALL),
+ * some are not direct dependencies of BetonQuest and most of them are not compatible with the {@link BetonQuestLogger}.
+ */
+public enum LogEventLevel {
+    /**
+     * Level used for normal messages, default level.
+     */
+    INFO(BetonQuestLogger::info),
+
+    /**
+     * Level used for debug messages.
+     */
+    DEBUG(BetonQuestLogger::debug),
+
+    /**
+     * Level used for warnings.
+     */
+    WARNING(BetonQuestLogger::warn),
+
+    /**
+     * Level used for errors.
+     */
+    ERROR(BetonQuestLogger::error);
+
+    /**
+     * Method of the {@link BetonQuestLogger} used to log the message.
+     */
+    private final BiConsumer<BetonQuestLogger, String> logFunction;
+
+    /**
+     * Create a new {@link LogEventLevel}.
+     *
+     * @param logFunction method of the {@link BetonQuestLogger} used to log the message.
+     */
+    LogEventLevel(final BiConsumer<BetonQuestLogger, String> logFunction) {
+        this.logFunction = logFunction;
+    }
+
+    /**
+     * Log the message with the given logger at this level.
+     *
+     * @param logger logger used to log the message.
+     * @param message message to log.
+     */
+    public void log(final BetonQuestLogger logger, final String message) {
+        logFunction.accept(logger, message);
+    }
+
+}


### PR DESCRIPTION
While testing some stuff I thought it was unnecessarily complicated to print information to the server log.

So I quickly created this event to simplify the process. It prints a given message to the log.

It could come in handy for debugging and testing or for server admins that want to log more information about players quest progress so they can investigate quest errors easier. 

Let me know what you think of it.

### Related Issues
_None_

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
