### PR TITLE
Apply static events migration to schedules examples

### DIFF
--- a/docs/Documentation/Scripting/Schedules.md
+++ b/docs/Documentation/Scripting/Schedules.md
@@ -63,14 +63,15 @@ Just specify the time of the day when the events should run, and they will run e
     ```YAML
     # This example works out of the box. Copy-paste to try out how it works.
     events:
-      bell_sound: 'notify io:sound sound:block.bell.use'
+      bell_sound: 'notifyall io:sound sound:block.bell.use'
       bell_ring: 'folder bell_sound,bell_sound,bell_sound,bell_sound period:0.5'
-      notify_goodNight: 'notify &6Good night, sleep well!'
+      notify_goodNight: 'notifyall &6Good night, sleep well!'
     schedules:
       sayGoodNight:
         type: realtime-daily
         time: '22:00'
         events: bell_ring,notify_goodNight
+        events:
     ```
 ---
 
@@ -118,9 +119,9 @@ The supported syntax is identical to the original unix crontab syntax.
     ```YAML
     # This example works out of the box. Copy-paste to try out how it works.
     events:
-      bell_sound: 'notify io:sound sound:block.bell.use'
+      bell_sound: 'notifyall io:sound sound:block.bell.use'
       bell_ring: 'folder bell_sound,bell_sound,bell_sound,bell_sound period:0.5'
-      notify_goodNight: 'notify &6Good night, sleep well!'
+      notify_goodNight: 'notifyall &6Good night, sleep well!'
     schedules:
       sayGoodNight:
         type: realtime-cron


### PR DESCRIPTION
Seems like I forgot to update the full examples for the schedules. So here is the fix

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
