### PR TITLE
Fix Vault money Condition

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/condition/MoneyConditionFactory.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/condition/MoneyConditionFactory.java
@@ -36,7 +36,7 @@ public class MoneyConditionFactory implements PlayerConditionFactory {
 
     @Override
     public PlayerCondition parsePlayer(final Instruction instruction) throws InstructionParseException {
-        final VariableNumber amount = instruction.getVarNum(VariableNumber.NOT_LESS_THAN_ONE_CHECKER);
+        final VariableNumber amount = instruction.getVarNum(VariableNumber.NOT_LESS_THAN_ZERO_CHECKER);
         return new PrimaryServerThreadPlayerCondition(new MoneyCondition(economy, amount), data);
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Return back to allow checking if the bank of a player is back at 0. Got changed in the migration, but we want to allow checking if a player has an eco of 0 or not.

https://github.com/BetonQuest/BetonQuest/pull/2845
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
