### PR TITLE
fixes NPE  when calling Instruction#getBlockSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
 - `variable` objective loads newlines correctly
+- exception in `lookAtBlock` condition when omitting the type
 ### Security
 
 ## [2.0.1] - 2024-03-24

--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -381,7 +381,7 @@ public class Instruction {
     }
 
     public BlockSelector getBlockSelector(final String string) throws InstructionParseException {
-        return new BlockSelector(string);
+        return string == null ? null : new BlockSelector(string);
     }
 
     public EntityType getEntity() throws InstructionParseException {


### PR DESCRIPTION
<!-- Please describe your changes here. -->
with null as value. 
---
This was valled in BlockSelector with null and changed in Instruction because null is a valid parameter to that method but not to the constructor of BlockSelector.

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
