### PR TITLE
standardised marking of mobs with VariableString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `%player.name%` will display the name of the player
   - `%player.display%` will use the display name used in chat
   - `%player.uuid%` will display the UUID of the player
+- marking of mobs now uses variables in all contexts of spawning killing and removing
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -719,7 +719,7 @@ events:
 
 **persistent**, **static**
 
-Spawns specified amount of mobs of given type at the location. First argument is a location. Next is [type of the mob](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html). The last, third argument is integer for amount of mobs to be spawned. You can also specify `name:` argument, followed by the name of the mob. All `_` characters will be replaced with spaces. You can also mark the spawned mob with a keyword using `marked:` argument. It won't show anywhere, and you can check for only marked mobs in `mobkill` objective.
+Spawns specified amount of mobs of given type at the location. First argument is a location. Next is [type of the mob](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html). The last, third argument is integer for amount of mobs to be spawned. You can also specify `name:` argument, followed by the name of the mob. All `_` characters will be replaced with spaces. You can also mark the spawned mob with a keyword using `marked:` argument supporting variables. It won't show anywhere, and you can check for only marked mobs in `mobkill` objective.
 
 You can specify armor which the mob will wear and items it will hold with `h:` (helmet), `c:` (chestplate), `l:` (leggings), `b:` (boots), `m:` (main hand) and `o:` (off hand) optional arguments. These take a single item without amount, as defined in the _items_ section. You can also add a list of drops with `drops:` argument, followed by a list of items with amounts after colons, separated by commas.
 

--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -783,8 +783,7 @@ within the defined radius when the mob is killed by any non-player source.
 Alternatively, you could use the `deathRadiusAllPlayers` argument to count all deaths of the specified mythic mob(s),
 no matter if it was killed by a non-player source or not.
 You can add a `notify` keyword if you want to send a notification to players whenever the objective progresses.
-You can also add an optional `marked` argument to only count kills marked with the `mspawn` event.
-The only supported variable for the marked argument is `%player%`.
+You can also add an optional `marked` argument to only count kills marked with the `mspawn` event. Variables are supported.
 
 This objective has three properties: `amount`, `left` and `total`. `amount` is the amount of mythic mobs already killed,
 `left` is the amount of mythic mobs still needed to kill and `total` is the amount of mythic mobs initially required.
@@ -812,14 +811,14 @@ Check whether the player is near a specific MythicMobs entity. The first argumen
 
 #### :material-skull: Spawn MythicMob: `mspawnmob`
 
