### PR TITLE
[DOCS] disable instant loading to fix fetch bug in firefox

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,6 @@ theme:
     - search.suggest
     - content.tooltips
     - toc.follow
-    - navigation.instant
-    - navigation.instant.prefetch
 
   palette:
     - scheme: slate


### PR DESCRIPTION
<!-- Please describe your changes here. -->

Unfortunately, instant loading breaks fetch calls to external websites in Firefox. See https://github.com/squidfunk/mkdocs-material/issues/6565 for more information.

### Related Issues
<!-- Issue number if existing. -->
Closes #2631 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
