### PR TITLE
added `resourcepack` objective to check for the state of a resourcepack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `block` objective now supports the parameter `ignorecancel` allow counting breaking / placing blocks in protected regions
 - command `variable` to list and modify variables on a variable objective
 - config option `conversation_IO_config.slowtellraw.message_delay` to set the delay between messages in the SlowTellRaw conversation IO
+- `resourcepack` objective - to allow checking when the player accepts, denies, downloads, or fails to download a resource pack 
 ### Changed
 - player variable
   - `%player%` is now the same as `%player.name%`

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -285,6 +285,18 @@ initially required.
     ```YAML
     interact right creeper 1 marked:sick condition:syringeInHand cancel
     ```
+    
+## Resource pack state: `resourcepack`
+
+To complete this objective the player must have the specified resource pack state.
+The first argument is the state of the resource pack.
+It can be `successfully_loaded`, `declined`, `failed_download` and `accepted`.
+
+!!! example
+    ```YAML
+    resourcepack successfully_loaded events:reward
+    resourcepack declined events:declined
+    ```
 
 ## Kill player: `kill`
 

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -193,6 +193,7 @@ import org.betonquest.betonquest.objectives.LogoutObjective;
 import org.betonquest.betonquest.objectives.MobKillObjective;
 import org.betonquest.betonquest.objectives.PasswordObjective;
 import org.betonquest.betonquest.objectives.PickupObjective;
+import org.betonquest.betonquest.objectives.ResourcePackObjective;
 import org.betonquest.betonquest.objectives.RespawnObjective;
 import org.betonquest.betonquest.objectives.RideObjective;
 import org.betonquest.betonquest.objectives.ShearObjective;
@@ -998,6 +999,7 @@ public class BetonQuest extends JavaPlugin {
         registerObjectives("variable", VariableObjective.class);
         registerObjectives("kill", KillPlayerObjective.class);
         registerObjectives("interact", EntityInteractObjective.class);
+        registerObjectives("resourcepack", ResourcePackObjective.class);
         registerObjectives("respawn", RespawnObjective.class);
         registerObjectives("breed", BreedObjective.class);
         registerObjectives("command", CommandObjective.class);

--- a/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
+++ b/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
@@ -7,6 +7,7 @@ import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.conversation.ConversationResumer;
 import org.betonquest.betonquest.database.PlayerData;
+import org.betonquest.betonquest.objectives.ResourcePackObjective;
 import org.betonquest.betonquest.utils.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -16,6 +17,7 @@ import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 
 /**
  * Listener which handles data loadin/saving when players are joining/quitting
@@ -65,6 +67,13 @@ public class JoinQuitListener implements Listener {
         }
         playerData.startObjectives();
         GlobalObjectives.startAll(onlineProfile);
+        final PlayerResourcePackStatusEvent.Status resourcePackStatus = event.getPlayer().getResourcePackStatus();
+        if (resourcePackStatus != null) {
+            BetonQuest.getInstance().getPlayerObjectives(onlineProfile).stream()
+                    .filter(objective -> objective instanceof ResourcePackObjective)
+                    .map(objective -> (ResourcePackObjective) objective)
+                    .forEach(objective -> objective.processObjective(onlineProfile, resourcePackStatus));
+        }
 
         if (Journal.hasJournal(onlineProfile)) {
             playerData.getJournal().update();

--- a/src/main/java/org/betonquest/betonquest/objectives/ResourcePackObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ResourcePackObjective.java
@@ -55,9 +55,21 @@ public class ResourcePackObjective extends Objective implements Listener {
     @EventHandler
     public void onResourcePackReceived(final PlayerResourcePackStatusEvent event) {
         final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        processObjective(onlineProfile, event.getStatus());
+    }
+
+    /**
+     * Processes the objective. This is needed if the resource pack is received before the objective is started.
+     * If a plugin handles the resource pack normally the PlayerResourcePackStatusEvent
+     * is called after the objective is started.
+     *
+     * @param onlineProfile The online profile.
+     * @param status        The status of the received resource pack.
+     */
+    public void processObjective(final OnlineProfile onlineProfile, final PlayerResourcePackStatusEvent.Status status) {
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
-            final PlayerResourcePackStatusEvent.Status status = PlayerResourcePackStatusEvent.Status.valueOf(targetStatus.getString(onlineProfile).toUpperCase(Locale.ROOT));
-            if (status.equals(event.getStatus())) {
+            final PlayerResourcePackStatusEvent.Status expectedStatus = PlayerResourcePackStatusEvent.Status.valueOf(targetStatus.getString(onlineProfile).toUpperCase(Locale.ROOT));
+            if (expectedStatus.equals(status)) {
                 completeObjective(onlineProfile);
             }
         }

--- a/src/main/java/org/betonquest/betonquest/objectives/ResourcePackObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ResourcePackObjective.java
@@ -1,0 +1,75 @@
+package org.betonquest.betonquest.objectives;
+
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.VariableString;
+import org.betonquest.betonquest.api.Objective;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.utils.PlayerConverter;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+
+import java.util.Locale;
+
+/**
+ * Represents an objective that is completed when the status of the received resource pack matches the target status.
+ */
+public class ResourcePackObjective extends Objective implements Listener {
+
+    /**
+     * The target status for the received resource pack.
+     */
+    private final VariableString targetStatus;
+
+    /**
+     * Constructs a new ResourcePackObjective instance.
+     *
+     * @param instruction The instruction object.
+     * @throws InstructionParseException if an error occurs while parsing the instruction.
+     */
+    public ResourcePackObjective(final Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        targetStatus = new VariableString(instruction.getPackage(), instruction.next());
+    }
+
+    @Override
+    public void start() {
+        Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
+    }
+
+    @Override
+    public void stop() {
+        HandlerList.unregisterAll(this);
+    }
+
+    /**
+     * Handles the PlayerResourcePackStatusEvent event.
+     *
+     * @param event The event object.
+     */
+    @EventHandler
+    public void onResourcePackReceived(final PlayerResourcePackStatusEvent event) {
+        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
+            final PlayerResourcePackStatusEvent.Status status = PlayerResourcePackStatusEvent.Status.valueOf(targetStatus.getString(onlineProfile).toUpperCase(Locale.ROOT));
+            if (status.equals(event.getStatus())) {
+                completeObjective(onlineProfile);
+            }
+        }
+    }
+
+    @Override
+    public String getDefaultDataInstruction() {
+        return "";
+    }
+
+    @Override
+    public String getProperty(final String name, final Profile profile) {
+        return "";
+    }
+}


### PR DESCRIPTION
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
