### PR TITLE
Fix: invalid conversation state can be started + add new `option` arg to conversation event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `math` and `version` variables - now static
 - `alternative` and `check` condition - now static
 - `open_events` in a menu are now called before the menu actually opens
+- `conversation` event now support a start option
 ### Deprecated
 ### Removed
 - deprecated internals, code and old features

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -124,11 +124,16 @@ Looking for [run command as player](#sudo-sudo)?
 
 ## Conversation: `conversation`
 
-Starts a conversation at location of the player. The only argument is ID of the conversation. This bypasses the conversation permission!
+Starts a conversation at location of the player. 
+The first argument is ID of the conversation. This bypasses the conversation permission!
+
+The optional `option` argument is a NPC option where the conversation will start.
+When using this argument the conversation will start without its header. 
 
 !!! example
     ```YAML
     conversation village_smith
+    conversation tutorial option:explain_world
     ```
 
 ## Damage player: `damage`

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -179,7 +179,7 @@ public class Conversation implements Listener {
         this.messagesDelaying = "true".equalsIgnoreCase(plugin.getPluginConfig().getString("display_chat_after_conversation"));
 
         if (data == null) {
-            log.warn(pack, "Conversation data is not defined, returning. Check for errors on reload!");
+            log.error(pack, "Tried to start conversation '" + conversationID.getFullID() + "' but it is not loaded! Check for errors on /bq reload!");
             return;
         }
         if (ACTIVE_CONVERSATIONS.containsKey(onlineProfile)) {

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -178,6 +178,10 @@ public class Conversation implements Listener {
         this.blacklist = plugin.getPluginConfig().getStringList("cmd_blacklist");
         this.messagesDelaying = "true".equalsIgnoreCase(plugin.getPluginConfig().getString("display_chat_after_conversation"));
 
+        if (data == null) {
+            log.warn(pack, "Conversation data is not defined, returning. Check for errors on reload!");
+            return;
+        }
         if (ACTIVE_CONVERSATIONS.containsKey(onlineProfile)) {
             log.debug(pack, onlineProfile + " is in conversation right now, returning.");
             return;

--- a/src/main/java/org/betonquest/betonquest/quest/event/conversation/ConversationEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/conversation/ConversationEvent.java
@@ -8,6 +8,7 @@ import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.conversation.Conversation;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.betonquest.betonquest.id.ConversationID;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Starts a conversation.
@@ -24,18 +25,26 @@ public class ConversationEvent implements Event {
     private final ConversationID conversation;
 
     /**
+     * The optional NPC option to start at.
+     */
+    private final String startOption;
+
+    /**
      * Creates a new ConversationEvent.
      *
-     * @param conversation the conversation to start
+     * @param loggerFactory loggerFactory to use
+     * @param conversation  the conversation to start
+     * @param startOption   name of the option which the conversation should start at
      */
-    public ConversationEvent(final BetonQuestLoggerFactory loggerFactory, final ConversationID conversation) {
+    public ConversationEvent(final BetonQuestLoggerFactory loggerFactory, final ConversationID conversation, @Nullable final String startOption) {
         this.loggerFactory = loggerFactory;
         this.conversation = conversation;
+        this.startOption = startOption;
     }
 
     @Override
     public void execute(final Profile profile) throws QuestRuntimeException {
         final OnlineProfile onlineProfile = profile.getOnlineProfile().get();
-        new Conversation(loggerFactory.create(Conversation.class), onlineProfile, conversation, onlineProfile.getPlayer().getLocation());
+        new Conversation(loggerFactory.create(Conversation.class), onlineProfile, conversation, onlineProfile.getPlayer().getLocation(), startOption);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/conversation/ConversationEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/conversation/ConversationEventFactory.java
@@ -70,8 +70,6 @@ public class ConversationEventFactory implements EventFactory {
 
     /**
      * Gets an optional start option for the conversation.
-     * This can't verify if the option is actually valid
-     * because the conversation data is not loaded at event creation.
      *
      * @param instruction    to get option name from
      * @param conversationID to get option from
@@ -84,6 +82,7 @@ public class ConversationEventFactory implements EventFactory {
             return null;
         }
 
+        // We need to manually check the existence of the starting option because the conversation is not loaded yet.
         final String optionPath = "conversations." + conversationID.getBaseID() + ".NPC_options." + targetOptionName;
         if (!conversationID.getPackage().getConfig().contains(optionPath)) {
             throw new InstructionParseException("NPC Option '" + targetOptionName + "' does not exist in '" + conversationID + "'.");


### PR DESCRIPTION
<!-- Please describe your changes here. -->

Adds the `option` argument to conversation event.
---
Fixes also an issue where an invalid started conversation halts the player in an invalid conversation state. The fix does not have a changelog yet.

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
