### PR TITLE
Bump authlib and get rid of reflection for loading NPC-Skulls

### DIFF
--- a/docs/Documentation/Configuration/Configuration.md
+++ b/docs/Documentation/Configuration/Configuration.md
@@ -90,15 +90,17 @@ value: `500`
 `max_npc_distance` is the distance you need to walk away from the NPC for the conversation to end (in the case of using
 chat-based conversation interface).
 
-### Default conversation style
+### Default Conversation Style
 
-`default_conversation_IO` is a comma-separated list of conversation interfaces with the first valid one used.
-Read [this page](../Features/Conversations.md) for more information about conversation interfaces.
+`default_conversation_IO` is a comma-separated list of conversation styles. The first one that is loaded
+(depending on the available 3rd party plugin integrations) is used.
+See [conversation styles](../Features/Conversations.md#conversation-displaying) for supported styles.
 
 ### Default Chat interceptor
 
-`default_interceptor` is a comma-separated list of chat interceptors with the first valid one used.
-Read [this page](../Features/Conversations.md) for more information about chat interceptors.
+`default_interceptor` is a comma-separated list of chat interceptors. The first one that is loaded
+(depending on the available 3rd party plugin integrations) is used.
+See [chat interceptors](../Features/Conversations.md#chat-interceptors) for supported chat interceptors.
 
 ### Default Hologram Plugin
 The holograms related features work with multiple plugins.

--- a/docs/Documentation/Features/Conversations.md
+++ b/docs/Documentation/Features/Conversations.md
@@ -96,8 +96,16 @@ You can assign the same conversation to multiple NPCs.
 BetonQuest provides different conversation styles, so called "conversationIO's". They differ in their visual style
 and the way the player interacts with them.
 
+BetonQuest uses the `menu` style by default. If ProtocolLib is not installed, the `chest` style will be used.
+You can change this setting globally by changing the [`default_conversation_IO`](../Configuration/Configuration.md#default-conversation-style) option in the _config.yml_ file.
+
+It is also possible to override this setting per conversation. Add a `conversationIO:
+<type>` setting to the conversation file at the top of the YAML hierarchy (which is the same level as `quester` or `first` options).
+
+In both cases, you can choose from the following conversation styles:
+
 !!! example "Conversation Styles"
-    === "Menu Style"
+    === "`menu`"
         A modern conversation style that works with some of Minecraft's native controls.
         
         **Requires [ProtocolLib](https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/)**
@@ -162,7 +170,7 @@ and the way the player interacts with them.
           Sorry, your browser doesn't support embedded videos.
         </video>
         The blue overlay shows the player's key presses.
-    === "Chest Style"
+    === "`chest`"
         A chest GUI with clickable buttons where the NPC's text and options will be shown as item lore.
         ??? "Customizing the Chest Style"
             The colors of this style can be configured with the [`conversation_colors` config option](../Configuration/Configuration.md#conversation-colors).
@@ -175,29 +183,24 @@ and the way the player interacts with them.
         <video controls loop src="../../../_media/content/Documentation/Conversations/ChestIO.mp4" width="100%">
           Sorry, your browser doesn't support embedded videos.
         </video>
-    === "Combined Style"
+    === "`combined`"
         The same as the chest style but the conversation is also displayed in the chat.
-    === "Simple Style"
+    === "`simple`"
         A chat output. The user has to write a number into their chat to select an option.
         ??? "Customizing the Simple Style"
             The colors of this style can be configured with the [`conversation_colors` config option](../Configuration/Configuration.md#conversation-colors).
         ![SimpleIO](../../_media/content/Documentation/Conversations/SimpleIO.png)
-    === "Tellraw Style"
+    === "`tellraw`"
         The same as the simple style but the user can also click the numbers instead of writing them in the chat.
         ??? "Customizing the Simple Style"
             The colors of this style can be configured with the [`conversation_colors` config option](../Configuration/Configuration.md#conversation-colors).
         ![SimpleIO](../../_media/content/Documentation/Conversations/SimpleIO.png)
-    === "Slowtellraw Style"
+    === "`slowtellraw`"
         The same as tellraw style but the NPC's text is printed line by line, delayed by 0.5 seconds.
         ??? "Customizing the Simple Style"
             The colors of this style can be configured with the [`conversation_colors` config option](../Configuration/Configuration.md#conversation-colors).
         ![SimpleIO](../../_media/content/Documentation/Conversations/SimpleIO.png)
 
-BetonQuest uses the `menu` style by default. If ProtocolLib is not installed, the `chest` style will be used.
-You can however change the utilized conversationIO by changing the `default_conversation_IO` option in the _config.yml_ file.
-
-In case you want to use a different type of conversation display for just one specific conversation you can add a `conversationIO:
-<type>` setting to the conversation file at the top of the YAML hierarchy (which is the same level as `quester` or `first` options).
 
 ## Cross-Conversation Pointers
 

--- a/docs/Documentation/Features/Conversations.md
+++ b/docs/Documentation/Features/Conversations.md
@@ -175,6 +175,8 @@ and the way the player interacts with them.
         <video controls loop src="../../../_media/content/Documentation/Conversations/ChestIO.mp4" width="100%">
           Sorry, your browser doesn't support embedded videos.
         </video>
+    === "Combined Style"
+        The same as the chest style but the conversation is also displayed in the chat.
     === "Simple Style"
         A chat output. The user has to write a number into their chat to select an option.
         ??? "Customizing the Simple Style"

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>net.citizensnpcs</groupId>
       <artifactId>citizens-main</artifactId>
-      <version>2.0.31-SNAPSHOT</version>
+      <version>2.0.33-SNAPSHOT</version>
       <scope>provided</scope>
       <optional>true</optional>
       <exclusions>
@@ -344,7 +344,7 @@
     <dependency>
       <groupId>com.mojang</groupId>
       <artifactId>authlib</artifactId>
-      <version>1.5.21</version>
+      <version>5.0.47</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
@@ -97,8 +97,17 @@ public class CitizensInventoryConvIO extends InventoryConvIO {
         }
     }
 
+    /**
+     * A CitizensInventoryConvIO that also prints the messages in the chat.
+     */
     public static class CitizensCombined extends CitizensInventoryConvIO {
 
+        /**
+         * Creates a new {@link CitizensCombined} conversationIO instance.
+         *
+         * @param conv          the conversation
+         * @param onlineProfile the online profile
+         */
         public CitizensCombined(final Conversation conv, final OnlineProfile onlineProfile) {
             super(conv, onlineProfile);
             super.printMessages = true;

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
@@ -1,7 +1,5 @@
 package org.betonquest.betonquest.compatibility.citizens;
 
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
 import net.citizensnpcs.trait.SkinTrait;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
@@ -10,25 +8,45 @@ import org.betonquest.betonquest.conversation.Conversation;
 import org.betonquest.betonquest.conversation.InventoryConvIO;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
 
-import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-@SuppressWarnings("PMD.CommentRequired")
+/**
+ * A chest conversationIO that replaces the NPCs skull with the skin of the Citizen NPC.
+ */
 public class CitizensInventoryConvIO extends InventoryConvIO {
+
+    /**
+     * A regex pattern to match the skin URL in the base64 encoded skin texture.
+     * See <a href="https://wiki.vg/Mojang_API#UUID_to_Profile_and_Skin.2FCape">wiki.vg</a> for unofficial documentation.
+     */
+    private static final Pattern SKIN_JSON_URL_PATTERN = Pattern.compile("\"SKIN\" ?: ?\\{\\n *\"url\" ?: ?\"(?<url>.*)\"");
+
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
      */
     private final BetonQuestLogger log;
 
+    /**
+     * Creates a new {@link CitizensInventoryConvIO} instance.
+     *
+     * @param conv          the conversation
+     * @param onlineProfile the online profile
+     */
     public CitizensInventoryConvIO(final Conversation conv, final OnlineProfile onlineProfile) {
         super(conv, onlineProfile);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     protected SkullMeta updateSkullMeta(final SkullMeta meta) {
         // this only applied to Citizens NPC conversations
         if (conv instanceof final CitizensConversation citizensConv) {
@@ -39,23 +57,44 @@ public class CitizensInventoryConvIO extends InventoryConvIO {
             try {
                 final SkinTrait skinTrait = Bukkit.getScheduler().callSyncMethod(BetonQuest.getInstance(), () -> citizensConv.getNPC().getOrAddTrait(SkinTrait.class)).get();
                 final String texture = skinTrait.getTexture();
-
                 if (texture != null) {
-                    final GameProfile gameProfile = new GameProfile(UUID.randomUUID(), null);
-                    final Property property = new Property("textures", texture, skinTrait.getSignature());
-                    gameProfile.getProperties().put("textures", property);
 
-                    final Field field = meta.getClass().getDeclaredField("profile");
-                    field.setAccessible(true);
-                    field.set(meta, gameProfile);
+                    final PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID(), "");
+                    final PlayerTextures skullTexture = profile.getTextures();
+                    skullTexture.setSkin(resolveSkinURL(texture), PlayerTextures.SkinModel.CLASSIC);
+                    profile.setTextures(skullTexture);
+                    meta.setOwnerProfile(profile);
                     return meta;
                 }
-            } catch (final NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException
-                           | InterruptedException | ExecutionException e) {
+            } catch (InterruptedException | ExecutionException e) {
                 log.debug(citizensConv.getPackage(), "Could not resolve a skin Texture!", e);
+            } catch (final SkinFormatParseException e) {
+                log.reportException(conv.getPackage(), new IllegalStateException("Could not parse the skin metadata provided by the NPC plugin. The format may have changed."));
             }
         }
         return super.updateSkullMeta(meta);
+    }
+
+    /**
+     * Resolves a base64 encoded skin JSON to a skin URL.
+     * See <a href="https://wiki.vg/Mojang_API#UUID_to_Profile_and_Skin.2FCape">wiki.vg</a> for unofficial documentation
+     * on the skin JSON format.
+     *
+     * @param base64Texture base64 encoded skin JSON metadata
+     * @return the skin URL
+     */
+    private URL resolveSkinURL(final String base64Texture) throws SkinFormatParseException {
+        final String decoded = new String(Base64.getDecoder().decode(base64Texture));
+        final Matcher matcher = SKIN_JSON_URL_PATTERN.matcher(decoded);
+        if (!matcher.find()) {
+            throw new SkinFormatParseException("Could not find the skin URL in the skin JSON!");
+        }
+        final String variable = matcher.group("url");
+        try {
+            return new URL(variable);
+        } catch (final MalformedURLException e) {
+            throw new SkinFormatParseException("Could not parse the skin URL!", e);
+        }
     }
 
     public static class CitizensCombined extends CitizensInventoryConvIO {

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensInventoryConvIO.java
@@ -13,6 +13,7 @@ import org.bukkit.profile.PlayerTextures;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -84,7 +85,7 @@ public class CitizensInventoryConvIO extends InventoryConvIO {
      * @return the skin URL
      */
     private URL resolveSkinURL(final String base64Texture) throws SkinFormatParseException {
-        final String decoded = new String(Base64.getDecoder().decode(base64Texture));
+        final String decoded = new String(Base64.getDecoder().decode(base64Texture), StandardCharsets.UTF_8);
         final Matcher matcher = SKIN_JSON_URL_PATTERN.matcher(decoded);
         if (!matcher.find()) {
             throw new SkinFormatParseException("Could not find the skin URL in the skin JSON!");

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/SkinFormatParseException.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/SkinFormatParseException.java
@@ -1,9 +1,14 @@
 package org.betonquest.betonquest.compatibility.citizens;
 
+import java.io.Serial;
+
 /**
  * An exception that is thrown when the base64 skin JSON is invalid.
  */
 public class SkinFormatParseException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = -6313544890230009673L;
 
     /**
      * {@link Exception#Exception(String)}

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/SkinFormatParseException.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/SkinFormatParseException.java
@@ -1,0 +1,36 @@
+package org.betonquest.betonquest.compatibility.citizens;
+
+/**
+ * An exception that is thrown when the base64 skin JSON is invalid.
+ */
+public class SkinFormatParseException extends Exception {
+
+    /**
+     * {@link Exception#Exception(String)}
+     *
+     * @param message the exception's message.
+     */
+    public SkinFormatParseException(final String message) {
+        super(message);
+    }
+
+    /**
+     * {@link Exception#Exception(String, Throwable)}
+     *
+     * @param message the exception's message.
+     * @param cause   the throwable that caused this exception.
+     */
+    public SkinFormatParseException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * {@link Exception#Exception(Throwable)}
+     *
+     * @param cause the throwable that caused this exception.
+     */
+    public SkinFormatParseException(final Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Previously we used reflection to set a skull's skin. This can be done with Spigot API since 1.18.
We also used an ancient version of authlib that is not compatible with modern servers. The CitizensAPI dependency was also bumped, no changes needed.

We might need to test if this still works on < 1.20.

---

### Related Issues
<!-- Issue number if existing. -->
Closes https://discord.com/channels/407221862980911105/1187721202198925382

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
