### PR TITLE
LuckPerms group permission

### DIFF
--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -533,6 +533,7 @@ for an in-depth explanation on what contexts are and how to add them to permissi
 ### Permissions
 If you prefer to directly add or remove permissions without triggering the LuckPerms changelog chat notifications,
 you can utilize the `luckperms addPermission` and `luckperms removePermission` events. 
+You also have the possibility to assign groups to the player via the `group.<GroupName>` permission. 
 
  ```YAML title="Example"
  events:

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsEventFactory.java
@@ -40,15 +40,15 @@ public class LuckPermsEventFactory implements EventFactory {
 
         return switch (action.toLowerCase(Locale.ROOT)) {
             case "addpermission" ->
-                    new LuckPermsPermissionEvent(getPermissionNodeBuilder(instruction), luckPermsAPI, NodeMap::add);
+                    new LuckPermsPermissionEvent(getNodeBuilder(instruction), luckPermsAPI, NodeMap::add);
             case "removepermission" ->
-                    new LuckPermsPermissionEvent(getPermissionNodeBuilder(instruction), luckPermsAPI, NodeMap::remove);
+                    new LuckPermsPermissionEvent(getNodeBuilder(instruction), luckPermsAPI, NodeMap::remove);
             default ->
                     throw new InstructionParseException("Unknown action: " + action + ". Expected addPermission or removePermission.");
         };
     }
 
-    private LuckPermsNodeBuilder getPermissionNodeBuilder(final Instruction instruction) throws InstructionParseException {
+    private LuckPermsNodeBuilder getNodeBuilder(final Instruction instruction) throws InstructionParseException {
         final String unparsedPermissions = instruction.getOptional("permission", "");
         if (unparsedPermissions.isEmpty()) {
             throw new InstructionParseException("Missing permissions argument. Expected permissions:permission1,"

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
@@ -4,6 +4,7 @@ import net.luckperms.api.LuckPerms;
 import net.luckperms.api.model.data.NodeMap;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.model.user.UserManager;
+import net.luckperms.api.node.Node;
 import net.luckperms.api.node.types.PermissionNode;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.event.Event;
@@ -25,26 +26,26 @@ public class LuckPermsPermissionEvent implements Event {
     private final LuckPerms luckPermsAPI;
 
     /**
-     * The {@link PermissionApply} to apply the permissions.
+     * The {@link NodeApply} to apply the permissions.
      */
-    private final PermissionApply permissionApply;
+    private final NodeApply nodeApply;
 
     /**
      * The list of {@link PermissionNode}s to add.
      */
-    private final LuckPermsNodeBuilder permissionNodeBuilder;
+    private final LuckPermsNodeBuilder nodeBuilder;
 
     /**
      * The Constructor for the {@link LuckPermsPermissionEvent}.
      *
-     * @param permissionNodeBuilder The list of {@link PermissionNode}s to add.
-     * @param luckPermsAPI          The {@link LuckPerms} API.
-     * @param permissionApply       The {@link PermissionApply} to apply the permissions.
+     * @param nodeBuilder  The list of {@link PermissionNode}s to add.
+     * @param luckPermsAPI The {@link LuckPerms} API.
+     * @param nodeApply    The {@link NodeApply} to apply the permissions.
      */
-    public LuckPermsPermissionEvent(final LuckPermsNodeBuilder permissionNodeBuilder, final LuckPerms luckPermsAPI, final PermissionApply permissionApply) {
-        this.permissionNodeBuilder = permissionNodeBuilder;
+    public LuckPermsPermissionEvent(final LuckPermsNodeBuilder nodeBuilder, final LuckPerms luckPermsAPI, final NodeApply nodeApply) {
+        this.nodeBuilder = nodeBuilder;
         this.luckPermsAPI = luckPermsAPI;
-        this.permissionApply = permissionApply;
+        this.nodeApply = nodeApply;
     }
 
     @Override
@@ -55,9 +56,9 @@ public class LuckPermsPermissionEvent implements Event {
         final User user = getUser(userFuture);
 
         final NodeMap data = user.data();
-        final List<PermissionNode> nodes = permissionNodeBuilder.getNodes(profile);
-        for (final PermissionNode permission : nodes) {
-            permissionApply.apply(data, permission);
+        final List<Node> buildNodes = nodeBuilder.getNodes(profile);
+        for (final Node node : buildNodes) {
+            nodeApply.apply(data, node);
         }
         userManager.saveUser(user);
     }
@@ -74,13 +75,13 @@ public class LuckPermsPermissionEvent implements Event {
      * Functional interface to apply a {@link PermissionNode} to a {@link NodeMap}.
      */
     @FunctionalInterface
-    public interface PermissionApply {
+    public interface NodeApply {
         /**
          * Applies the {@link PermissionNode} to the {@link NodeMap}.
          *
-         * @param nodeMap    The {@link NodeMap} to apply the {@link PermissionNode} to.
-         * @param permission The {@link PermissionNode} to apply.
+         * @param nodeMap The {@link NodeMap} to apply the {@link PermissionNode} to.
+         * @param node    The {@link PermissionNode} to apply.
          */
-        void apply(NodeMap nodeMap, PermissionNode permission);
+        void apply(NodeMap nodeMap, Node node);
     }
 }


### PR DESCRIPTION
### Discription
fixed an issue where the group cant be applied in the form of a permission String. A Stacktrace from LuckPerms was thrown when trying to use `group.<groupName>` permission strings.

The PermissionNode does not allow to modify InerhitanceNodes from the player. I Updated the PermissionNodeBuilder to a NodeBuilder and used the Node type in order to allow to set LuckPerms groups to a player. 

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
