### PR TITLE
Fix inconsistency of objectives' vars when serialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Deprecated
 ### Removed
 ### Fixed
+- objectives' vars now behave correctly after reload/logout
 ### Security
 
 ## [2.0.1] - 2024-03-24

--- a/src/main/java/org/betonquest/betonquest/objectives/VariableObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/VariableObjective.java
@@ -130,7 +130,7 @@ public class VariableObjective extends Objective implements Listener {
             return part
                     .replace("\\", "\\\\")
                     .replace(":", "\\:")
-                    .replace("\n", "\\n");
+                    .replace("\n", "\\\\n");
         }
 
         public static Map<String, String> deserializeData(final String data) {

--- a/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
+++ b/src/test/java/org/betonquest/betonquest/objectives/VariableObjectiveTest.java
@@ -63,9 +63,9 @@ class VariableObjectiveTest {
                 Arguments.of(Collections.emptyMap(), ""),
                 Arguments.of(Collections.singletonMap("test", "data"), "test:data"),
                 Arguments.of(linkedMapOf("one", "1", "two", "22", "three", "333"), "one:1\ntwo:22\nthree:333"),
-                Arguments.of(Collections.singletonMap("newline", "This is a\nnewline test!"), "newline:This is a\\nnewline test!"),
-                Arguments.of(Collections.singletonMap("multi-newline", "This\nis\na\nmulti\nnewline\ntest!"), "multi-newline:This\\nis\\na\\nmulti\\nnewline\\ntest!"),
-                Arguments.of(linkedMapOf("first-newliner", "This is a\nnewline test!", "second-newliner", "This also\ncontains a newline!"), "first-newliner:This is a\\nnewline test!\nsecond-newliner:This also\\ncontains a newline!"),
+                Arguments.of(Collections.singletonMap("newline", "This is a\nnewline test!"), "newline:This is a\\\\nnewline test!"),
+                Arguments.of(Collections.singletonMap("multi-newline", "This\nis\na\nmulti\nnewline\ntest!"), "multi-newline:This\\\\nis\\\\na\\\\nmulti\\\\nnewline\\\\ntest!"),
+                Arguments.of(linkedMapOf("first-newliner", "This is a\nnewline test!", "second-newliner", "This also\ncontains a newline!"), "first-newliner:This is a\\\\nnewline test!\nsecond-newliner:This also\\\\ncontains a newline!"),
                 Arguments.of(Collections.singletonMap("contains_colon", "This: Is a test."), "contains_colon:This\\: Is a test."),
                 Arguments.of(Collections.singletonMap("rouge", "back\\slash"), "rouge:back\\\\slash"),
                 Arguments.of(Collections.singletonMap("rou\\ge", "backslash"), "rou\\\\ge:backslash"),
@@ -75,8 +75,8 @@ class VariableObjectiveTest {
                 Arguments.of(Collections.singletonMap("ending:", ":beginning"), "ending\\::\\:beginning"),
                 Arguments.of(Collections.singletonMap("escaped_escape\\", "does_not_escape"), "escaped_escape\\\\:does_not_escape"),
                 Arguments.of(Collections.singletonMap(" starts_with_space ", " ends with space "), " starts_with_space : ends with space "),
-                Arguments.of(Collections.singletonMap("newline\nin_key?", "That's fancy!"), "newline\\nin_key?:That's fancy!"),
-                Arguments.of(linkedMapOf("test", "works", "newline_in\nsecond_key?", "That's fancy!"), "test:works\nnewline_in\\nsecond_key?:That's fancy!"),
+                Arguments.of(Collections.singletonMap("newline\nin_key?", "That's fancy!"), "newline\\\\nin_key?:That's fancy!"),
+                Arguments.of(linkedMapOf("test", "works", "newline_in\nsecond_key?", "That's fancy!"), "test:works\nnewline_in\\\\nsecond_key?:That's fancy!"),
                 Arguments.of(linkedMapOf("test", "works", "\\", "Only backslash key!"), "test:works\n\\\\:Only backslash key!"),
                 Arguments.of(linkedMapOf("test", "works", "\\\\\\", "Multi backslash key!"), "test:works\n\\\\\\\\\\\\:Multi backslash key!")
         );


### PR DESCRIPTION
This bug was reported on Discord by `zyenix`. 

<img width="920" alt="Screenshot 2024-03-26 at 2 49 03 AM" src="https://github.com/BetonQuest/BetonQuest/assets/48872538/5271b5e4-388d-472e-9d92-0b04700c1430">

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
