### PR TITLE
removed left over CHANGES_IN_DOCS_ONLY ref in discord.sh and use VERS…

### DIFF
--- a/.github/scripts/discord.sh
+++ b/.github/scripts/discord.sh
@@ -81,7 +81,7 @@ case "$JOB_STATUS" in
     ;;
 
   "failure"|"cancelled" )
-    if [[ $CHANGES_IN_DOCS_ONLY == false ]]; then VERSION_HINT=$VERSION; else VERSION_HINT="the Docs"; fi
+    if [[ $VERSION_IS_NEW == true ]]; then VERSION_HINT=$VERSION; else VERSION_HINT="the Docs"; fi
     EMBED_COLOR=15158332
     STATUS_MESSAGE="There was an error building a $RELEASE_NAME!"
     DEV_BUILD_DOWNLOAD="Inspect the failure on $VERSION_HINT!"


### PR DESCRIPTION
…ION_IS_NEW instead

<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
