### PR TITLE
download command now allows commit SHAs to directly refer to

### DIFF
--- a/docs/Documentation/Configuration/Commands-and-permissions.md
+++ b/docs/Documentation/Configuration/Commands-and-permissions.md
@@ -133,14 +133,13 @@ Beware though, the debug level might be spammy.
 
 The download command (`/q download`) can be used to download tutorial quests & quest templates from
 the [Quest-Tutorials](https://github.com/BetonQuest/Quest-Tutorials) repository. For
-example `/q download BetonQuest/Quest-Tutorials main QuestPackages /default` will download the `default` tutorial quest and
+example `/q download BetonQuest/Quest-Tutorials refs/tags/v2.0.0 QuestPackages /default` will download the `default` tutorial quest and
 place it in the same folder. The first argument (`gitHubNamespace`) is the github repository in the format user/repo or
 organisation/repo. Before you can download from a repo you need to add the namespace to
 the [`repo_whitelist`](Configuration.md#quest-downloader) in the BetonQuest config. This is a security measure that
 prevents users from screwing up all your quests or downloading malicious files if they get the permission to run this
-command by accident. The second argument (`ref`) is either a branch name or a git reference to a specific commit that
-should be downloaded. So for a branch (eg. `main`) both `main` and `refs/heads/main` works. For a tag it
-is `refs/tags/tagname`. Pull request references (
+command by accident. The second argument (`ref`) is either a commit SHA or a git reference to a specific commit that
+should be downloaded. For a branch (eg. `main`)  `refs/heads/main` works. For a tag it is `refs/tags/tagname`. Pull request references (
 eg. `refs/pull/1731/head`) are also possible but must be enabled in the [config](Configuration.md#quest-downloader).
 Keep in mind that anyone can open a pullrequest so use this very carefully. Third argument (`type`) is
 either `QuestPackages` or `QuestTemplates` depending on what type you want to download. As 4th argument (`sourcePath`)

--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -5,7 +5,6 @@ import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.Journal;
@@ -63,6 +62,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -1783,7 +1783,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             try {
                 downloader.call();
                 sendMessage(sender, "download_success");
-            } catch (final DownloadFailedException | SecurityException e) {
+            } catch (final DownloadFailedException | SecurityException | FileNotFoundException e) {
                 sendMessage(sender, "download_failed", e.getMessage());
                 log.debug(errSummary, e);
             } catch (final Exception e) {
@@ -1791,8 +1791,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
                 if (sender instanceof final Player player) {
                     final BetonQuestLogRecord record = new BetonQuestLogRecord(Level.FINE, "", instance);
                     record.setThrown(e);
-                    final String msgJson = new ChatFormatter().format(record);
-                    bukkitAudiences.player(player).sendMessage(GsonComponentSerializer.gson().deserialize(msgJson));
+                    bukkitAudiences.player(player).sendMessage(new ChatFormatter().formatTextComponent(record));
                     log.debug(errSummary, e);
                 } else {
                     log.error(errSummary, e);

--- a/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/commands/QuestCommand.java
@@ -1748,7 +1748,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             }
         }
         final String githubNamespace = args[1];
-        final String ref = args[2].startsWith("refs/") ? args[2] : "refs/heads/" + args[2];
+        final String ref = args[2];
         final String offsetPath = args[3];
         final String errSummary = String.format("Download from %s ref %s of %s at %s to %s failed:",
                 githubNamespace, ref, offsetPath, sourcePath, targetPath);

--- a/src/main/java/org/betonquest/betonquest/modules/logger/format/ChatFormatter.java
+++ b/src/main/java/org/betonquest/betonquest/modules/logger/format/ChatFormatter.java
@@ -65,6 +65,17 @@ public final class ChatFormatter extends Formatter {
 
     @Override
     public String format(final LogRecord record) {
+        return GsonComponentSerializer.gson().serialize(formatTextComponent(record));
+    }
+
+    /**
+     * Formats a {@link LogRecord} to a readable chat {@link TextComponent}.
+     *
+     * @param record The record to format
+     * @return The formatted component
+     */
+    @NotNull
+    public TextComponent formatTextComponent(final LogRecord record) {
         final String color = formatColor(record.getLevel());
         final Optional<BetonQuestLogRecord> betonRecord = BetonQuestLogRecord.safeCast(record);
         final String plugin = betonRecord
@@ -78,9 +89,8 @@ public final class ChatFormatter extends Formatter {
         final String message = record.getMessage();
         final Component throwable = formatComponentThrowable(record);
 
-        final TextComponent formattedRecord = Component.text(displayMethod.getPluginTag(pluginName, plugin, shortName) + questPackage + color + message)
+        return Component.text(displayMethod.getPluginTag(pluginName, plugin, shortName) + questPackage + color + message)
                 .append(throwable);
-        return GsonComponentSerializer.gson().serialize(formattedRecord);
     }
 
     private String formatColor(final Level level) {

--- a/src/main/java/org/betonquest/betonquest/modules/web/downloader/Downloader.java
+++ b/src/main/java/org/betonquest/betonquest/modules/web/downloader/Downloader.java
@@ -176,7 +176,13 @@ public class Downloader implements Callable<Boolean> {
      * @throws DownloadFailedException if the download fails due to any qualified error
      * @throws IOException             if any io error occurs during request or parsing
      */
+    @SuppressWarnings("PMD.CyclomaticComplexity")
     private void requestCommitSHA() throws DownloadFailedException, IOException {
+        if (!ref.startsWith("refs/")) {
+            this.sha = ref;
+            log.debug("Commit has sha '" + this.sha + "'");
+            return;
+        }
         final URL url = new URL(GITHUB_REFS_URL
                 .replace("{namespace}", namespace)
                 .replace("{ref}", ref));

--- a/src/main/java/org/betonquest/betonquest/modules/web/downloader/Downloader.java
+++ b/src/main/java/org/betonquest/betonquest/modules/web/downloader/Downloader.java
@@ -7,6 +7,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -280,7 +281,7 @@ public class Downloader implements Callable<Boolean> {
      * @throws IOException if any io error occurs while downloading the repo
      */
     @SuppressWarnings("PMD.AssignmentInOperand")
-    private void download() throws IOException {
+    private void download() throws IOException, DownloadFailedException {
         Files.createDirectories(Optional.ofNullable(getCacheFile().getParent()).orElseThrow());
         final URL url = new URL(GITHUB_DOWNLOAD_URL
                 .replace("{namespace}", namespace)
@@ -294,6 +295,8 @@ public class Downloader implements Callable<Boolean> {
                 output.write(dataBuffer, 0, read);
             }
             log.debug("Repo has been saved to cache as " + getCacheFile());
+        } catch (final FileNotFoundException e) {
+            throw new DownloadFailedException("The commit SHA '" + this.sha + "' does not exist!", e);
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
in a previous PR we broke the tutorial download command, because they now refer to commit SHAs. With this fix now commit SHAs are now allowed.

TODOs:
- [x] Adjust documentation
- [x] better error message on wrong commit SHAs

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
