### PR TITLE
fixed `menu` conversation IO did not stopped scrolling at the bottom …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - giving `air` with the give command or the give event crashes the server
 - duplication of holograms when reloading BetonQuest and the hologram is hidden
 - `menu` conversation IO kicked players when conversation started in the air caused by flying detection
+- `menu` conversation IO did not stopped scrolling at the bottom and began to scroll from the top again
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -302,7 +302,6 @@ public class MenuConvIO extends ChatConvIO {
     }
 
     // Override this event from our parent
-
     @SuppressWarnings("deprecation")
     @Override
     @EventHandler(ignoreCancelled = true)
@@ -785,15 +784,14 @@ public class MenuConvIO extends ChatConvIO {
                 return;
             }
 
-            // Cheat and assume the closest distance between previous and new slots is the direction scrolled
-            final int slotDistance = event.getPreviousSlot() - event.getNewSlot();
+            final Direction scrollDirection = getScrollDirection(event.getPreviousSlot(), event.getNewSlot());
 
-            if ((slotDistance > 5 || slotDistance < 0 && slotDistance >= -5) && selectedOption < options.size() - 1) {
+            if (scrollDirection == Direction.DOWN && selectedOption < options.size() - 1) {
                 oldSelectedOption = selectedOption;
                 selectedOption++;
                 updateDisplay();
                 debounce = true;
-            } else if (slotDistance != 0 && selectedOption > 0) {
+            } else if (scrollDirection == Direction.UP && selectedOption > 0) {
                 oldSelectedOption = selectedOption;
                 selectedOption--;
                 updateDisplay();
@@ -802,6 +800,15 @@ public class MenuConvIO extends ChatConvIO {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    private Direction getScrollDirection(final int start, final int end) {
+        for (int offset = 1; offset <= 4; offset++) {
+            if ((start + offset) % 9 == end) {
+                return Direction.DOWN;
+            }
+        }
+        return Direction.UP;
     }
 
     public enum ACTION {
@@ -816,5 +823,10 @@ public class MenuConvIO extends ChatConvIO {
         SCROLL,
         MOVE,
         LEFT_CLICK
+    }
+
+    public enum Direction {
+        UP,
+        DOWN
     }
 }


### PR DESCRIPTION
…and began to scroll from the top again

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
