### PR TITLE
Cleaned and improved the region and location objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - command `variable` to list and modify variables on a variable objective
 - config option `conversation_IO_config.slowtellraw.message_delay` to set the delay between messages in the SlowTellRaw conversation IO
 - `resourcepack` objective - to allow checking when the player accepts, denies, downloads, or fails to download a resource pack 
+- `region` objective now supports variables as region name
+- `location` objective now allows `entry` and `exit` keywords to track entering and leaving the location
 ### Changed
 - player variable
   - `%player%` is now the same as `%player.name%`

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -315,15 +315,27 @@ already killed players and `total` is the initially required amount to kill.
 
 ## Location: `location`
 
-This objective completes when player moves in specified range of specified location and meets all conditions. The first
-argument after objective's name must be location, the second - radius around the location. It can be a variable.
+The specified location where the player needs to be.
+It is not required to specify `entry` or `exit` then the objective also completes
+if the player just moves inside the location's range.
 
-Location objective contains one property, `location`. It's a string formatted like `X: 100, Y: 200, Z:300`.
+| Parameter  | Syntax                                               | Default Value          | Explanation                                                                                                             |
+|------------|------------------------------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| _location_ | [ULF](../Data-Formats.md#unified-location-formating) | :octicons-x-circle-16: | The location to go to                                                                                                   |
+| _range_    | range:number                                         | :octicons-x-circle-16: | The range arround the location where the player must be.                                                                |
+| _entry_    | entry:keyword                                        | Disabled               | The player must enter (go from outside to inside) the location to complete the objective.                               |
+| _exit_     | exit:keyword                                         | Disabled               | The player must exit (go from inside to outside) the location to complete the objective.                                |
 
 !!! example
     ```YAML
-    location 100;200;300;world 5 condition:test1,!test2 events:test1,test2
+    location 100;200;300;world 5 condition:started events:notifyWelcome,start
+    location 100;200;300;world 5 exit conditions:started events:notifyBye
     ```
+<h5> Variable Properties </h5> 
+
+| Name       | Example Output        | Explanation                              |
+|------------|-----------------------|------------------------------------------|
+| _location_ | X: 100, Y: 200, Z:300 | The target location of this objective    |
 
 ## Login: `login`
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCInteractObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCInteractObjective.java
@@ -50,7 +50,6 @@ public class NPCInteractObjective extends Objective implements Listener {
      */
     public NPCInteractObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         npcId = instruction.getInt();
         if (npcId < 0) {
             throw new InstructionParseException("ID cannot be negative");

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCRangeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/NPCRangeObjective.java
@@ -34,7 +34,6 @@ public class NPCRangeObjective extends Objective {
 
     public NPCRangeObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        super.template = ObjectiveData.class;
         this.npcIds = new ArrayList<>();
         for (final String npcIdString : instruction.getArray()) {
             try {

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveJoinJob.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveJoinJob.java
@@ -23,7 +23,6 @@ public class ObjectiveJoinJob extends Objective implements Listener {
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public ObjectiveJoinJob(final Instruction instructions) throws InstructionParseException {
         super(instructions);
-        template = ObjectiveData.class;
         if (instructions.size() < 2) {
             throw new InstructionParseException("Not enough arguments");
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLeaveJob.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLeaveJob.java
@@ -23,7 +23,6 @@ public class ObjectiveLeaveJob extends Objective implements Listener {
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public ObjectiveLeaveJob(final Instruction instructions) throws InstructionParseException {
         super(instructions);
-        template = ObjectiveData.class;
         if (instructions.size() < 2) {
             throw new InstructionParseException("Not enough arguments");
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLevelUpEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLevelUpEvent.java
@@ -22,7 +22,6 @@ public class ObjectiveLevelUpEvent extends Objective implements Listener {
     @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public ObjectiveLevelUpEvent(final Instruction instructions) throws InstructionParseException {
         super(instructions);
-        template = ObjectiveData.class;
         if (instructions.size() < 2) {
             throw new InstructionParseException("Not enough arguments");
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
@@ -23,8 +23,6 @@ public class MMOCoreProfessionObjective extends Objective implements Listener {
 
     public MMOCoreProfessionObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-
-        template = ObjectiveData.class;
         final String profession = instruction.next();
         professionName = "MAIN".equalsIgnoreCase(profession) ? null : profession;
         targetLevel = instruction.getVarNum();

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsApplyGemObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsApplyGemObjective.java
@@ -24,8 +24,6 @@ public class MMOItemsApplyGemObjective extends Objective implements Listener {
 
     public MMOItemsApplyGemObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
-
         itemType = instruction.next();
         itemID = instruction.next();
         gemID = instruction.next();

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsUpgradeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsUpgradeObjective.java
@@ -25,7 +25,6 @@ public class MMOItemsUpgradeObjective extends Objective implements Listener {
 
         itemType = instruction.next();
         itemID = instruction.next();
-        template = ObjectiveData.class;
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
@@ -43,8 +43,6 @@ public class MythicLibSkillObjective extends Objective implements Listener {
      */
     public MythicLibSkillObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-
-        template = ObjectiveData.class;
         skillId = instruction.next();
         final String triggerTypesString = instruction.getOptional("trigger");
         if (triggerTypesString == null) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
@@ -2,128 +2,38 @@ package org.betonquest.betonquest.compatibility.worldguard;
 
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.Instruction;
-import org.betonquest.betonquest.api.Objective;
+import org.betonquest.betonquest.VariableString;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
-import org.betonquest.betonquest.utils.PlayerConverter;
+import org.betonquest.betonquest.objectives.AbstractLocationObjective;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.event.vehicle.VehicleMoveEvent;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 /**
- * Player has to enter the WorldGuard region
+ * The region objective requires the player to be inside a specific region.
  */
-@SuppressWarnings("PMD.CommentRequired")
-public class RegionObjective extends Objective implements Listener {
-    private final String name;
+public class RegionObjective extends AbstractLocationObjective {
+    /**
+     * The name of the region.
+     */
+    private final VariableString name;
 
-    private final boolean entry;
-
-    private final boolean exit;
-
-    private final Map<UUID, Boolean> playersInsideRegion;
-
+    /**
+     * The constructor takes an Instruction object as a parameter and throws an InstructionParseException.
+     *
+     * @param instruction the Instruction object to be used in the constructor
+     * @throws InstructionParseException if there is an error while parsing the instruction
+     */
     public RegionObjective(final Instruction instruction) throws InstructionParseException {
-        super(instruction);
-        template = ObjectiveData.class;
-        name = instruction.next();
-        entry = instruction.hasArgument("entry");
-        exit = instruction.hasArgument("exit");
-        playersInsideRegion = new HashMap<>();
+        super(BetonQuest.getInstance().getLoggerFactory().create(RegionObjective.class), instruction);
+        name = instruction.next() == null ? null : new VariableString(instruction.getPackage(), instruction.current());
     }
 
-    @EventHandler(ignoreCancelled = true)
-    public void onPlayerJoin(final PlayerJoinEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
-        if (containsPlayer(onlineProfile)) {
-            final boolean inside = WorldGuardIntegrator.isInsideRegion(onlineProfile.getPlayer().getLocation(), name);
-            if (!entry && !exit && inside && checkConditions(onlineProfile)) {
-                completeObjective(onlineProfile);
-            } else {
-                playersInsideRegion.put(onlineProfile.getProfileUUID(), inside);
-            }
-        }
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onPlayerQuit(final PlayerQuitEvent event) {
-        playersInsideRegion.remove(PlayerConverter.getID(event.getPlayer()).getProfileUUID());
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onPlayerDeath(final PlayerDeathEvent event) {
-        checkLocation(event.getEntity(), event.getEntity().getLocation());
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onPlayerRespawn(final PlayerRespawnEvent event) {
-        checkLocation(event.getPlayer(), event.getRespawnLocation());
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onTeleport(final PlayerTeleportEvent event) {
-        onMove(event);
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onMove(final PlayerMoveEvent event) {
-        checkLocation(event.getPlayer(), event.getTo());
-    }
-
-    @EventHandler(ignoreCancelled = true)
-    public void onRide(final VehicleMoveEvent event) {
-        qreHandler.handle(() -> {
-            final List<Entity> passengers = event.getVehicle().getPassengers();
-            for (final Entity passenger : passengers) {
-                if (passenger instanceof final Player player) {
-                    checkLocation(player, event.getTo());
-                }
-            }
-        });
-    }
-
-    @SuppressWarnings("PMD.CyclomaticComplexity")
-    private void checkLocation(final Player player, final Location location) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
-        if (!containsPlayer(onlineProfile)) {
-            return;
-        }
-
-        final boolean inside = WorldGuardIntegrator.isInsideRegion(location, name);
-
-        if (!entry && !exit) {
-            if (inside && checkConditions(onlineProfile)) {
-                completeObjective(onlineProfile);
-            }
-            return;
-        }
-        if (!playersInsideRegion.containsKey(onlineProfile.getProfileUUID())) {
-            playersInsideRegion.put(onlineProfile.getProfileUUID(), WorldGuardIntegrator.isInsideRegion(player.getLocation(), name));
-        }
-        final boolean fromInside = playersInsideRegion.get(onlineProfile.getProfileUUID());
-        playersInsideRegion.put(onlineProfile.getProfileUUID(), inside);
-
-        if ((entry && inside && !fromInside || exit && fromInside && !inside) && checkConditions(onlineProfile)) {
-            completeObjective(onlineProfile);
-            playersInsideRegion.remove(onlineProfile.getProfileUUID());
-        }
+    @Override
+    protected boolean isInside(final OnlineProfile onlineProfile, final Location location) {
+        return WorldGuardIntegrator.isInsideRegion(location, name.getString(onlineProfile));
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
@@ -28,7 +28,7 @@ public class RegionObjective extends AbstractLocationObjective {
      */
     public RegionObjective(final Instruction instruction) throws InstructionParseException {
         super(BetonQuest.getInstance().getLoggerFactory().create(RegionObjective.class), instruction);
-        name = instruction.next() == null ? null : new VariableString(instruction.getPackage(), instruction.current());
+        name = new VariableString(instruction.getPackage(), instruction.next());
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
+++ b/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
@@ -30,7 +30,6 @@ public class MenuObjective extends Objective implements Listener {
     public MenuObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
-        template = ObjectiveData.class;
         try {
             this.menuID = new MenuID(instruction.getPackage(), instruction.next());
         } catch (final ObjectNotFoundException e) {

--- a/src/main/java/org/betonquest/betonquest/objectives/AbstractLocationObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/AbstractLocationObjective.java
@@ -1,0 +1,196 @@
+package org.betonquest.betonquest.objectives;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.Objective;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.betonquest.betonquest.utils.PlayerConverter;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.vehicle.VehicleMoveEvent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The AbstractLocationObjective class extends the Objective class and implements the Listener interface
+ * to handle all movements of players in the game.
+ * This abstract class serves as a base for objectives that are completed
+ * when a player enters or exits a specific location.
+ * It listens for various player events such as join, quit, death, respawn, teleport, and movement
+ * to check the player's location.
+ */
+public abstract class AbstractLocationObjective extends Objective implements Listener {
+    /**
+     * Custom {@link BetonQuestLogger} instance for this class.
+     */
+    protected final BetonQuestLogger log;
+
+    /**
+     * Should entry be checked instead of being inside the location of not.
+     */
+    private final boolean entry;
+
+    /**
+     * Should exit be checked instead of being inside the location of not.
+     */
+    private final boolean exit;
+
+    /**
+     * A map of players and if they are inside the location.
+     */
+    private final Map<UUID, Boolean> playersInsideRegion;
+
+    /**
+     * The constructor takes an Instruction object as a parameter and throws an InstructionParseException.
+     * It initializes the entry and exit booleans and the playersInsideRegion map.
+     *
+     * @param log         the BetonQuestLogger object to be used in the constructor
+     * @param instruction the Instruction object to be used in the constructor
+     * @throws InstructionParseException if there is an error while parsing the instruction
+     */
+    public AbstractLocationObjective(final BetonQuestLogger log, final Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        this.log = log;
+        entry = instruction.hasArgument("entry");
+        exit = instruction.hasArgument("exit");
+        playersInsideRegion = new HashMap<>();
+    }
+
+    /**
+     * The onPlayerJoin method listens for the PlayerJoinEvent and checks the player's location.
+     *
+     * @param event the PlayerJoinEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerJoin(final PlayerJoinEvent event) {
+        checkLocation(event.getPlayer(), event.getPlayer().getLocation());
+    }
+
+    /**
+     * The onPlayerQuit method listens for the PlayerQuitEvent and removes the player from the playersInsideRegion map.
+     *
+     * @param event the PlayerQuitEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        playersInsideRegion.remove(PlayerConverter.getID(event.getPlayer()).getProfileUUID());
+    }
+
+    /**
+     * The onPlayerDeath method listens for the PlayerDeathEvent and checks the player's location.
+     *
+     * @param event the PlayerDeathEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerDeath(final PlayerDeathEvent event) {
+        checkLocation(event.getEntity(), event.getEntity().getLocation());
+    }
+
+    /**
+     * The onPlayerRespawn method listens for the PlayerRespawnEvent and checks the player's location.
+     *
+     * @param event the PlayerRespawnEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerRespawn(final PlayerRespawnEvent event) {
+        checkLocation(event.getPlayer(), event.getRespawnLocation());
+    }
+
+    /**
+     * The onPlayerTeleport method listens for the PlayerTeleportEvent and checks the player's location.
+     *
+     * @param event the PlayerTeleportEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerTeleport(final PlayerTeleportEvent event) {
+        onPlayerMove(event);
+    }
+
+    /**
+     * The onPlayerMove method listens for the PlayerMoveEvent and checks the player's location.
+     *
+     * @param event the PlayerMoveEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerMove(final PlayerMoveEvent event) {
+        checkLocation(event.getPlayer(), event.getTo());
+    }
+
+    /**
+     * The onVehicleMove method listens for the VehicleMoveEvent and checks the player's location.
+     *
+     * @param event the VehicleMoveEvent to be used in the method
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onVehicleMove(final VehicleMoveEvent event) {
+        final List<Entity> passengers = event.getVehicle().getPassengers();
+        for (final Entity passenger : passengers) {
+            if (passenger instanceof final Player player) {
+                checkLocation(player, event.getTo());
+            }
+        }
+    }
+
+    private void checkLocation(final Player player, final Location location) {
+        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        if (!containsPlayer(onlineProfile)) {
+            return;
+        }
+
+        final boolean toInside = isInsideHandleException(location, onlineProfile);
+        if (!entry && !exit) {
+            if (toInside && checkConditions(onlineProfile)) {
+                completeObjective(onlineProfile);
+            }
+            return;
+        }
+
+        checkLocationEnterExit(onlineProfile, toInside);
+    }
+
+    private void checkLocationEnterExit(final OnlineProfile onlineProfile, final boolean toInside) {
+        if (!playersInsideRegion.containsKey(onlineProfile.getProfileUUID())) {
+            playersInsideRegion.put(onlineProfile.getProfileUUID(), toInside);
+            return;
+        }
+
+        final boolean fromInside = playersInsideRegion.get(onlineProfile.getProfileUUID());
+        playersInsideRegion.put(onlineProfile.getProfileUUID(), toInside);
+
+        if ((entry && toInside && !fromInside || exit && fromInside && !toInside) && checkConditions(onlineProfile)) {
+            completeObjective(onlineProfile);
+            playersInsideRegion.remove(onlineProfile.getProfileUUID());
+        }
+    }
+
+    private boolean isInsideHandleException(final Location location, final OnlineProfile onlineProfile) {
+        final AtomicBoolean toInsideAtomic = new AtomicBoolean();
+        qreHandler.handle(() -> toInsideAtomic.set(isInside(onlineProfile, location)));
+        return toInsideAtomic.get();
+    }
+
+    /**
+     * Checks if the player at the given location is inside the location.
+     *
+     * @param onlineProfile the online profile of the player
+     * @param location      the location to be checked
+     * @return true if the player is inside the location, false otherwise
+     * @throws QuestRuntimeException if there is an error while checking if the player is inside the location
+     */
+    protected abstract boolean isInside(OnlineProfile onlineProfile, Location location) throws QuestRuntimeException;
+}

--- a/src/main/java/org/betonquest/betonquest/objectives/ActionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ActionObjective.java
@@ -55,7 +55,6 @@ public class ActionObjective extends Objective implements Listener {
     public ActionObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
-        template = ObjectiveData.class;
 
         action = instruction.getEnum(Click.class);
         if ("any".equalsIgnoreCase(instruction.next())) {

--- a/src/main/java/org/betonquest/betonquest/objectives/ArrowShootObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ArrowShootObjective.java
@@ -40,7 +40,6 @@ public class ArrowShootObjective extends Objective implements Listener {
     public ArrowShootObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
-        template = ObjectiveData.class;
         loc = instruction.getLocation();
         range = instruction.getVarNum();
     }

--- a/src/main/java/org/betonquest/betonquest/objectives/ChestPutObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ChestPutObjective.java
@@ -61,7 +61,6 @@ public class ChestPutObjective extends Objective implements Listener {
         super(instruction);
         final BetonQuestLoggerFactory loggerFactory = BetonQuest.getInstance().getLoggerFactory();
         this.log = loggerFactory.create(getClass());
-        template = ObjectiveData.class;
         // extract location
         loc = instruction.getLocation();
         final String location = instruction.current();

--- a/src/main/java/org/betonquest/betonquest/objectives/DieObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/DieObjective.java
@@ -41,7 +41,6 @@ public class DieObjective extends Objective implements Listener {
     public DieObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
-        template = ObjectiveData.class;
         cancel = instruction.hasArgument("cancel");
         location = instruction.getLocation(instruction.getOptional("respawn"));
     }

--- a/src/main/java/org/betonquest/betonquest/objectives/LoginObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/LoginObjective.java
@@ -22,7 +22,6 @@ public class LoginObjective extends Objective implements Listener {
 
     public LoginObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
     }
 

--- a/src/main/java/org/betonquest/betonquest/objectives/LogoutObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/LogoutObjective.java
@@ -22,7 +22,6 @@ public class LogoutObjective extends Objective implements Listener {
 
     public LogoutObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)

--- a/src/main/java/org/betonquest/betonquest/objectives/PasswordObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/PasswordObjective.java
@@ -35,7 +35,6 @@ public class PasswordObjective extends Objective implements Listener {
 
     public PasswordObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         final String pattern = instruction.next().replace('_', ' ');
         final int regexFlags = instruction.hasArgument("ignoreCase") ? Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE : 0;
         regex = Pattern.compile(pattern, regexFlags);

--- a/src/main/java/org/betonquest/betonquest/objectives/RespawnObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/RespawnObjective.java
@@ -29,7 +29,6 @@ public class RespawnObjective extends Objective implements Listener {
     public RespawnObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
         this.log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
-        template = ObjectiveData.class;
         location = instruction.getLocation(instruction.getOptional("location"));
     }
 

--- a/src/main/java/org/betonquest/betonquest/objectives/RideObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/RideObjective.java
@@ -25,7 +25,6 @@ public class RideObjective extends Objective implements Listener {
 
     public RideObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         final String name = instruction.next();
         if ("any".equalsIgnoreCase(name)) {
             any = true;

--- a/src/main/java/org/betonquest/betonquest/objectives/StepObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/StepObjective.java
@@ -36,7 +36,6 @@ public class StepObjective extends Objective implements Listener {
 
     public StepObjective(final Instruction instruction) throws InstructionParseException {
         super(instruction);
-        template = ObjectiveData.class;
         loc = instruction.getLocation();
     }
 


### PR DESCRIPTION
- `region` objective now supports variables as region name
- `location` objective now allows `entry` and `exit` keywords to track entering and leaving the location

![image](https://github.com/BetonQuest/BetonQuest/assets/4036106/a4014171-1ebf-4cd5-ac77-1e2243c850ea)

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
