### PR TITLE
Fix Burn event parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MMOCoreClassCondition, MMOItemsGiveEvent, MMOItemsHandCondition and MMOItemsItemCondition now work with numeric identifiers
 - yaml multiline instructions could lead to partly working events, conditions and objectives
 - creation of advancement tab when an advancement NotifyIO is sent
+- `burn` event throwing unexpected error when omitting duration
 ### Security
 
 ## [2.0.1] - 2024-03-24

--- a/src/main/java/org/betonquest/betonquest/quest/event/burn/BurnEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/burn/BurnEventFactory.java
@@ -53,7 +53,8 @@ public class BurnEventFactory implements EventFactory {
 
     @Override
     public Event parseEvent(final Instruction instruction) throws InstructionParseException {
-        final VariableNumber duration = instruction.getVarNum(instruction.getOptional("duration"));
+        final VariableNumber duration = instruction.getVarNum(instruction.getOptionalArgument("duration")
+                .orElseThrow(() -> new InstructionParseException("Missing duration!")));
         return new PrimaryServerThreadEvent(
                 new OnlineProfileRequiredEvent(
                         loggerFactory.create(BurnEvent.class), new BurnEvent(duration), instruction.getPackage()),


### PR DESCRIPTION
<!-- Please describe your changes here. -->
It now throws when no `duration` is given instead of throwing NPE on `#execute`.
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
