### PR TITLE
Improve char width calculation with accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - chaining of movenpc events did trigger fail events
 - effect event duration -1 did not result in infinite duration
 - translation in conversation got stored in default language
+- incorrect calculation of the width of strings when using characters with certain accents when doing pagination 
 ### Security
 
 ## [2.1.2] - 2024-06-23

--- a/src/main/java/org/betonquest/betonquest/utils/LocalChatPaginator.java
+++ b/src/main/java/org/betonquest/betonquest/utils/LocalChatPaginator.java
@@ -51,6 +51,12 @@ public final class LocalChatPaginator {
                 Map.entry('`', 3),
                 Map.entry('f', 5),
                 Map.entry('i', 2),
+                Map.entry('í', 3),
+                Map.entry('ì', 3),
+                Map.entry('ȋ', 4),
+                Map.entry('î', 4),
+                Map.entry('ǐ', 4),
+                Map.entry('ï', 4),
                 Map.entry('k', 5),
                 Map.entry('l', 3),
                 Map.entry('t', 4),
@@ -208,6 +214,16 @@ public final class LocalChatPaginator {
      * @return width of the character
      */
     public static int getWidth(final Character character) {
-        return FONT_SIZES.getOrDefault(character, DEFAULT_CHAR_WIDTH);
+        final Integer charWidth = FONT_SIZES.get(character);
+        if (charWidth != null) {
+            return charWidth;
+        }
+
+        final String withoutAccent = StringUtils.stripAccents(character.toString());
+        final char withoutAccentChar = withoutAccent.charAt(0);
+        if (!character.equals(withoutAccentChar)) {
+            return FONT_SIZES.getOrDefault(withoutAccentChar, DEFAULT_CHAR_WIDTH);
+        }
+        return DEFAULT_CHAR_WIDTH;
     }
 }


### PR DESCRIPTION
I found some more characters (with accents this time) which's widths aren't correctly calculated by BetonQuest yet. This change improves the char width calculation with accents as well as tries to fall back on the base characters without accents if a character with accent doesn't have a special value defined.

### Related Issues
<!-- Issue number if existing. -->
~~Closes #XXXX~~

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
