### PR TITLE
New event: "first", an if-else logic event with the structure of a folder event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Version checks for ProtocolLib and Shopkeepers support
     - `mmoitemtake` event and `mmoitem` condition - now also check the backpack
         - this will not work until the item rework / until the backpack contains NBT data
+- `first` event - attempts to run a list of events until one successfully runs, like a compressed `if` event
 ### Changed
 - Java 17 is now required
 - changed package names from `pl.betoncraft.betonquest` to `org.betonquest.betonquest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `log` event
 - `party` event - new range 0 and -1 to select players in the same world or server wide
 - `stage` objective, condition and event
+- `first` event - attempts to run a list of events until one successfully runs, like a compressed `if` event
 - Things that are also added in 1.12.X:
     - new line support for `journal_lore` in `messages.yml`
     - FastAsyncWorldEdit compatibility
@@ -129,7 +130,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - Version checks for ProtocolLib and Shopkeepers support
     - `mmoitemtake` event and `mmoitem` condition - now also check the backpack
         - this will not work until the item rework / until the backpack contains NBT data
-- `first` event - attempts to run a list of events until one successfully runs, like a compressed `if` event
 ### Changed
 - Java 17 is now required
 - changed package names from `pl.betoncraft.betonquest` to `org.betonquest.betonquest`

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -293,6 +293,9 @@ collapsing long if-else chains into single events.
 This event is especially powerful when it is used in conjunction with the `condition:` keyword,
 which can be used with any event.
 
+Note that if an event throws an exception, it still counts as having succeeded, and will not execute the rest of the
+events in the list.
+
 ```YAML title="Example"
 events: # (1)!
   firstExample: "first event1,event2,event3"

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -284,12 +284,43 @@ events:
 3. Randomly executes one of the three events after 5 seconds.
 4. Executes the events after one minute.
 
+## If-else through a list of events: `first`
+
+This event wraps multiple events inside itself, similar `folder`. Unlike `folder`, it attempts to execute each event,
+starting from the first onward. Once it successfully executes one event, it stops executing the rest. This is useful for
+collapsing long if-else chains into single events.
+
+This event is especially powerful when it is used in conjunction with the `condition:` keyword,
+which can be used with any event.
+
+```YAML title="Example"
+events: # (1)!
+  firstExample: "first event1,event2,event3"
+  event1: "point carry boxes 10 action:add condition:firstCondition"
+  event2: "point carry boxes 20 action:add condition:secondCondition"
+  event3: "point carry boxes 40 action:add condition:thirdCondition"
+```
+
+1. If firstCondition is false, secondCondition is true, and thirdCondition is true, event2 is the only event that will
+   be run.
+
+```YAML title="Equivalent using if-else"
+events:
+  firstExample: "if firstCondition event1 else firstExample2"
+  firstExample2: "if secondCondition event2 else firstExample3"
+  firstExample3: "if thirdCondition event3"
+  event1: "point carry boxes 10 action:add"
+  event2: "point carry boxes 20 action:add"
+  event3: "point carry boxes 40 action:add"
+```
+
 ## Give Items: `give`
 
-Gives the player predefined items. They are specified exactly as in `item` condition - 
-list separated by commas, every item can have amount separated by colon. Default amount is 1. 
+Gives the player predefined items. They are specified exactly as in `item` condition -
+list separated by commas, every item can have amount separated by colon. Default amount is 1.
 If the player doesn't have required space in the inventory, the items are dropped on the ground,
-unless they are quest items. Then they will be put into the backpack. You can also specify `notify` keyword to display a simple message to the player about receiving items.
+unless they are quest items. Then they will be put into the backpack. You can also specify `notify` keyword to display a
+simple message to the player about receiving items.
 The optional `backpack` argument forces quest items to be placed in the backpack.
 
 !!! example

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -293,9 +293,6 @@ collapsing long if-else chains into single events.
 This event is especially powerful when it is used in conjunction with the `condition:` keyword,
 which can be used with any event.
 
