### PR TITLE
changed that `open_events` in a menu are now called before the menu a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `command` event no longer runs for all players on the server if a variable is used
 - `math` and `version` variables - now static
 - `alternative` and `check` condition - now static
+- `open_events` in a menu are now called before the menu actually opens
 ### Deprecated
 ### Removed
 - deprecated internals, code and old features

--- a/src/main/java/org/betonquest/betonquest/menu/OpenedMenu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/OpenedMenu.java
@@ -54,12 +54,12 @@ public class OpenedMenu implements Listener {
 
         this.data = menu;
         this.onlineProfile = onlineProfile;
+        this.data.runOpenEvents(onlineProfile);
         final Inventory inventory = Bukkit.createInventory(null, data.getSize(), data.getTitle(onlineProfile));
         this.update(onlineProfile, inventory);
         onlineProfile.getPlayer().openInventory(inventory);
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
         OPENED_MENUS.put(onlineProfile.getProfileUUID(), this);
-        this.data.runOpenEvents(onlineProfile);
     }
 
     /**


### PR DESCRIPTION
…ctually opens

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
