### PR TITLE
restore LuckPerms TagCalculator behaviour 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
 - LuckPerms integration not sending the permission updates via the messaging service to connected Servers in the same network.
+- LuckPerms TagCalculator trying to use PlayerData even if player is offline
 ### Security
 
 ## [2.1.2] - 2024-06-23

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
@@ -33,8 +33,8 @@ public final class TagCalculatorUtils {
      */
     public static ContextCalculator<Player> getTagContextCalculator() {
         return (player, contextConsumer) -> {
-            final PlayerData data = BetonQuest.getInstance().getPlayerData(PlayerConverter.getID(player));
-            if (data != null) {
+            if (player.isOnline()) {
+                final PlayerData data = BetonQuest.getInstance().getPlayerData(PlayerConverter.getID(player));
                 data.getTags().forEach(tag -> contextConsumer.accept(KEY_LOCAL + tag, "true"));
             }
 


### PR DESCRIPTION
broken in c8bf3cdcc7fcb3710424599973b06604e70c0a3d.

<!-- Please describe your changes here. -->
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
