### PR TITLE
fixed issue where holograms are duplicated cased by citizens calling multiple times the NPC spawn and despawn event.

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensHologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensHologramLoop.java
@@ -117,8 +117,9 @@ public class CitizensHologramLoop extends HologramLoop implements Listener {
         return npcIDs;
     }
 
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private void updateHologram(final NPCHologram npcHologram) {
-        npcHologram.npcHolograms.entrySet().forEach(entry -> {
+        npcHologram.npcHolograms().entrySet().forEach(entry -> {
                     final Integer npcID = entry.getKey();
                     final BetonHologram hologram = entry.getValue();
                     final NPC npc = CitizensAPI.getNPCRegistry().getById(npcID);
@@ -126,10 +127,7 @@ public class CitizensHologramLoop extends HologramLoop implements Listener {
                         if (hologram == null) {
                             return;
                         }
-                        hologram.hideAll();
-                        entry.setValue(null);
-                        npcHologram.holograms().remove(hologram);
-                        hologram.delete();
+                        hologram.disable();
                     } else {
                         final Location location = npc.getStoredLocation().add(npcHologram.vector());
                         if (hologram == null) {
@@ -138,6 +136,9 @@ public class CitizensHologramLoop extends HologramLoop implements Listener {
                             npcHologram.holograms().add(newHologram);
                             updateHologram(newHologram);
                         } else {
+                            if (hologram.isDisable()) {
+                                hologram.enable();
+                            }
                             hologram.move(location);
                         }
                     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensHologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensHologramLoop.java
@@ -136,7 +136,7 @@ public class CitizensHologramLoop extends HologramLoop implements Listener {
                             npcHologram.holograms().add(newHologram);
                             updateHologram(newHologram);
                         } else {
-                            if (hologram.isDisable()) {
+                            if (hologram.isDisabled()) {
                                 hologram.enable();
                             }
                             hologram.move(location);

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
@@ -98,7 +98,7 @@ public interface BetonHologram {
      *
      * @return true if disabled, false otherwise
      */
-    boolean isDisable();
+    boolean isDisabled();
 
     /**
      * Disables the hologram without deleting it

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
@@ -94,6 +94,23 @@ public interface BetonHologram {
     void delete();
 
     /**
+     * Whether the hologram is disabled or not
+     *
+     * @return true if disabled, false otherwise
+     */
+    boolean isDisable();
+
+    /**
+     * Disables the hologram without deleting it
+     */
+    void disable();
+
+    /**
+     * Enables the hologram after it has been disabled
+     */
+    void enable();
+
+    /**
      * Counts the amount of lines in this hologram when called
      *
      * @return the amount of lines

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
@@ -115,7 +115,7 @@ public class DecentHologramsHologram implements BetonHologram {
     }
 
     @Override
-    public boolean isDisable() {
+    public boolean isDisabled() {
         return hologram.isDisabled();
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
@@ -110,8 +110,23 @@ public class DecentHologramsHologram implements BetonHologram {
 
     @Override
     public void delete() {
-        hologram.disable();
+        hologram.destroy();
         DHAPI.removeHologram(hologram.getName());
+    }
+
+    @Override
+    public boolean isDisable() {
+        return hologram.isDisabled();
+    }
+
+    @Override
+    public void disable() {
+        hologram.disable();
+    }
+
+    @Override
+    public void enable() {
+        hologram.enable();
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
@@ -119,7 +119,7 @@ public class HolographicDisplaysHologram implements BetonHologram {
     }
 
     @Override
-    public boolean isDisable() {
+    public boolean isDisabled() {
         return disabled;
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
@@ -20,6 +20,11 @@ public class HolographicDisplaysHologram implements BetonHologram {
     private final Hologram hologram;
 
     /**
+     * Indicates whether the hologram is disabled or not.
+     */
+    private boolean disabled;
+
+    /**
      * Create a BetonHologram to wrap the given HolographicDisplays hologram
      *
      * @param hologram The hologram object to wrap
@@ -69,11 +74,17 @@ public class HolographicDisplaysHologram implements BetonHologram {
 
     @Override
     public void show(final Player player) {
+        if (disabled) {
+            return;
+        }
         hologram.getVisibilitySettings().setIndividualVisibility(player, VisibilitySettings.Visibility.VISIBLE);
     }
 
     @Override
     public void hide(final Player player) {
+        if (disabled) {
+            return;
+        }
         hologram.getVisibilitySettings().setIndividualVisibility(player, VisibilitySettings.Visibility.HIDDEN);
     }
 
@@ -84,6 +95,9 @@ public class HolographicDisplaysHologram implements BetonHologram {
 
     @Override
     public void showAll() {
+        if (disabled) {
+            return;
+        }
         final VisibilitySettings settings = hologram.getVisibilitySettings();
         settings.setGlobalVisibility(VisibilitySettings.Visibility.VISIBLE);
         settings.clearIndividualVisibilities();
@@ -91,6 +105,9 @@ public class HolographicDisplaysHologram implements BetonHologram {
 
     @Override
     public void hideAll() {
+        if (disabled) {
+            return;
+        }
         final VisibilitySettings settings = hologram.getVisibilitySettings();
         settings.setGlobalVisibility(VisibilitySettings.Visibility.HIDDEN);
         settings.clearIndividualVisibilities();
@@ -99,6 +116,23 @@ public class HolographicDisplaysHologram implements BetonHologram {
     @Override
     public void delete() {
         hologram.delete();
+    }
+
+    @Override
+    public boolean isDisable() {
+        return disabled;
+    }
+
+    @Override
+    public void disable() {
+        hideAll();
+        disabled = true;
+    }
+
+    @Override
+    public void enable() {
+        disabled = false;
+        showAll();
     }
 
     @Override


### PR DESCRIPTION
Citizens does this, when the skin of an NPC is fetched

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2624

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://docs.betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://docs.betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://docs.betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://docs.betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://docs.betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
