### PR TITLE
fix `npcinteract` objective:  wrong interaction types documented

### DIFF
--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -194,7 +194,7 @@ This event will teleport the NPC with the given ID to the given location.
 The player has to right-click on the NPC with specified ID. It can also optionally cancel the action, so the conversation won't start.
 The first argument is number (ID of the NPC).
 You can add the optional argument `cancel` to cancel the actual interaction with the NPC. 
-With `interaction` you can also define the type of interaction that is required, you can define `left`, `right` or `both`.
+With `interaction` you can also define the type of interaction that is required, you can define `left`, `right` or `any`.
 
 !!! example
     ```YAML

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCInteractObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCInteractObjective.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.objectives.EntityInteractObjective.Interaction;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -16,17 +17,37 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
+import static org.betonquest.betonquest.objectives.EntityInteractObjective.Interaction.ANY;
+import static org.betonquest.betonquest.objectives.EntityInteractObjective.Interaction.LEFT;
+import static org.betonquest.betonquest.objectives.EntityInteractObjective.Interaction.RIGHT;
+
 /**
- * Player has to right click the NPC
+ * An objective that requires the player to interact with a specific NPC.
  */
-@SuppressWarnings("PMD.CommentRequired")
+
 public class NPCInteractObjective extends Objective implements Listener {
+
+    /**
+     * The ID of the NPC to interact with.
+     */
     private final int npcId;
 
+    /**
+     * Whether to cancel the interaction with the NPC.
+     */
     private final boolean cancel;
 
-    private final InteractionType interactionType;
+    /**
+     * The type of interaction with the NPC.
+     */
+    private final Interaction interactionType;
 
+    /**
+     * Creates a new NPCInteractObjective from the given instruction.
+     *
+     * @param instruction the user-provided instruction
+     * @throws InstructionParseException if the instruction is invalid
+     */
     public NPCInteractObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         template = ObjectiveData.class;
@@ -35,19 +56,29 @@ public class NPCInteractObjective extends Objective implements Listener {
             throw new InstructionParseException("ID cannot be negative");
         }
         cancel = instruction.hasArgument("cancel");
-        interactionType = instruction.getEnum(instruction.getOptional("interaction"), InteractionType.class, InteractionType.RIGHT_CLICK);
+        interactionType = instruction.getEnum(instruction.getOptional("interaction"), Interaction.class, RIGHT);
     }
 
+    /**
+     * Handles RightClick events.
+     *
+     * @param event the event provided by the NPC plugin
+     */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onNPCRightClick(final NPCRightClickEvent event) {
-        if (interactionType.isRight()) {
+        if (interactionType.equals(RIGHT) || interactionType.equals(ANY)) {
             onNPCClick(event);
         }
     }
 
+    /**
+     * Handles LeftClick events.
+     *
+     * @param event the event provided by the NPC plugin
+     */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onNPCLeftClick(final NPCLeftClickEvent event) {
-        if (interactionType.isLeft()) {
+        if (interactionType.equals(LEFT) || interactionType.equals(ANY)) {
             onNPCClick(event);
         }
     }
@@ -83,29 +114,6 @@ public class NPCInteractObjective extends Objective implements Listener {
     @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
-    }
-
-    private enum InteractionType {
-        LEFT_CLICK(true, false),
-        RIGHT_CLICK(false, true),
-        BOTH(true, true);
-
-        final boolean left;
-
-        final boolean right;
-
-        InteractionType(final boolean left, final boolean right) {
-            this.left = left;
-            this.right = right;
-        }
-
-        public boolean isLeft() {
-            return left;
-        }
-
-        public boolean isRight() {
-            return right;
-        }
     }
 
 }


### PR DESCRIPTION
Adjusted code instead of docs because the names in the docs are used in other places across the plugin as well. Let's be consistent.

No changelog required because this bug was introduced in 2.0.


---

### Related Issues
<!-- Issue number if existing. -->
Closes https://discord.com/channels/407221862980911105/1186030689632665621

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
