### PR TITLE
fix release type detection on the GitHub repository

### DIFF
--- a/.github/actions/version/type/action.yml
+++ b/.github/actions/version/type/action.yml
@@ -21,7 +21,7 @@ runs:
       if: "startsWith(github.ref,'refs/tags/v')"
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
-        if [[ github.repository != inputs.ROOT_REPOSITORY ]]; then
+        if [ ${{ github.repository }} != inputs.ROOT_REPOSITORY ]; then
           echo "Version tags are not allowed in forks!"
           exit 1
         fi


### PR DESCRIPTION
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