-Note that if an event throws an exception, it still counts as having succeeded, and will not execute the rest of the
-events in the list.
-
 ```YAML title="Example"
 events: # (1)!
   firstExample: "first event1,event2,event3"

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -511,7 +511,7 @@ public class BetonQuest extends JavaPlugin {
      *
      * @param profile the {@link Profile} for which the event must be executed or null
      * @param eventID ID of the event to fire
-     * @return whether the event was successfully run.
+     * @return true if the event was run
      */
     public static boolean event(@Nullable final Profile profile, final EventID eventID) {
         if (eventID == null) {

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -533,7 +533,7 @@ public class BetonQuest extends JavaPlugin {
             return event.fire(profile);
         } catch (final QuestRuntimeException e) {
             getInstance().log.warn(eventID.getPackage(), "Error while firing '" + eventID + "' event: " + e.getMessage(), e);
-            return false;
+            return true;
         }
     }
 

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -234,6 +234,7 @@ import org.betonquest.betonquest.quest.event.legacy.QuestEventFactoryAdapter;
 import org.betonquest.betonquest.quest.event.lever.LeverEventFactory;
 import org.betonquest.betonquest.quest.event.lightning.LightningEventFactory;
 import org.betonquest.betonquest.quest.event.log.LogEventFactory;
+import org.betonquest.betonquest.quest.event.logic.FirstEventFactory;
 import org.betonquest.betonquest.quest.event.logic.IfElseEventFactory;
 import org.betonquest.betonquest.quest.event.notify.NotifyAllEventFactory;
 import org.betonquest.betonquest.quest.event.notify.NotifyEventFactory;
@@ -510,16 +511,17 @@ public class BetonQuest extends JavaPlugin {
      *
      * @param profile the {@link Profile} for which the event must be executed or null
      * @param eventID ID of the event to fire
+     * @return whether the event was successfully run.
      */
-    public static void event(@Nullable final Profile profile, final EventID eventID) {
+    public static boolean event(@Nullable final Profile profile, final EventID eventID) {
         if (eventID == null) {
             getInstance().log.debug("Null event ID!");
-            return;
+            return false;
         }
         final QuestEvent event = EVENTS.get(eventID);
         if (event == null) {
             getInstance().log.warn(eventID.getPackage(), "Event " + eventID + " is not defined");
-            return;
+            return false;
         }
         if (profile == null) {
             getInstance().log.debug(eventID.getPackage(), "Firing event " + eventID + " player independent");
@@ -528,9 +530,10 @@ public class BetonQuest extends JavaPlugin {
                     "Firing event " + eventID + " for " + profile);
         }
         try {
-            event.fire(profile);
+            return event.fire(profile);
         } catch (final QuestRuntimeException e) {
             getInstance().log.warn(eventID.getPackage(), "Error while firing '" + eventID + "' event: " + e.getMessage(), e);
+            return false;
         }
     }
 
@@ -949,6 +952,7 @@ public class BetonQuest extends JavaPlugin {
         registerEvent("lever", new LeverEventFactory(getServer(), getServer().getScheduler(), this));
         registerEvent("door", new DoorEventFactory(getServer(), getServer().getScheduler(), this));
         registerEvent("if", new IfElseEventFactory());
+        registerEvent("first", new FirstEventFactory());
         registerEvents("variable", VariableEvent.class);
         registerNonStaticEvent("language", new LanguageEventFactory(this));
         registerEvent("pickrandom", new PickRandomEventFactory());

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -511,7 +511,7 @@ public class BetonQuest extends JavaPlugin {
      *
      * @param profile the {@link Profile} for which the event must be executed or null
      * @param eventID ID of the event to fire
-     * @return true if the event was run
+     * @return true if the event was run even if there was an exception during execution
      */
     public static boolean event(@Nullable final Profile profile, final EventID eventID) {
         if (eventID == null) {

--- a/src/main/java/org/betonquest/betonquest/api/QuestEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/QuestEvent.java
@@ -104,46 +104,51 @@ public abstract class QuestEvent extends ForceSyncHandler<Void> {
      * If the profile is null, the event will be fired as a static event.
      *
      * @param profile the {@link Profile} of the player for whom the event will fire
+     * @return whether the event was successfully handled or not.
      * @throws QuestRuntimeException passes the exception from the event up the stack
      */
-    public final void fire(final Profile profile) throws QuestRuntimeException {
+    public final boolean fire(final Profile profile) throws QuestRuntimeException {
         if (profile == null) {
-            handleNullProfile();
+            return handleNullProfile();
         } else if (profile.getOnlineProfile().isEmpty()) {
-            handleOfflineProfile(profile);
+            return handleOfflineProfile(profile);
         } else {
-            handleOnlineProfile(profile);
+            return handleOnlineProfile(profile);
         }
     }
 
-    private void handleNullProfile() throws QuestRuntimeException {
+    private boolean handleNullProfile() throws QuestRuntimeException {
         if (!staticness) {
             log.warn(instruction.getPackage(),
                     "Cannot fire non-static event '" + instruction.getID() + "' without a player!");
-            return;
+            return false;
         }
         log.debug(instruction.getPackage(), "Static event will be fired without a profile.");
         if (!BetonQuest.conditions(null, conditions)) {
             log.debug(instruction.getPackage(), "Event conditions were not met");
-            return;
+            return false;
         }
         handle(null);
+        return true;
     }
 
-    private void handleOfflineProfile(final Profile profile) throws QuestRuntimeException {
+    private boolean handleOfflineProfile(final Profile profile) throws QuestRuntimeException {
         if (persistent) {
             log.debug(instruction.getPackage(), "Persistent event will be fired for offline profile.");
             handle(profile);
+            return true;
         } else {
             log.debug(instruction.getPackage(), profile + " is offline, cannot fire event because it's not persistent.");
+            return false;
         }
     }
 
-    private void handleOnlineProfile(final Profile profile) throws QuestRuntimeException {
+    private boolean handleOnlineProfile(final Profile profile) throws QuestRuntimeException {
         if (!BetonQuest.conditions(profile, conditions)) {
             log.debug(instruction.getPackage(), "Event conditions were not met for " + profile);
-            return;
+            return false;
         }
         handle(profile);
+        return true;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
@@ -1,0 +1,45 @@
+package org.betonquest.betonquest.quest.event.logic;
+
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.betonquest.betonquest.id.EventID;
+
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * The First event. Similar to the folder, except it runs linearly through a list of events and
+ * stops after the first one succeeds. This is intended to be used with condition: syntax in events.
+ */
+public class FirstEvent implements Event {
+    /**
+     * The events to run.
+     */
+    private final EventID[] events;
+
+    /**
+     * Makes a new first event.
+     *
+     * @param eventIDList A list of events to execute in order.
+     */
+    public FirstEvent(final List<EventID> eventIDList) {
+        events = eventIDList.toArray(new EventID[0]);
+    }
+
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.CognitiveComplexity"})
+    @Override
+    public void execute(final Profile profile) throws QuestRuntimeException {
+        final Deque<EventID> chosenList = new LinkedList<>(Arrays.asList(events));
+        if (!chosenList.isEmpty()) {
+            for (final EventID event : chosenList) {
+                if (BetonQuest.event(profile, event)) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
@@ -6,9 +6,6 @@ import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.betonquest.betonquest.id.EventID;
 
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -19,7 +16,7 @@ public class FirstEvent implements Event {
     /**
      * The events to run.
      */
-    private final EventID[] events;
+    private final List<EventID> events;
 
     /**
      * Makes a new first event.
@@ -27,14 +24,13 @@ public class FirstEvent implements Event {
      * @param eventIDList A list of events to execute in order.
      */
     public FirstEvent(final List<EventID> eventIDList) {
-        events = eventIDList.toArray(new EventID[0]);
+        events = eventIDList;
     }
 
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
-        final Deque<EventID> chosenList = new LinkedList<>(Arrays.asList(events));
-        if (!chosenList.isEmpty()) {
-            for (final EventID event : chosenList) {
+        if (!events.isEmpty()) {
+            for (final EventID event : events) {
                 if (BetonQuest.event(profile, event)) {
                     break;
                 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
@@ -29,11 +29,9 @@ public class FirstEvent implements Event {
 
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
-        if (!events.isEmpty()) {
-            for (final EventID event : events) {
-                if (BetonQuest.event(profile, event)) {
-                    break;
-                }
+        for (final EventID event : events) {
+            if (BetonQuest.event(profile, event)) {
+                break;
             }
         }
     }

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEvent.java
@@ -30,7 +30,6 @@ public class FirstEvent implements Event {
         events = eventIDList.toArray(new EventID[0]);
     }
 
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.CognitiveComplexity"})
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
         final Deque<EventID> chosenList = new LinkedList<>(Arrays.asList(events));

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEventFactory.java
@@ -23,7 +23,6 @@ public class FirstEventFactory implements EventFactory, StaticEventFactory {
 
     }
 
-    @SuppressWarnings({"PMD.AvoidLiteralsInIfCondition", "PMD.PrematureDeclaration"})
     @Override
     public Event parseEvent(final Instruction instruction) throws InstructionParseException {
         final List<EventID> list = instruction.getList(instruction::getEvent);

--- a/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/logic/FirstEventFactory.java
@@ -1,0 +1,38 @@
+package org.betonquest.betonquest.quest.event.logic;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.quest.event.Event;
+import org.betonquest.betonquest.api.quest.event.EventFactory;
+import org.betonquest.betonquest.api.quest.event.StaticEvent;
+import org.betonquest.betonquest.api.quest.event.StaticEventFactory;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.id.EventID;
+import org.betonquest.betonquest.quest.event.NullStaticEventAdapter;
+
+import java.util.List;
+
+/**
+ * Factory to create FirstEvents from events from {@link Instruction}s.
+ */
+public class FirstEventFactory implements EventFactory, StaticEventFactory {
+
+    /**
+     * Empty constructor.
+     */
+    public FirstEventFactory() {
+
+    }
+
+    @SuppressWarnings({"PMD.AvoidLiteralsInIfCondition", "PMD.PrematureDeclaration"})
+    @Override
+    public Event parseEvent(final Instruction instruction) throws InstructionParseException {
+        final List<EventID> list = instruction.getList(instruction::getEvent);
+
+        return new FirstEvent(list);
+    }
+
+    @Override
+    public StaticEvent parseStaticEvent(final Instruction instruction) throws InstructionParseException {
+        return new NullStaticEventAdapter(parseEvent(instruction));
+    }
+}


### PR DESCRIPTION
I've had an issue for a while now where I wanted to run through a whole lot of conditions in order to decide which one specific event from a list of events to run. There are two approaches to this:

- Use `folder` events and `condition:` keywords to run a list of events.
- Use a series of `if` events to run down the list in order.

Approach 1 is very neat, but it will run **every** event which fulfills these conditions. This means that conditions have to be structured in a very brittle way which makes maintenance difficult.

Approach 2 looks bad and is annoying to maintain, though it does halt execution once one condition is fulfilled.

I figured I couldn't be the only person to ever have this dilemma, so I made a new event for it. `first` takes a list of EventIDs, and combines both approaches above: it runs down the list, and stops once the first event that _can_ run does run. This makes it sort of like an if-else event that can get really really really long, using the power of `condition:` keywords.

**NOTE**:

This PR changes the return value on the base QuestEvent fire method and the BetonQuest event method from _void_ to _boolean_. This does not break anything, and opens the door to other events and systems being able to detect whether an event has successfully run based on its return value.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
