### PR TITLE
Another approach to get rid of the check for online profiles in event…

### DIFF
--- a/src/main/java/org/betonquest/betonquest/api/quest/condition/PlayerCondition.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/condition/PlayerCondition.java
@@ -1,7 +1,10 @@
 package org.betonquest.betonquest.api.quest.condition;
 
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+
+import java.util.Optional;
 
 /**
  * Interface for quest-conditions that are checked for a profile. It represents the normal condition as described in the
@@ -11,9 +14,24 @@ public interface PlayerCondition {
     /**
      * Checks the condition.
      *
+     * @param profile the {@link OnlineProfile} the condition is checked for
+     * @return if the condition is fulfilled
+     * @throws QuestRuntimeException when the condition check fails
+     */
+    boolean check(OnlineProfile profile) throws QuestRuntimeException;
+
+    /**
+     * Checks the condition.
+     *
      * @param profile the {@link Profile} the condition is checked for
      * @return if the condition is fulfilled
      * @throws QuestRuntimeException when the condition check fails
      */
-    boolean check(Profile profile) throws QuestRuntimeException;
+    default boolean check(final Profile profile) throws QuestRuntimeException {
+        final Optional<OnlineProfile> onlineProfile = profile.getOnlineProfile();
+        if (onlineProfile.isPresent()) {
+            return check(onlineProfile.get());
+        }
+        throw new QuestRuntimeException("PlayerCondition can only be checked for OnlineProfiles");
+    }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/condition/PrimaryServerThreadCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/PrimaryServerThreadCondition.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.condition;
 
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.Condition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -25,6 +26,11 @@ public class PrimaryServerThreadCondition extends PrimaryServerThreadType<Condit
      */
     public PrimaryServerThreadCondition(final Condition synced, final PrimaryServerThreadData data) {
         super(synced, data);
+    }
+
+    @Override
+    public boolean check(final OnlineProfile profile) throws QuestRuntimeException {
+        return call(() -> synced.check(profile));
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/quest/condition/PrimaryServerThreadPlayerCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/PrimaryServerThreadPlayerCondition.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.condition;
 
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -24,6 +25,11 @@ public class PrimaryServerThreadPlayerCondition extends PrimaryServerThreadType<
      */
     public PrimaryServerThreadPlayerCondition(final PlayerCondition synced, final PrimaryServerThreadData data) {
         super(synced, data);
+    }
+
+    @Override
+    public boolean check(final OnlineProfile profile) throws QuestRuntimeException {
+        return call(() -> synced.check(profile));
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/quest/condition/advancement/AdvancementCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/advancement/AdvancementCondition.java
@@ -1,6 +1,6 @@
 package org.betonquest.betonquest.quest.condition.advancement;
 
-import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.advancement.Advancement;
@@ -25,8 +25,8 @@ public class AdvancementCondition implements PlayerCondition {
     }
 
     @Override
-    public boolean check(final Profile profile) throws QuestRuntimeException {
-        final AdvancementProgress progress = profile.getOnlineProfile().get().getPlayer().getAdvancementProgress(advancement);
+    public boolean check(final OnlineProfile profile) throws QuestRuntimeException {
+        final AdvancementProgress progress = profile.getPlayer().getAdvancementProgress(advancement);
         return progress.isDone();
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/condition/block/BlockCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/block/BlockCondition.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.condition.block;
 
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.Condition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
@@ -38,6 +39,11 @@ public class BlockCondition implements Condition {
         this.loc = loc;
         this.selector = selector;
         this.exactMatch = exactMatch;
+    }
+
+    @Override
+    public boolean check(final OnlineProfile profile) throws QuestRuntimeException {
+        return check((Profile) profile);
     }
 
     @Override

--- a/src/main/java/org/betonquest/betonquest/quest/legacy/LegacyConditionAdapter.java
+++ b/src/main/java/org/betonquest/betonquest/quest/legacy/LegacyConditionAdapter.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.quest.legacy;
 
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.api.quest.condition.PlayerlessCondition;
@@ -9,6 +10,7 @@ import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Adapter for {@link PlayerCondition} and {@link PlayerlessCondition} to fit the old convention of
@@ -55,6 +57,10 @@ public class LegacyConditionAdapter extends org.betonquest.betonquest.api.Condit
             Objects.requireNonNull(playerlessCondition);
             return playerlessCondition.check();
         } else {
+            final Optional<OnlineProfile> onlineProfile = profile.getOnlineProfile();
+            if (onlineProfile.isPresent()) {
+                return playerCondition.check(onlineProfile.get());
+            }
             return playerCondition.check(profile);
         }
     }


### PR DESCRIPTION
…s only supporting execution on online Players

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
