### PR TITLE
[DOCS] Info to multiple conversation binding

### DIFF
--- a/docs/Documentation/Features/Conversations.md
+++ b/docs/Documentation/Features/Conversations.md
@@ -90,6 +90,9 @@ npcs:
 The first part is the ID of the NPC. To acquire the NPCs ID select the NPC using `/npc select`, then run `/npc id`.
 The second part is the identifier of the corresponding conversation name as defined in the `conversations` section. 
 You can assign the same conversation to multiple NPCs.
+It is not possible to assign multiple conversations to one npc. For this
+purpose, have a look at 
+[cross-conversation-pointers](#cross-conversation-pointers) though.
 
 ## Conversation displaying
 


### PR DESCRIPTION
I added a hint that it's not possible to assign multiple conversations to one npc. This is already written to the FAQ, but not at the according section in the main documentation. This is changed by this commit, so that this information can be found more directly.

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
