### PR TITLE
Fix floating point numbers not working in `time` event

### DIFF
--- a/src/main/java/org/betonquest/betonquest/quest/event/time/TimeEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/time/TimeEventFactory.java
@@ -83,7 +83,7 @@ public class TimeEventFactory implements EventFactory, StaticEventFactory {
     }
 
     private Long parseTime(final String timeString) {
-        return Math.abs((long) Float.parseFloat(timeString) * 1000);
+        return Math.abs((long) (Float.parseFloat(timeString) * 1000));
     }
 
     @NotNull


### PR DESCRIPTION
### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
