### PR TITLE
Fix cross conversation pointers

### DIFF
--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -587,11 +587,12 @@ public class Conversation implements Listener {
 
     @NotNull
     private List<ResolvedOption> resolvePointers(final ResolvedOption option) throws ObjectNotFoundException, InstructionParseException {
-        final List<String> rawPointers = option.conversationData().getPointers(onlineProfile, option);
+        final ConversationData nextConvData = option.conversationData();
+        final List<String> rawPointers = nextConvData.getPointers(onlineProfile, option);
         final List<ResolvedOption> pointers = new ArrayList<>();
         for (final String pointer : rawPointers) {
             final OptionType nextType = option.type() == PLAYER ? NPC : PLAYER;
-            pointers.add(new ConversationOptionResolver(plugin, pack, conv.identifier.getBaseID(), nextType, pointer).resolve());
+            pointers.add(new ConversationOptionResolver(plugin, nextConvData.getPack(), nextConvData.getName(), nextType, pointer).resolve());
         }
         return pointers;
     }
@@ -782,8 +783,16 @@ public class Conversation implements Listener {
      */
     private class PlayerEventRunner extends BukkitRunnable {
 
+        /**
+         * The option that has been selected.
+         */
         private final ResolvedOption option;
 
+        /**
+         * Creates a new PlayerEventRunner with the option that has been selected by the player.
+         *
+         * @param option the option that has been selected by the player
+         */
         public PlayerEventRunner(final ResolvedOption option) {
             super();
             this.option = option;

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationOptionResolver.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationOptionResolver.java
@@ -76,7 +76,7 @@ public class ConversationOptionResolver {
                 optionName = parts[0];
             }
             default -> throw new InstructionParseException("Invalid conversation pointer format in package '"
-                    + currentPackage.getQuestPath() + "', conversation '" + currentConversationName + "':" + option);
+                    + currentPackage.getQuestPath() + "', conversation '" + currentConversationName + "': " + option);
         }
     }
 


### PR DESCRIPTION
Fixed a bug in the logic for resolving cross conversation pointers. 
Follow up for #2313 

---

### Related Issues
<!-- Issue number if existing. -->
Closes an issue reported on the discord.

### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
