### PR TITLE
multiline instruction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `variable` objective loads newlines correctly
 - exception in `lookAtBlock` condition when omitting the type
 - MMOCoreClassCondition, MMOItemsGiveEvent, MMOItemsHandCondition and MMOItemsItemCondition now work with numeric identifiers
+- yaml multiline instructions could lead to partly working events, conditions and objectives
 ### Security
 
 ## [2.0.1] - 2024-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - `variable` objective loads newlines correctly
 - exception in `lookAtBlock` condition when omitting the type
+- MMOCoreClassCondition, MMOItemsGiveEvent, MMOItemsHandCondition and MMOItemsItemCondition now work with numeric identifiers
 ### Security
 
 ## [2.0.1] - 2024-03-24

--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -40,8 +40,6 @@ public class Instruction {
 
     private final QuestPackage pack;
 
-    protected String instruction;
-
     protected String[] parts;
 
     private ID identifier;
@@ -60,17 +58,16 @@ public class Instruction {
         } catch (final ObjectNotFoundException e) {
             this.log.warn(pack, "Could not find instruction: " + e.getMessage(), e);
         }
-        this.instruction = instruction;
         this.parts = Utils.split(instruction);
     }
 
     @Override
     public String toString() {
-        return instruction;
+        return getInstruction();
     }
 
     public String getInstruction() {
-        return instruction;
+        return String.join(" ", parts);
     }
 
     public int size() {
@@ -91,11 +88,11 @@ public class Instruction {
      * @return a new instruction
      */
     public Instruction copy() {
-        return new Instruction(log, pack, identifier, instruction);
+        return copy(identifier);
     }
 
     public Instruction copy(final ID newID) {
-        return new Instruction(log, pack, newID, instruction);
+        return new Instruction(log, pack, newID, getInstruction());
     }
 
     /////////////////////

--- a/src/main/java/org/betonquest/betonquest/Instruction.java
+++ b/src/main/java/org/betonquest/betonquest/Instruction.java
@@ -29,14 +29,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessivePublicCount", "PMD.GodClass", "PMD.CommentRequired",
         "PMD.AvoidFieldNameMatchingTypeName", "PMD.AvoidLiteralsInIfCondition", "PMD.TooManyMethods"})
 public class Instruction {
-    private static final Pattern NUMBER_PATTERN = Pattern.compile("(?:\\s|\\G|^)(([+\\-])?\\d+)(?:\\s|$)");
-
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
      */
@@ -538,16 +534,6 @@ public class Instruction {
         } catch (final NumberFormatException e) {
             throw new PartParseException("Could not parse decimal value: " + string, e);
         }
-    }
-
-    public List<Integer> getAllNumbers() {
-        final Matcher matcher = NUMBER_PATTERN.matcher(instruction);
-
-        final ArrayList<Integer> result = new ArrayList<>();
-        while (matcher.find()) {
-            result.add(Integer.parseInt(matcher.group(1)));
-        }
-        return result;
     }
 
     ////////////////////

--- a/src/main/java/org/betonquest/betonquest/VariableInstruction.java
+++ b/src/main/java/org/betonquest/betonquest/VariableInstruction.java
@@ -29,17 +29,16 @@ public class VariableInstruction extends Instruction {
         if (!instruction.isEmpty() && instruction.charAt(0) != '%' && !instruction.endsWith("%")) {
             throw new IllegalArgumentException("Variable instruction does not start and end with '%' character");
         }
-        super.instruction = instruction.substring(1, instruction.length() - 1);
-        super.parts = super.instruction.split("\\.");
+        super.parts = instruction.substring(1, instruction.length() - 1).split("\\.");
     }
 
     @Override
