### PR TITLE
[DOCS] make custom JS compatible with instant loading

### DIFF
--- a/config/docs-requirements-insiders.txt
+++ b/config/docs-requirements-insiders.txt
@@ -1,5 +1,5 @@
 #MkDocs and the MkDocs-material theme
-git+https://${MKDOCS_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.1.21-insiders-4.37.1
+git+https://${MKDOCS_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.2-insiders-4.47.1
 
 mkdocs-snippets
 

--- a/config/docs-requirements.txt
+++ b/config/docs-requirements.txt
@@ -1,5 +1,5 @@
 #MkDocs and the MkDocs-material theme
-mkdocs-material==9.1.21
+mkdocs-material==9.5.2
 
 mkdocs-snippets
 

--- a/docs/_webCode/js/copyLinkToClipboard.js
+++ b/docs/_webCode/js/copyLinkToClipboard.js
@@ -1,14 +1,17 @@
+//mkdocs-material provided observable that is called when the page is fully loaded. Respects both default and "instant loading" of pages.
+document$.subscribe(function () {
 //Adds an EventListener to all "chain link" elements next to headings.
-let links = document.getElementsByClassName("headerlink");
-for (let i = 0; i < links.length; i++) {
-  links[i].addEventListener("click", onClick);
-}
+  let links = document.getElementsByClassName("headerlink");
+  for (let i = 0; i < links.length; i++) {
+    links[i].addEventListener("click", onClick);
+  }
 
 //Copies the current URL into the users clipboard.
 //This needs to be delayed by a bit since the browser needs to update the URL before it's copied.
-function onClick() {
-  setTimeout(() => {
-    let url = window.location.href;
-    navigator.clipboard.writeText(url);
-  }, 10);
-}
+  function onClick() {
+    setTimeout(() => {
+      let url = window.location.href;
+      navigator.clipboard.writeText(url);
+    }, 10);
+  }
+});

--- a/docs/_webCode/js/copyrightYearUpdater.js
+++ b/docs/_webCode/js/copyrightYearUpdater.js
@@ -1,4 +1,8 @@
-const copyrightElement = document.getElementsByClassName("md-copyright__highlight");
-const currentYear = new Date().getFullYear().toString();
-//Assumes that there is only one copyright footer
-copyrightElement.item(0).textContent = "© 2014-" + currentYear + "  BetonQuest Organisation. GPLv3";
+//mkdocs-material provided observable that is called when the page is fully loaded. Respects both default and "instant loading" of pages.
+document$.subscribe(function () {
+  const copyrightElement = document.getElementsByClassName("md-copyright__highlight");
+  const currentYear = new Date().getFullYear().toString();
+  //Assumes that there is only one copyright footer
+  copyrightElement.item(0).textContent = "© 2014-" + currentYear + "  BetonQuest Organisation. GPLv3";
+})
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ theme:
     - content.tooltips
     - toc.follow
     - navigation.instant
+    - navigation.instant.prefetch
 
   palette:
     - scheme: slate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.keys
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
       options:
         custom_icons:
           - '_custom_theme/.icons'


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Since mkdocs-material instant loading does not actually reload the page but just refreshes it's contents all javascripts are only executed for the content of the inital page load.

Also bumped mkdocs-material and removed deprecated emoji plugins.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2618

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
