### PR TITLE
Improve database connection safety

### DIFF
--- a/src/main/java/org/betonquest/betonquest/database/Database.java
+++ b/src/main/java/org/betonquest/betonquest/database/Database.java
@@ -6,6 +6,8 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
 import java.util.SortedMap;
@@ -39,13 +41,24 @@ public abstract class Database {
 
     public Connection getConnection() {
         try {
-            if (con == null || con.isClosed()) {
+            if (con == null || con.isClosed() || isConnectionBroken(con)) {
                 con = openConnection();
             }
         } catch (final SQLException e) {
             log.error("Failed opening database connection!", e);
         }
         return con;
+    }
+
+    private boolean isConnectionBroken(final Connection connection) throws SQLException {
+        try {
+            try (PreparedStatement stmnt = connection.prepareStatement("SELECT 1");
+                 ResultSet result = stmnt.executeQuery()) {
+                return !result.next();
+            }
+        } catch (final SQLException e) {
+            return true;
+        }
     }
 
     protected abstract Connection openConnection() throws SQLException;

--- a/src/main/java/org/betonquest/betonquest/database/MySQL.java
+++ b/src/main/java/org/betonquest/betonquest/database/MySQL.java
@@ -63,6 +63,10 @@ public class MySQL extends Database {
             Class.forName("com.mysql.jdbc.Driver");
             connection = DriverManager.getConnection(
                     "jdbc:mysql://" + this.hostname + ":" + this.port + "/" + this.database + "?&useSSL=false", this.user, this.password);
+            final String connectionClassName = connection.getClass().getName();
+            if (!connectionClassName.startsWith("com.mysql.")) {
+                log.warn("External source modified or changed the MySQL connector! We can not guarantee that BetonQuest will work correctly with this connector: " + connectionClassName);
+            }
         } catch (final ClassNotFoundException | SQLException e) {
             log.warn("MySQL says: " + e.getMessage(), e);
         }


### PR DESCRIPTION
We had cases were the returned database connection was closed and the used class belonged to another plugin or mod that overwrote the default MySQL connector with its shaded dependency.

These adjustments should help prevent most issues.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
