### PR TITLE
journal entries now keep there leading whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `menu` conversation IO kicked players when conversation started in the air caused by flying detection
 - `menu` conversation IO did not stopped scrolling at the bottom and began to scroll from the top again
 - removed the hearts of the Armorstand in the Menu Conversation IO
+- journal entries now keep there leading whitespaces
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `menu` conversation IO kicked players when conversation started in the air caused by flying detection
 - `menu` conversation IO did not stopped scrolling at the bottom and began to scroll from the top again
 - removed the hearts of the Armorstand in the Menu Conversation IO
-- journal entries now keep there leading whitespaces
+- journal entries now keep their leading whitespaces
 - Things that are also fixed in 1.12.X:
     - eating of items when entering the chest conversation io actually consumed the item 
     - legacy `§x` HEX color format not working in some contexts

--- a/src/main/java/org/betonquest/betonquest/utils/Utils.java
+++ b/src/main/java/org/betonquest/betonquest/utils/Utils.java
@@ -94,12 +94,12 @@ public final class Utils {
                 StringBuilder page = new StringBuilder();
                 for (final String word : bigPage.split(" ")) {
                     if (getStringLength(page.toString()) + getStringLength(word) + 1 > charsPerPage) {
-                        pages.add(page.toString().trim());
+                        pages.add(page.toString().stripTrailing());
                         page = new StringBuilder();
                     }
                     page.append(word).append(' ');
                 }
-                pages.add(page.toString().trim().replaceAll("(?<!\\\\)\\\\n", "\n"));
+                pages.add(page.toString().stripTrailing().replaceAll("(?<!\\\\)\\\\n", "\n"));
             } else {
                 final int charsPerLine = Integer.parseInt(Config.getString("config.journal.chars_per_line"));
                 final int linesPerPage = Integer.parseInt(Config.getString("config.journal.lines_per_page"));
@@ -127,7 +127,7 @@ public final class Utils {
                                 lines = 1;
                                 page = new StringBuilder();
                             }
-                            page.append(lineBuilder.toString().trim()).append('\n');
+                            page.append(lineBuilder.toString().stripTrailing()).append('\n');
                             lineBuilder = new StringBuilder();
                         }
                         lineBuilder.append(word).append(' ');
@@ -138,7 +138,7 @@ public final class Utils {
                         lines = 1;
                         page = new StringBuilder();
                     }
-                    page.append(lineBuilder.toString().trim()).append('\n');
+                    page.append(lineBuilder.toString().stripTrailing()).append('\n');
                 }
                 if (page.length() != 0) {
                     pages.add(page.toString());


### PR DESCRIPTION
<!-- Please describe your changes here. -->
While using the journal i find out, that in many cases leading whitespace is trimmed away, making it hard to format the journal in a wanted way

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
