### PR TITLE
added tag variable to mobkill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Version checks for ProtocolLib and Shopkeepers support
     - `mmoitemtake` event and `mmoitem` condition - now also check the backpack
         - this will not work until the item rework / until the backpack contains NBT data
-- entity kill Objective now supports `tags` as a parameter, which will need to match tags (NBT) of killed entity
+    - entity kill Objective now supports `tags` as a parameter, which will need to match tags (NBT) of killed entity
 ### Changed
 - Java 17 is now required
 - changed package names from `pl.betoncraft.betonquest` to `org.betonquest.betonquest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Version checks for ProtocolLib and Shopkeepers support
     - `mmoitemtake` event and `mmoitem` condition - now also check the backpack
         - this will not work until the item rework / until the backpack contains NBT data
+- entity kill Objective now supports `tags` as a parameter, which will need to match tags (NBT) of killed entity
 ### Changed
 - Java 17 is now required
 - changed package names from `pl.betoncraft.betonquest` to `org.betonquest.betonquest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `log` event
 - `party` event - new range 0 and -1 to select players in the same world or server wide
 - `stage` objective, condition and event
+- entity kill Objective now supports `tags` as a parameter, which will need to match tags (NBT) of killed entity
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility
@@ -127,7 +128,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Version checks for ProtocolLib and Shopkeepers support
     - `mmoitemtake` event and `mmoitem` condition - now also check the backpack
         - this will not work until the item rework / until the backpack contains NBT data
-    - entity kill Objective now supports `tags` as a parameter, which will need to match tags (NBT) of killed entity
 ### Changed
 - Java 17 is now required
 - changed package names from `pl.betoncraft.betonquest` to `org.betonquest.betonquest`

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -395,6 +395,7 @@ All entities work, make sure to use their [correct types](https://hub.spigotmc.o
 | _type_    | ENTITY_TYPE,ENTITY_TYPE | :octicons-x-circle-16: | A list of entities, e.g. `ZOMBIE,SKELETON`.                                                                              |
 | _amount_  | Positive Number         | :octicons-x-circle-16: | Amount of mobs to kill in total.                                                                                         |
 | _name_    | name:text               | Disabled               | Only count named mobs. Spaces must be replaced with `_`.                                                                 |
+| _tags_    | tags:text               | Disabled               | Only count mobs that match all of the listed NBT tags                                                                    |
 | _marked_  | marked:keyword          | Disabled               | Only count marked mobs. See the [spawn event](Events-List.md#spawn-mob-spawn) for more information. Supports `%player%`. |
 | _notify_  | notify:interval         | Disabled               | Display a message to the player each time they kill a mob. Optionally with the notification interval after colon.        |
 
@@ -403,6 +404,7 @@ objectives:
   monsterHunter: "mobkill ZOMBIE,SKELETON,SPIDER 10 notify" #(1)!
   specialMob: "mobkill PIG 1 marked:special" #(2)!
   bossZombie: "mobkill ZOMBIE 1 name:Uber_Zombie" #(3)!
+  infernalZombie: "mobkill ZOMBIE 1 tags:infernalZombie,bossZombie" #(4)!
 ```
    
 1. The player must kill a zombie,skeleton or a spider to progress this objective. In total, they must kill 10 entities. Additionally, there will be a notification after each kill.

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,11 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>de.tr7zw</groupId>
+      <artifactId>item-nbt-api</artifactId>
+      <version>2.12.0</version>
+    </dependency>
 
     <!-- only dependencies from maven central that are no MC Plugins -->
     <dependency>
@@ -537,6 +542,11 @@
       <id>betonquest-minecraft-repo</id>
       <url>https://libraries.minecraft.net/</url>
     </repository>
+    <repository>
+      <id>codemc-repo</id>
+      <url>https://repo.codemc.org/repository/maven-public/</url>
+      <layout>default</layout>
+    </repository>
   </repositories>
 
   <build>
@@ -636,6 +646,7 @@
                   <include>io.papermc:paperlib</include>
                   <include>com.cronutils:cron-utils</include>
                   <include>com.zaxxer</include>
+                  <include>de.tr7zw</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -706,6 +717,10 @@
                 <relocation>
                   <pattern>com.zaxxer.hikari</pattern>
                   <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.com.zaxxer.hikari</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                  <shadedPattern>${project.groupId}.${project.artifactId}.dependencies.de.tr7zw.changeme.nbtapi</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
@@ -49,7 +49,7 @@ public class MobKillObjective extends CountingObjective implements Listener {
         }
         tags = instruction.getOptionalArgument("tags")
                 .map(s -> s.split(","))
-                .orElse(new String[0]);
+                .orElse(null);
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})

--- a/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
@@ -76,7 +76,7 @@ public class MobKillObjective extends CountingObjective implements Listener {
         }
 
         if (tags != null) {
-            final NBTEntity mcnbt = new NBTEntity(event.getEntity()); //Only for vanilla tags!
+            final NBTEntity mcnbt = new NBTEntity(event.getEntity());
             final HashSet<String> entityTags = new HashSet<>(mcnbt.getStringList("Tags"));
             final HashSet<String> userDefinedTags = new HashSet<>(List.of(tags));
             if (!entityTags.containsAll(userDefinedTags)) {

--- a/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.objectives;
 
+import de.tr7zw.changeme.nbtapi.NBTEntity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
@@ -15,6 +16,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.metadata.MetadataValue;
 
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -30,6 +32,8 @@ public class MobKillObjective extends CountingObjective implements Listener {
 
     protected String marked;
 
+    protected String[] tags;
+
     public MobKillObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction, "mobs_to_kill");
         entities = instruction.getList(mob -> instruction.getEnum(mob, EntityType.class));
@@ -43,6 +47,9 @@ public class MobKillObjective extends CountingObjective implements Listener {
         if (marked != null) {
             marked = Utils.addPackage(instruction.getPackage(), marked);
         }
+        tags = instruction.getOptionalArgument("tags")
+                .map(s -> s.split(","))
+                .orElse(new String[0]);
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
@@ -65,6 +72,15 @@ public class MobKillObjective extends CountingObjective implements Listener {
                 if (!m.asString().equals(marked.replace("%player%", event.getProfile().getProfileUUID().toString()))) {
                     return;
                 }
+            }
+        }
+
+        if (tags != null) {
+            final NBTEntity mcnbt = new NBTEntity(event.getEntity()); //Only for vanilla tags!
+            final HashSet<String> entityTags = new HashSet<>(mcnbt.getStringList("Tags"));
+            final HashSet<String> userDefinedTags = new HashSet<>(List.of(tags));
+            if (!entityTags.containsAll(userDefinedTags)) {
+                return;
             }
         }
 


### PR DESCRIPTION
I added a new dependency called NBTAPI, this allows devs to access the NBT information for not only items, but entities.
https://www.spigotmc.org/resources/nbt-api.7939/

The objective Entity Kill has been updated to accept a new parameter called tags. it is disabled by default. and defined like so
tags:my_custom_tag,my_custom_tag_2

When a mob kill objective (event) is fired and tags are defined, the objective will only complete if the mob that was killed contains all of the defined tags
---

### Related Issues
There are no related issues currently reported, but it fixes an issue I was having where a data pack boss I added was difficult to hook into an objective because I did not want to use mob name. 

### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
Did the contributor...
- [ ]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
