### PR TITLE
`resourcepack` objective is now paper only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `aureliumstatslevel` condition was renamed to `auraskillsstatslevel`
   - `aureliumskillsxp` event was renamed to `auraskillsxp`
 - prevent reply when the text is not completely displayed for the SlowTellRaw conversation IO
+- `resourcepack` objective is now paper only 
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -287,6 +287,7 @@ initially required.
     ```
     
 ## Resource pack state: `resourcepack`
+**:fontawesome-solid-list-check:{.task} Objective  ·  :fontawesome-solid-paper-plane: Requires [Paper](https://papermc.io)**
 
 To complete this objective the player must have the specified resource pack state.
 The first argument is the state of the resource pack.

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -981,13 +981,13 @@ public class BetonQuest extends JavaPlugin {
         registerObjectives("variable", VariableObjective.class);
         registerObjectives("kill", KillPlayerObjective.class);
         registerObjectives("interact", EntityInteractObjective.class);
-        registerObjectives("resourcepack", ResourcePackObjective.class);
         registerObjectives("respawn", RespawnObjective.class);
         registerObjectives("breed", BreedObjective.class);
         registerObjectives("command", CommandObjective.class);
         if (PaperLib.isPaper()) {
-            registerObjectives("jump", JumpObjective.class);
             registerObjectives("equip", EquipItemObjective.class);
+            registerObjectives("jump", JumpObjective.class);
+            registerObjectives("resourcepack", ResourcePackObjective.class);
         }
 
         registerConversationIO("simple", SimpleConvIO.class);

--- a/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
+++ b/src/main/java/org/betonquest/betonquest/JoinQuitListener.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest;
 
+import io.papermc.lib.PaperLib;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -55,19 +56,26 @@ public class JoinQuitListener implements Listener {
         final PlayerData playerData = BetonQuest.getInstance().getPlayerData(onlineProfile);
         playerData.startObjectives();
         GlobalObjectives.startAll(onlineProfile);
-        final PlayerResourcePackStatusEvent.Status resourcePackStatus = event.getPlayer().getResourcePackStatus();
-        if (resourcePackStatus != null) {
-            BetonQuest.getInstance().getPlayerObjectives(onlineProfile).stream()
-                    .filter(objective -> objective instanceof ResourcePackObjective)
-                    .map(objective -> (ResourcePackObjective) objective)
-                    .forEach(objective -> objective.processObjective(onlineProfile, resourcePackStatus));
-        }
+        checkResourcepack(event, onlineProfile);
 
         if (Journal.hasJournal(onlineProfile)) {
             playerData.getJournal().update();
         }
         if (playerData.getActiveConversation() != null) {
             new ConversationResumer(loggerFactory, onlineProfile, playerData.getActiveConversation());
+        }
+    }
+
+    private void checkResourcepack(final PlayerJoinEvent event, final OnlineProfile onlineProfile) {
+        if (!PaperLib.isPaper()) {
+            return;
+        }
+        final PlayerResourcePackStatusEvent.Status resourcePackStatus = event.getPlayer().getResourcePackStatus();
+        if (resourcePackStatus != null) {
+            BetonQuest.getInstance().getPlayerObjectives(onlineProfile).stream()
+                    .filter(objective -> objective instanceof ResourcePackObjective)
+                    .map(objective -> (ResourcePackObjective) objective)
+                    .forEach(objective -> objective.processObjective(onlineProfile, resourcePackStatus));
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
getResourcePackStatus is a paper method, and spigot has no good alternative

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
