### PR TITLE
rollback accidentally deleted deprecated constructor in PrimaryServerThreadEvent

### DIFF
--- a/src/main/java/org/betonquest/betonquest/quest/event/PrimaryServerThreadEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/PrimaryServerThreadEvent.java
@@ -19,6 +19,24 @@ public class PrimaryServerThreadEvent extends PrimaryServerThreadType<Event, Voi
      * determine if the current thread is the primary server thread and to
      * schedule the execution onto it in case it isn't.
      *
+     * @param syncedEvent event to synchronize
+     * @param server      server for primary thread identification
+     * @param scheduler   scheduler for primary thread scheduling
+     * @param plugin      plugin to associate with the scheduled task
+     * @deprecated use constructor with {@link PrimaryServerThreadData}
+     */
+    @Deprecated
+    public PrimaryServerThreadEvent(final Event syncedEvent, final Server server,
+                                    final BukkitScheduler scheduler, final Plugin plugin) {
+        super(syncedEvent, server, scheduler, plugin);
+    }
+
+    /**
+     * Wrap the given {@link Event} for execution on the primary server thread.
+     * The {@link Server}, {@link BukkitScheduler} and {@link Plugin} are used to
+     * determine if the current thread is the primary server thread and to
+     * schedule the execution onto it in case it isn't.
+     *
      * @param synced event to synchronize
      * @param data   the data containing server, scheduler and plugin used for primary thread access
      */


### PR DESCRIPTION
if #2879 the deprecated method was accidentally deleted, this is a rollback of it

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
