### PR TITLE
Tag of Quest-Tutorials during release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: ${{ env.VERSION_TYPE == 'release' }}
+          token: ${{ secrets.ALL_REPOSITORIES_ACCESS_TOKEN }}
       - uses: ./.github/actions/setup-git-lfs
       - uses: ./.github/actions/setup-mkdocs-material
         with:


### PR DESCRIPTION
added ALL_REPOSITORIES_ACCESS_TOKEN to have access to all BetonQuest repositories to be able to tag the Quest-Tutorials repo during a release

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #2651

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
