### PR TITLE
Customize the SlowTellrawConvIO message speed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- config option `conversation_IO_config.slowtellraw.message_delay` to set the delay between messages in the SlowTellRaw conversation IO
 ### Changed
 ### Deprecated
 ### Removed

--- a/docs/Documentation/Configuration/Configuration.md
+++ b/docs/Documentation/Configuration/Configuration.md
@@ -207,12 +207,14 @@ If you want to add a font style (bold, italic etc.) do so after placing a comma.
   * `number` is the option number
   * `option` is the text of an option
 
-### Conversation Settings: ChestIO
+### Conversation Settings: ChestIO & SlowTellrawIO
 
 * `conversation_IO_config` manages settings for individual conversation IO's:
   - `chest` manages settings for the chest conversation IO
     - `show_number` will show the player number option if true (default: true)
     - `show_npc_text` will show the npc text in every player option if true (default: true)
+  - `slowtellraw` manages settings for the slowtellraw conversation IO
+    - `message_delay` is the delay ticks between each message (default: 2)
 
 ### Quest downloader
 

--- a/docs/Documentation/Features/Conversations.md
+++ b/docs/Documentation/Features/Conversations.md
@@ -200,6 +200,9 @@ In both cases, you can choose from the following conversation styles:
         ![SimpleIO](../../_media/content/Documentation/Conversations/SimpleIO.png)
     === "`slowtellraw`"
         The same as tellraw style but the NPC's text is printed line by line, delayed by 0.5 seconds.
+        
+        The delay between lines (in ticks) can be configured with the [`conversation_IO_config.slowtellraw` config option](../Configuration/Configuration.md#conversation-settings).
+
         ??? "Customizing the Simple Style"
             The colors of this style can be configured with the [`conversation_colors` config option](../Configuration/Configuration.md#conversation-colors).
         ![SimpleIO](../../_media/content/Documentation/Conversations/SimpleIO.png)

--- a/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.utils.LocalChatPaginator;
 import org.betonquest.betonquest.utils.Utils;
 import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
@@ -21,6 +22,8 @@ public class SlowTellrawConvIO extends TellrawConvIO {
 
     private List<String> endLines;
 
+    private int messageDelay = 2;
+
     public SlowTellrawConvIO(final Conversation conv, final OnlineProfile onlineProfile) {
         super(conv, onlineProfile);
         final StringBuilder string = new StringBuilder();
@@ -28,7 +31,15 @@ public class SlowTellrawConvIO extends TellrawConvIO {
             string.append(color);
         }
         this.npcTextColor = string.toString();
-
+        // Load config
+        if (BetonQuest.getInstance().getPluginConfig().contains("conversation_IO_config.slowtellraw")) {
+            final ConfigurationSection config = BetonQuest.getInstance().getPluginConfig().getConfigurationSection("conversation_IO_config.slowtellraw");
+            this.messageDelay = config.getInt("message_delay", messageDelay);
+            if (this.messageDelay <= 0) {
+                BetonQuest.getInstance().getLogger().warning("Invalid message delay for SlowTellrawConvIO, using default value of 2");
+                this.messageDelay = 2;
+            }
+        }
     }
 
     @Override
@@ -80,7 +91,7 @@ public class SlowTellrawConvIO extends TellrawConvIO {
                 }
                 conv.sendMessage(lines[lineCount++]);
             }
-        }.runTaskTimer(BetonQuest.getInstance(), 0, 2);
+        }.runTaskTimer(BetonQuest.getInstance(), 0, messageDelay);
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
@@ -34,6 +34,9 @@ public class SlowTellrawConvIO extends TellrawConvIO {
         // Load config
         if (BetonQuest.getInstance().getPluginConfig().contains("conversation_IO_config.slowtellraw")) {
             final ConfigurationSection config = BetonQuest.getInstance().getPluginConfig().getConfigurationSection("conversation_IO_config.slowtellraw");
+            if (config == null) {
+                return;
+            }
             this.messageDelay = config.getInt("message_delay", messageDelay);
             if (this.messageDelay <= 0) {
                 BetonQuest.getInstance().getLogger().warning("Invalid message delay for SlowTellrawConvIO, using default value of 2");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,8 @@ conversation_IO_config:
   chest:
     show_number: true
     show_npc_text: true
+  slowtellraw:
+    message_delay: 2
 default_interceptor: redischat,packet,simple
 default_hologram: DecentHolograms,HolographicDisplays
 display_chat_after_conversation: true


### PR DESCRIPTION
<!-- Please describe your changes here. -->
add a config entry 'conversation_IO_config.slowtellraw.message_delay', which controls the SlowTellrawConvIO message speed.
---
I cannot click 'Squash Commits' in my IntellJ because it is gray for an unknown reason, I have searched the web but don't solved this problem. So I am very sorry about this. The other steps in the requirements are all fulfilled.

### Related Issues
<!-- Issue number if existing. -->
No.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
