### PR TITLE
Make `ph` variable static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - prevent reply when the text is not completely displayed for the SlowTellRaw conversation IO
 - `resourcepack` objective is now paper only
 - `die` objective now support respawns without canceling the actual death of the player
+- `ph` variable can now be used static
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -879,6 +879,8 @@ Testing your placeholder is easy using this command:
 
 ### Variable: `ph`
 
+**persistent**, **static**
+
 You can also use placeholders from other plugins in BetonQuest. Simply insert a variable starting with `ph`, the second argument should be the placeholder without percentage characters.
 
 !!! example

--- a/src/main/java/org/betonquest/betonquest/compatibility/placeholderapi/PlaceholderVariable.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/placeholderapi/PlaceholderVariable.java
@@ -4,20 +4,32 @@ import me.clip.placeholderapi.PlaceholderAPI;
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.api.Variable;
 import org.betonquest.betonquest.api.profiles.Profile;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.Nullable;
 
-@SuppressWarnings("PMD.CommentRequired")
+/**
+ * A BetonQuest variable which delegates to PAPI.
+ */
 public class PlaceholderVariable extends Variable {
-
+    /**
+     * Placeholder to resolve without surrounding '%'.
+     */
     private final String placeholder;
 
+    /**
+     * Create a new Placeholder API variable.
+     *
+     * @param instruction the instruction to parse
+     */
     public PlaceholderVariable(final Instruction instruction) {
         super(instruction);
+        staticness = true;
         placeholder = String.join(".", instruction.getAllParts());
     }
 
     @Override
-    public String getValue(final Profile profile) {
-        return PlaceholderAPI.setPlaceholders(profile.getOnlineProfile().get().getPlayer(), '%' + placeholder + '%');
+    public String getValue(@Nullable final Profile profile) {
+        final OfflinePlayer player = profile == null ? null : profile.getPlayer();
+        return PlaceholderAPI.setPlaceholders(player, '%' + placeholder + '%');
     }
-
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
to reflect it's possible playerless usage.
---
Since the resolve method with a player just delegates to the one with an OfflinePlayer we can avoid getting the online Player.
### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