-| Parameter  | Syntax                                              | Default Value          | Explanation                                                                                                                             |
-|------------|-----------------------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| Parameter  | Syntax                                               | Default Value          | Explanation                                                                                                                             |
+|------------|------------------------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | _location_ | [ULF](../Data-Formats.md#unified-location-formating) | :octicons-x-circle-16: | The location to spawn the mob at.                                                                                                       |
-| _name_     | name:level                                          | :octicons-x-circle-16: | MythicMobs mob name. A level must be specifed after a colon.                                                                            |
-| _amount_   | Positive Number                                     | :octicons-x-circle-16: | Amount of mobs to spawn.                                                                                                                |
-| _target_   | Keyword                                             | False                  | Will make the mob target the player.                                                                                                    |
-| _private_  | Keyword                                             | Disabled               | Will hide the mob from all other players until restart. This does not hide particles or block sound from the mob. Also see notes below. |
-| _marked_   | marked:text                                         | None                   | Marks the mob. You can check for marked mobs in mmobkill objective.                                                                     |
+| _name_     | name:level                                           | :octicons-x-circle-16: | MythicMobs mob name. A level must be specifed after a colon.                                                                            |
+| _amount_   | Positive Number                                      | :octicons-x-circle-16: | Amount of mobs to spawn.                                                                                                                |
+| _target_   | Keyword                                              | False                  | Will make the mob target the player.                                                                                                    |
+| _private_  | Keyword                                              | Disabled               | Will hide the mob from all other players until restart. This does not hide particles or block sound from the mob. Also see notes below. |
+| _marked_   | marked:text                                          | None                   | Marks the mob, supporting variables. You can check for marked mobs in mmobkill objective.                                               |
 
 
 ```YAML title="Example"

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -393,13 +393,13 @@ This objective has three properties: `amount`, `left` and `total`. `amount` is t
 The player must kill the specified amount of entities (living creatures).
 All entities work, make sure to use their [correct types](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html).
 
-| Parameter | Syntax                  | Default Value          | Explanation                                                                                                              |
-|-----------|-------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| _type_    | ENTITY_TYPE,ENTITY_TYPE | :octicons-x-circle-16: | A list of entities, e.g. `ZOMBIE,SKELETON`.                                                                              |
-| _amount_  | Positive Number         | :octicons-x-circle-16: | Amount of mobs to kill in total.                                                                                         |
-| _name_    | name:text               | Disabled               | Only count named mobs. Spaces must be replaced with `_`.                                                                 |
-| _marked_  | marked:keyword          | Disabled               | Only count marked mobs. See the [spawn event](Events-List.md#spawn-mob-spawn) for more information. Supports `%player%`. |
-| _notify_  | notify:interval         | Disabled               | Display a message to the player each time they kill a mob. Optionally with the notification interval after colon.        |
+| Parameter | Syntax                  | Default Value          | Explanation                                                                                                             |
+|-----------|-------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| _type_    | ENTITY_TYPE,ENTITY_TYPE | :octicons-x-circle-16: | A list of entities, e.g. `ZOMBIE,SKELETON`.                                                                             |
+| _amount_  | Positive Number         | :octicons-x-circle-16: | Amount of mobs to kill in total.                                                                                        |
+| _name_    | name:text               | Disabled               | Only count named mobs. Spaces must be replaced with `_`.                                                                |
+| _marked_  | marked:keyword          | Disabled               | Only count marked mobs. See the [spawn event](Events-List.md#spawn-mob-spawn) for more information. Supports variables. |
+| _notify_  | notify:interval         | Disabled               | Display a message to the player each time they kill a mob. Optionally with the notification interval after colon.       |
 
 ``` YAML title="Example"
 objectives:

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -7,6 +7,7 @@ import io.lumine.mythic.core.mobs.ActiveMob;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
@@ -59,7 +60,7 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
     /**
      * The text with which the mob must have been marked to count.
      */
-    protected String marked;
+    protected VariableString marked;
 
     /**
      * Creates a new MythicMobKillObjective.
@@ -85,10 +86,11 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
 
         minMobLevel = unsafeMinMobLevel == null ? new VariableNumber(Double.NEGATIVE_INFINITY) : new VariableNumber(pack, unsafeMinMobLevel);
         maxMobLevel = unsafeMaxMobLevel == null ? new VariableNumber(Double.POSITIVE_INFINITY) : new VariableNumber(pack, unsafeMaxMobLevel);
-        marked = instruction.getOptional("marked");
-        if (marked != null) {
-            marked = Utils.addPackage(instruction.getPackage(), marked);
-        }
+        final String markedString = instruction.getOptional("marked");
+        marked = markedString == null ? null : new VariableString(
+                instruction.getPackage(),
+                Utils.addPackage(instruction.getPackage(), markedString)
+        );
     }
 
     /**
@@ -126,7 +128,7 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
         if (marked != null) {
             final List<MetadataValue> meta = event.getEntity().getMetadata("betonquest-marked");
             for (final MetadataValue m : meta) {
-                if (!m.asString().equals(marked.replace("%player%", onlineProfile.getProfileUUID().toString()))) {
+                if (!m.asString().equals(marked.getString(onlineProfile))) {
                     return;
                 }
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicSpawnMobEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicSpawnMobEvent.java
@@ -8,6 +8,7 @@ import io.lumine.mythic.core.mobs.ActiveMob;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.VariableNumber;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.QuestEvent;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.compatibility.Compatibility;
@@ -39,7 +40,7 @@ public class MythicSpawnMobEvent extends QuestEvent {
 
     private final boolean targetPlayer;
 
-    private final String marked;
+    private final VariableString marked;
 
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public MythicSpawnMobEvent(final Instruction instruction) throws InstructionParseException {
@@ -59,7 +60,10 @@ public class MythicSpawnMobEvent extends QuestEvent {
         }
         targetPlayer = instruction.hasArgument("target");
         final String markedString = instruction.getOptional("marked");
-        marked = markedString == null ? null : Utils.addPackage(instruction.getPackage(), markedString);
+        marked = markedString == null ? null : new VariableString(
+                instruction.getPackage(),
+                Utils.addPackage(instruction.getPackage(), markedString)
+        );
 
     }
 
@@ -81,7 +85,7 @@ public class MythicSpawnMobEvent extends QuestEvent {
                     Bukkit.getScheduler().runTaskLater(BetonQuest.getInstance(), () -> targetMob.setTarget(BukkitAdapter.adapt(player)), 20L);
                 }
                 if (marked != null) {
-                    entity.setMetadata("betonquest-marked", new FixedMetadataValue(BetonQuest.getInstance(), marked.replace("%player%", profile.getProfileUUID().toString())));
+                    entity.setMetadata("betonquest-marked", new FixedMetadataValue(BetonQuest.getInstance(), marked.getString(profile)));
                 }
             } catch (final InvalidMobTypeException e) {
                 throw new QuestRuntimeException("MythicMob type " + mob + " is invalid.", e);

--- a/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/MobKillObjective.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.objectives;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.MobKillNotifier.MobKilledEvent;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
@@ -28,7 +29,7 @@ public class MobKillObjective extends CountingObjective implements Listener {
 
     protected String name;
 
-    protected String marked;
+    protected VariableString marked;
 
     public MobKillObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction, "mobs_to_kill");
@@ -39,10 +40,11 @@ public class MobKillObjective extends CountingObjective implements Listener {
         if (name != null) {
             name = Utils.format(name, true, false).replace('_', ' ');
         }
-        marked = instruction.getOptional("marked");
-        if (marked != null) {
-            marked = Utils.addPackage(instruction.getPackage(), marked);
-        }
+        final String markedString = instruction.getOptional("marked");
+        marked = markedString == null ? null : new VariableString(
+                instruction.getPackage(),
+                Utils.addPackage(instruction.getPackage(), markedString)
+        );
     }
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
@@ -62,7 +64,7 @@ public class MobKillObjective extends CountingObjective implements Listener {
             }
             final List<MetadataValue> meta = event.getEntity().getMetadata("betonquest-marked");
             for (final MetadataValue m : meta) {
-                if (!m.asString().equals(marked.replace("%player%", event.getProfile().getProfileUUID().toString()))) {
+                if (!m.asString().equals(marked.getString(onlineProfile))) {
                     return;
                 }
             }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
This PR removed the `%player%` variable form the mob related events and objectives and is not backwards compatible. May we accept this or we add a new variable for this as a replacement. But then we should may remove more `%player%` references.

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
