### PR TITLE
LuckPerms permission fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Deprecated
 ### Removed
 ### Fixed
+- LuckPerms integration not sending the permission updates via the messaging service to connected Servers in the same network.
 ### Security
 
 ## [2.1.2] - 2024-06-23

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
@@ -61,6 +61,7 @@ public class LuckPermsPermissionEvent implements Event {
             nodeApply.apply(data, node);
         }
         userManager.saveUser(user);
+        luckPermsAPI.getMessagingService().ifPresent(service -> service.pushUserUpdate(user));
     }
 
     private User getUser(final CompletableFuture<User> userFuture) throws QuestRuntimeException {


### PR DESCRIPTION
LuckPerms permission updates via the addPermission and removePermission event were not sent in the connected network if there is one present. With a network, a velocity or bungee network is meant.
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
