### PR TITLE
added persistent & static to Alternative & Check condition; added sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Item enchantments was changed to include zero as a legal value, not just positive numbers
 - the objectives mmocorecastskill and mmoitemcastability were merged into the mmoskill objective
 - `command` event no longer runs for all players on the server if a variable is used
+- `math` and `version` variables - now static
+- `alternative` and `check` condition - now static
 ### Deprecated
 ### Removed
 - deprecated internals, code and old features

--- a/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
@@ -52,6 +52,8 @@ conditions:
 
 ## Check conditions: `check`
 
+**persistent**, **static**
+
 This condition allow for specifying multiple instruction strings in one, longer string. Each instruction must be started with `^` character and no other dividers should be used. The condition will be met if all inner conditions are met. It's not the same as `and` condition, because you can specify an instruction string, not a condition name.
 
 !!! example
@@ -325,6 +327,8 @@ This condition is very simple: it's true only when the player has an active obje
     ```
 
 ## Alternative: `or`
+
+**persistent**, **static**
 
 Alternative of specified conditions. This means that only one of conditions has to be met in order for alternative to be true. You just define one mandatory argument, condition names separated by commas. `!` prefix works as always.
 

--- a/docs/Documentation/Scripting/Building-Blocks/Variables-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Variables-List.md
@@ -171,6 +171,8 @@ the variable will resolve.
     
 ### Math Variable
 
+**static**
+
 This variable allows you to perform a calculation based on other variables (for example point or objective variables)
 and resolves to the result of the specified calculation. The variable always starts with `math.calc:`, followed by the
 calculation which should be calculated. Supported operations are `+`, `-`, `*`, `/`, `^` and `%`. You can use `( )` and
@@ -210,6 +212,8 @@ This variable will be replaced with the name of the player. If you add `display`
 
 ### Random Number Variable
 
+**static**
+
 This variable gives a random number from the first value to the second.
 The first argument is `whole` or `decimal`, the second and third arguments are numbers or variables,
 seperated by a `~`.
@@ -226,6 +230,8 @@ Note that the first value is returned when it is higher than the second.
 ```
 
 ### Version Variable
+
+**static**
 
 This variable displays the version of the plugin. You can optionally add the name of the plugin as an argument to display version of another plugin.
 

--- a/src/main/java/org/betonquest/betonquest/conditions/AlternativeCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/AlternativeCondition.java
@@ -28,6 +28,8 @@ public class AlternativeCondition extends Condition {
 
     public AlternativeCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, false);
+        staticness = true;
+        persistent = true;
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
         conditionIDs = instruction.getList(instruction::getCondition);
     }

--- a/src/main/java/org/betonquest/betonquest/conditions/CheckCondition.java
+++ b/src/main/java/org/betonquest/betonquest/conditions/CheckCondition.java
@@ -26,6 +26,8 @@ public class CheckCondition extends Condition {
 
     public CheckCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, false);
+        staticness = true;
+        persistent = true;
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
         final String[] parts = instruction.getInstruction().substring(5).trim().split(" ");
         if (parts.length <= 0) {

--- a/src/main/java/org/betonquest/betonquest/variables/MathVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/MathVariable.java
@@ -26,6 +26,7 @@ public class MathVariable extends Variable {
 
     public MathVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);
+        staticness = true;
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
         final String instructionString = instruction.getInstruction();
         if (!instructionString.matches("math\\.calc:.+")) {

--- a/src/main/java/org/betonquest/betonquest/variables/RandomNumberVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/RandomNumberVariable.java
@@ -47,6 +47,7 @@ public class RandomNumberVariable extends Variable {
      */
     public RandomNumberVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);
+        staticness = true;
         final String type = instruction.next();
         if ("whole".equalsIgnoreCase(type)) {
             this.fractional = false;

--- a/src/main/java/org/betonquest/betonquest/variables/VersionVariable.java
+++ b/src/main/java/org/betonquest/betonquest/variables/VersionVariable.java
@@ -18,6 +18,7 @@ public class VersionVariable extends Variable {
 
     public VersionVariable(final Instruction instruction) throws InstructionParseException {
         super(instruction);
+        staticness = true;
         final int pointIndex = instruction.getInstruction().indexOf("\\.");
         if (pointIndex == -1) {
             plugin = BetonQuest.getInstance();


### PR DESCRIPTION
…tic to Math, RandomNumber & Version variable

Like repeated observerd, the changed conditions and variables were not static. This reduces usability in schedules and other cases, so they will be static now.

I did not add any note when a static condition/variable can use another variable because it is noted _somewhere_ and a proper error message is already thrown.
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