-    public VariableInstruction copy() {
-        return new VariableInstruction(log, getPackage(), getID(), "%" + instruction + "%");
+    public String getInstruction() {
+        return String.join(".", super.parts);
     }
 
     @Override
     public Instruction copy(final ID newID) {
-        return new VariableInstruction(log, getPackage(), newID, "%" + instruction + "%");
+        return new VariableInstruction(log, getPackage(), newID, "%" + getInstruction() + "%");
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreClassCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreClassCondition.java
@@ -2,12 +2,11 @@ package org.betonquest.betonquest.compatibility.mmogroup.mmocore;
 
 import net.Indyuce.mmocore.api.player.PlayerData;
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
-
-import java.util.List;
 
 @SuppressWarnings("PMD.CommentRequired")
 public class MMOCoreClassCondition extends Condition {
@@ -15,17 +14,12 @@ public class MMOCoreClassCondition extends Condition {
 
     private final boolean mustBeEqual;
 
-    private int targetClassLevel = -1;
+    private final VariableNumber targetClassLevel;
 
     public MMOCoreClassCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
         targetClassName = instruction.next();
-
-        final List<Integer> potentialLevel = instruction.getAllNumbers();
-        if (!potentialLevel.isEmpty()) {
-            targetClassLevel = potentialLevel.get(0);
-        }
-
+        targetClassLevel = instruction.hasNext() ? instruction.getVarNum() : null;
         mustBeEqual = instruction.hasArgument("equal");
     }
 
@@ -37,10 +31,11 @@ public class MMOCoreClassCondition extends Condition {
         final int actualClassLevel = data.getLevel();
 
         if (actualClassName.equalsIgnoreCase(targetClassName) || "*".equals(targetClassName) && !"HUMAN".equalsIgnoreCase(actualClassName)) {
-            if (targetClassLevel == -1) {
+            if (targetClassLevel == null) {
                 return true;
             }
-            return mustBeEqual ? actualClassLevel == targetClassLevel : actualClassLevel >= targetClassLevel;
+            final int level = targetClassLevel.getInt(profile);
+            return mustBeEqual ? actualClassLevel == level : actualClassLevel >= level;
         }
         return false;
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsGiveEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsGiveEvent.java
@@ -31,11 +31,11 @@ public class MMOItemsGiveEvent extends QuestEvent {
 
     private final String itemID;
 
-    private final boolean scale;
+    private boolean scale;
 
-    private final boolean notify;
+    private boolean notify;
 
-    private final boolean singleStack;
+    private boolean singleStack;
 
     private VariableNumber amountVar = new VariableNumber(1);
 
@@ -48,13 +48,15 @@ public class MMOItemsGiveEvent extends QuestEvent {
         itemType = mmoPlugin.getTypes().get(instruction.next());
         itemID = instruction.next();
 
-        if (instruction.getInstruction().contains("%") || !instruction.getAllNumbers().isEmpty()) {
-            amountVar = instruction.getVarNum();
+        while (instruction.hasNext()) {
+            final String next = instruction.next();
+            switch (next) {
+                case "scale" -> this.scale = true;
+                case "singleStack" -> this.singleStack = true;
+                case "notify" -> this.notify = true;
+                default -> this.amountVar = instruction.getVarNum(next);
+            }
         }
-
-        scale = instruction.hasArgument("scale");
-        singleStack = instruction.hasArgument("singleStack");
-        notify = instruction.hasArgument("notify");
 
         mmoItem = mmoPlugin.getItem(itemType, itemID);
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsHandCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsHandCondition.java
@@ -32,7 +32,7 @@ public class MMOItemsHandCondition extends Condition {
 
         while (instruction.hasNext()) {
             final String next = instruction.next();
-            if (next.equals("offhand")) {
+            if ("offhand".equals(next)) {
                 offhand = true;
             } else {
                 amount = instruction.getVarNum(next);

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsHandCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsHandCondition.java
@@ -5,6 +5,7 @@ import net.Indyuce.mmoitems.MMOItems;
 import net.Indyuce.mmoitems.api.Type;
 import net.Indyuce.mmoitems.manager.TypeManager;
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -12,17 +13,15 @@ import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
-import java.util.List;
-
 @SuppressWarnings("PMD.CommentRequired")
 public class MMOItemsHandCondition extends Condition {
     private final Type itemType;
 
     private final String itemID;
 
-    private final boolean offhand;
+    private boolean offhand;
 
-    private int amount = 1;
+    private VariableNumber amount = new VariableNumber(1);
 
     public MMOItemsHandCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
@@ -31,12 +30,14 @@ public class MMOItemsHandCondition extends Condition {
         itemType = typeManager.get(instruction.next());
         itemID = instruction.next();
 
-        final List<Integer> potentialAmount = instruction.getAllNumbers();
-        if (!potentialAmount.isEmpty()) {
-            amount = potentialAmount.get(0);
+        while (instruction.hasNext()) {
+            final String next = instruction.next();
+            if (next.equals("offhand")) {
+                offhand = true;
+            } else {
+                amount = instruction.getVarNum(next);
+            }
         }
-
-        offhand = instruction.hasArgument("offhand");
     }
 
     @Override
@@ -48,6 +49,8 @@ public class MMOItemsHandCondition extends Condition {
         final String realItemType = realItemNBT.getString("MMOITEMS_ITEM_TYPE");
         final String realItemID = realItemNBT.getString("MMOITEMS_ITEM_ID");
 
-        return realItemID.equalsIgnoreCase(itemID) && realItemType.equalsIgnoreCase(itemType.getId()) && item.getAmount() == amount;
+        return realItemID.equalsIgnoreCase(itemID)
+                && realItemType.equalsIgnoreCase(itemType.getId())
+                && item.getAmount() == amount.getInt(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsItemCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsItemCondition.java
@@ -6,6 +6,7 @@ import net.Indyuce.mmoitems.api.Type;
 import net.Indyuce.mmoitems.manager.TypeManager;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableNumber;
 import org.betonquest.betonquest.api.Condition;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -20,7 +21,7 @@ public class MMOItemsItemCondition extends Condition {
 
     private final String itemID;
 
-    private int amount = 1;
+    private final VariableNumber amount;
 
     public MMOItemsItemCondition(final Instruction instruction) throws InstructionParseException {
         super(instruction, true);
@@ -33,10 +34,7 @@ public class MMOItemsItemCondition extends Condition {
         }
         itemID = instruction.next();
 
-        final List<Integer> potentialAmount = instruction.getAllNumbers();
-        if (!potentialAmount.isEmpty()) {
-            amount = potentialAmount.get(0);
-        }
+        amount = instruction.hasNext() ? instruction.getVarNum() : new VariableNumber(1);
     }
 
     @Override
@@ -58,6 +56,6 @@ public class MMOItemsItemCondition extends Condition {
             }
         }
 
-        return counter >= amount;
+        return counter >= amount.getInt(profile);
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Based on: #2742
The following is detected as a notify event, but the notify event does not write `Wenn` because there is no space when getInstaruction is called, while the parts are actually correct splitted with the utils method split
```
events:
  roboter_3: |
    notify
    Wenn du sie befreien möchtest, solltest Du zuerst die Roboterfabrik reparieren...
    Ich erkläre es dir...
    category:roboter
```

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
