### PR TITLE
fixed ProtocolLib warning for Minecraft 1.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - conversation IO chest did not show the correct NPC heads
     - conversation could have a deadlock and a player can get stuck in a conversation
     - conversation could not be canceled due to a race condition
+    - ProtocolLib warning for Minecraft 1.20.2
     - `npcrange` objective - is triggered at wrong time
     - `command` event - includes 'conditions:...' into the command
     - `craft` objective - multi-craft, drop-craft, hotbar/offhand-craft, shift-Q-craft and any illegal crafting is

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
@@ -45,7 +45,6 @@ public class EntityHider implements Listener {
         final List<PacketType> entityPackets = new ArrayList<>(List.of(
                 PacketType.Play.Server.ENTITY_EQUIPMENT,
                 PacketType.Play.Server.ANIMATION,
-                PacketType.Play.Server.NAMED_ENTITY_SPAWN,
                 PacketType.Play.Server.COLLECT,
                 PacketType.Play.Server.SPAWN_ENTITY,
                 PacketType.Play.Server.SPAWN_ENTITY_EXPERIENCE_ORB,
@@ -68,6 +67,11 @@ public class EntityHider implements Listener {
         if (!PaperLib.isVersion(19)) {
             entityPackets.add(PacketType.Play.Server.SPAWN_ENTITY_LIVING);
             entityPackets.add(PacketType.Play.Server.SPAWN_ENTITY_PAINTING);
+        }
+        // TODO version switch:
+        // Remove this code when only 1.20.2+ is supported
+        if (!PaperLib.isVersion(20, 2)) {
+            entityPackets.add(PacketType.Play.Server.NAMED_ENTITY_SPAWN);
         }
 
         ENTITY_PACKETS = entityPackets.toArray(PacketType[]::new);


### PR DESCRIPTION
<!-- Please describe your changes here. -->
The package  PacketType.Play.Server.NAMED_ENTITY_SPAWN, was removed in 1.20.2

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
