### PR TITLE
Conversation heigth fix

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -258,7 +258,7 @@ public class MenuConvIO extends ChatConvIO {
 
     /**
      * Gets the location on the top of the block below the player.
-     * This is used to spawn the armor stand not in the air.
+     * This prevents the conversation's steering armor stand from spawning in the air.
      * <p>
      * This is done by getting the bounding box of the player.
      * Then all bounding boxes of the blocks in the bounding box of the player are checked for collision.

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -256,6 +256,18 @@ public class MenuConvIO extends ChatConvIO {
         }
     }
 
+    /**
+     * Gets the location on the top of the block below the player.
+     * This is used to spawn the armor stand not in the air.
+     * <p>
+     * This is done by getting the bounding box of the player.
+     * Then all bounding boxes of the blocks in the bounding box of the player are checked for collision.
+     * The highest collision is then returned.
+     * If no collision is found the process is repeated with the player bounding box shifted down by 1.
+     *
+     * @param player the player to get the location for
+     * @return the location on the top of the block below the player
+     */
     private Location getBlockBelowPlayer(final Player player) {
         if (player.isFlying()) {
             return player.getLocation();
@@ -286,6 +298,14 @@ public class MenuConvIO extends ChatConvIO {
         return player.getLocation();
     }
 
+    /**
+     * Get the blocks that are in the bounding box of the player.
+     * This could be 1, 2 or 4 blocks depending on the player's position.
+     *
+     * @param world             the world the player is in
+     * @param playerBoundingBox the bounding box of the player
+     * @return the blocks in the bounding box
+     */
     private Set<Block> getBlocksInBoundingBox(final World world, final BoundingBox playerBoundingBox) {
         final Set<Block> blocks = new HashSet<>();
         blocks.add(new Location(world, playerBoundingBox.getMinX(), playerBoundingBox.getMinY(), playerBoundingBox.getMinZ()).getBlock());

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -299,7 +299,7 @@ public class MenuConvIO extends ChatConvIO {
     }
 
     /**
-     * Get the blocks that are in the bounding box of the player.
+     * Get the blocks that are at the bottom corners of the player's bounding box.
      * This could be 1, 2 or 4 blocks depending on the player's position.
      *
      * @param world             the world the player is in

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -254,11 +254,11 @@ public class MenuConvIO extends ChatConvIO {
 
     private Location getBlockBelowPlayer(final Player player) {
         final Location location = player.getLocation();
-        if (player.isFlying()) {
-            return location.add(0, -1, 0);
-        }
         final Location target = location.clone();
         Block block = target.getBlock();
+        if (player.isFlying() | block.isSolid()) {
+            return location.add(0, -1, 0);
+        }
         while (!block.isSolid()) {
             target.add(0, -1, 0);
             block = target.getBlock();


### PR DESCRIPTION
<!-- Please describe your changes here. -->
This fixes a large number of edge cases when entering a `menu' conversation by checking for bounding boxes instead of relying on the simpler approach of solid blocks.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
