### PR TITLE
PacketInterceptor version checking now uses PaperLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `time` event now supports variables and new `ticks` argument
 ### Changed
 - Quests by PikaMug got updated from version 4.X to 5.X
+- The ProtocolLib dependency was downgraded from 5.2.0-SNAPSHOT-679 to 5.0.0-SNAPSHOT-636
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
@@ -32,8 +32,8 @@ public class ProtocolLibIntegrator implements Integrator {
         final Plugin protocolLib = Bukkit.getPluginManager().getPlugin("ProtocolLib");
         final Version protocolLibVersion = new Version(protocolLib.getDescription().getVersion());
         final VersionComparator comparator = new VersionComparator(UpdateStrategy.MAJOR, "SNAPSHOT-");
-        if (comparator.isOtherNewerThanCurrent(protocolLibVersion, new Version("5.2.0-SNAPSHOT-679"))) {
-            throw new UnsupportedVersionException(protocolLib, "5.2.0-SNAPSHOT-679");
+        if (comparator.isOtherNewerThanCurrent(protocolLibVersion, new Version("5.0.0-SNAPSHOT-636"))) {
+            throw new UnsupportedVersionException(protocolLib, "5.0.0-SNAPSHOT-636");
         }
         // if Citizens is hooked, start NPCHider
         if (Compatibility.getHooked().contains("Citizens")) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
@@ -6,8 +6,8 @@ import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.EnumWrappers;
+import io.papermc.lib.PaperLib;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.lang3.ArrayUtils;
@@ -24,13 +24,14 @@ import java.util.List;
 
 
 /**
- * Provide a packet interceptor to get all chat packets to player
+ * Provides a packet interceptor that catches all chat packets sent to a player.
  */
 @SuppressWarnings("PMD.CommentRequired")
 public class PacketInterceptor implements Interceptor, Listener {
+
     /**
      * A prefix that marks messages to be ignored by this interceptor.
-     * To be invisible if the interceptor was closed before the message was sent the tag is a color code.
+     * To be invisible if the interceptor was closed before the message was sent, the tag is a color code.
      * The actual tags colors are the hex-representation of the ASCII representing the string '_bq_'.
      */
     private static final String MESSAGE_PASSTHROUGH_TAG = "§5§f§6§2§7§1§5§f";
@@ -59,9 +60,9 @@ public class PacketInterceptor implements Interceptor, Listener {
                 }
                 final PacketContainer packet = event.getPacket();
                 final PacketType packetType = packet.getType();
-                if (MinecraftVersion.WILD_UPDATE.atOrAbove()) {
+                if (PaperLib.isVersion(19, 0)) {
                     if (packetType.equals(PacketType.Play.Server.SYSTEM_CHAT)) {
-                        if (MinecraftVersion.v1_20_4.atOrAbove()) {
+                        if (PaperLib.isVersion(20, 4)) {
                             final String message = packet.getChatComponents().read(0).getJson();
                             if (message != null && message.contains("{\"text\":\"\",\"extra\":[\"" + MESSAGE_PASSTHROUGH_TAG + "\"")) {
                                 return;
@@ -101,17 +102,17 @@ public class PacketInterceptor implements Interceptor, Listener {
     private static List<PacketType> getPacketTypes() {
         final List<PacketType> packets = new ArrayList<>();
         packets.add(PacketType.Play.Server.CHAT);
-        if (MinecraftVersion.WILD_UPDATE.atOrAbove()) {
+        if (PaperLib.isVersion(19, 0)) {
             packets.add(PacketType.Play.Server.SYSTEM_CHAT);
         }
-        if (MinecraftVersion.FEATURE_PREVIEW_UPDATE.atOrAbove()) {
+        if (PaperLib.isVersion(19, 3)) {
             packets.add(PacketType.Play.Server.DISGUISED_CHAT);
         }
         return packets;
     }
 
     /**
-     * Send message, bypassing Interceptor
+     * Sends a message that bypasses the interceptor.
      */
     @Override
     public void sendMessage(final String message) {


### PR DESCRIPTION
This makes it independent of the version of ProtocolLib in use. Previously, the latest PL was required just for the extra enum. Since PL has problems with backwards-compatibility, this hard dependency had to be removed.

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
