### PR TITLE
prevent reply when the text is not completely displayed for the SlowTellrawIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 ### Security
 
+## [2.1.1-DEV1] - 2024-05-12
+### Added
+### Changed
+- prevent reply when the text is not completely displayed for the SlowTellRaw conversation IO
+### Deprecated
+### Removed
+### Fixed
+- NPE if a player replies to a SlowTellRaw conversation IO when the text is not completely displayed
+### Security
+
 ## [2.1.1] - 2024-05-09
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `aureliumskillslevel` condition was renamed to `auraskillslevel`
   - `aureliumstatslevel` condition was renamed to `auraskillsstatslevel`
   - `aureliumskillsxp` event was renamed to `auraskillsxp`
-### Deprecated
-### Removed
-### Fixed
-### Security
-
-## [2.1.1-DEV1] - 2024-05-12
-### Added
-### Changed
 - prevent reply when the text is not completely displayed for the SlowTellRaw conversation IO
 ### Deprecated
 ### Removed

--- a/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
@@ -6,6 +6,9 @@ import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.utils.LocalChatPaginator;
 import org.betonquest.betonquest.utils.Utils;
 import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,6 +24,8 @@ public class SlowTellrawConvIO extends TellrawConvIO {
     @Nullable
     private List<String> endLines;
 
+    private boolean canReply;
+
     public SlowTellrawConvIO(final Conversation conv, final OnlineProfile onlineProfile) {
         super(conv, onlineProfile);
         final StringBuilder string = new StringBuilder();
@@ -34,6 +39,16 @@ public class SlowTellrawConvIO extends TellrawConvIO {
             delay = 10;
         }
         this.messageDelay = delay;
+        this.canReply = false;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @Override
+    public void onReply(final AsyncPlayerChatEvent event) {
+        if (!canReply) {
+            return;
+        }
+        super.onReply(event);
     }
 
     @Override
@@ -42,6 +57,7 @@ public class SlowTellrawConvIO extends TellrawConvIO {
             end();
             return;
         }
+        canReply = false;
 
         // NPC Text
         final String[] lines = LocalChatPaginator.wordWrap(
@@ -58,11 +74,14 @@ public class SlowTellrawConvIO extends TellrawConvIO {
                     displayText();
 
                     // Display endLines
-                    for (final String message : endLines) {
-                        SlowTellrawConvIO.super.print(message);
+                    if (endLines != null) {
+                        for (final String message : endLines) {
+                            SlowTellrawConvIO.super.print(message);
+                        }
                     }
 
                     endLines = null;
+                    canReply = true;
 
                     this.cancel();
                     return;

--- a/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
@@ -24,6 +24,9 @@ public class SlowTellrawConvIO extends TellrawConvIO {
     @Nullable
     private List<String> endLines;
 
+    /**
+     * Whether the player can reply to the conversation, disabled while the NPC is talking, enabled when options are displayed
+     */
     private boolean canReply;
 
     public SlowTellrawConvIO(final Conversation conv, final OnlineProfile onlineProfile) {
@@ -42,6 +45,9 @@ public class SlowTellrawConvIO extends TellrawConvIO {
         this.canReply = false;
     }
 
+    /**
+     * if canReply is false, we ignore the event, otherwise handle it as normal
+     */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     @Override
     public void onReply(final AsyncPlayerChatEvent event) {

--- a/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/SlowTellrawConvIO.java
@@ -80,10 +80,8 @@ public class SlowTellrawConvIO extends TellrawConvIO {
                     displayText();
 
                     // Display endLines
-                    if (endLines != null) {
-                        for (final String message : endLines) {
-                            SlowTellrawConvIO.super.print(message);
-                        }
+                    for (final String message : endLines) {
+                        SlowTellrawConvIO.super.print(message);
                     }
 
                     endLines = null;


### PR DESCRIPTION

<!-- Please describe your changes here. -->
Players can reply to NPC even if the text is still displaying, and NPE could be caused in this way.
Now it should be fixed. 
---

### Related Issues
<!-- Issue number if existing. -->


### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
