### PR TITLE
Add `chat` objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- `chat` objective
 ### Changed
 - `spawn` event now only spawn mobs and no other entities
 ### Deprecated

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -92,6 +92,20 @@ This objective has three properties: `amount`, `left` and `total`. `amount` is t
     breed cow 10 notify:2 events:reward
     ```
 
+## Capture a message: `chat`
+
+Requires the player to write a message in the chat.
+
+| Parameter  | Syntax                                   | Default Value          | Explanation                                                                                                            |
+|------------|------------------------------------------|------------------------|------------------------------------------------------------------------------------------------------------------------|
+| _variable_ | [Variable Objective](#variable-variable) | :octicons-x-circle-16: | The variable where to store the chat message. Like with the event the player is required to have the objective active. |
+| _cancel_   | cancel                                   | :octicons-x-circle-16: | If the chat message should be cancelled.                                                                               |
+
+!!! example
+    ```YAML
+    chat variable:Storage#message cancel events:broadcastMessage conditions:holdsBroadcastWand
+    ```
+
 ## Put items in a chest: `chestput`
 
 This objective requires the player to put specified items in a specified chest. First argument is a location of the

--- a/src/main/java/org/betonquest/betonquest/objectives/ChatObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objectives/ChatObjective.java
@@ -1,0 +1,128 @@
+package org.betonquest.betonquest.objectives;
+
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.Objective;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
+import org.betonquest.betonquest.id.ObjectiveID;
+import org.betonquest.betonquest.utils.PlayerConverter;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Catches the next chat message of a player.
+ */
+public class ChatObjective extends Objective implements Listener {
+    /**
+     * The amount of parts to parse for the ObjectiveID and key.
+     */
+    private static final int OBJECTIVE_FORMAT_LENGTH = 2;
+
+    /**
+     * Custom {@link BetonQuestLogger} for this class.
+     */
+    private final BetonQuestLogger log;
+
+    /**
+     * If the chat event should be cancelled.
+     */
+    private final boolean cancel;
+
+    /**
+     * A {@link VariableObjective} and key where the chat message should be stored.
+     */
+    @Nullable
+    private final Map.Entry<ObjectiveID, String> variable;
+
+    /**
+     * Create a new Chat Objective from an Instruction string.
+     *
+     * @param instruction the user provided instruction string
+     * @throws InstructionParseException when the Instruction is invalid or the VariableObjective does not exist
+     */
+    public ChatObjective(final Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        log = BetonQuest.getInstance().getLoggerFactory().create(getClass());
+        cancel = instruction.hasArgument("cancel");
+        variable = parseVariable(instruction.getOptional("variable"));
+    }
+
+    @Nullable
+    private Map.Entry<ObjectiveID, String> parseVariable(@Nullable final String variableString) throws InstructionParseException {
+        if (variableString == null) {
+            return null;
+        }
+        final String[] split = variableString.split("#");
+        if (split.length != OBJECTIVE_FORMAT_LENGTH) {
+            throw new InstructionParseException("Invalid variable '" + variableString + "' does not contain ID and Key!");
+        }
+        final ObjectiveID objectiveID;
+        try {
+            objectiveID = new ObjectiveID(instruction.getPackage(), split[0]);
+        } catch (final ObjectNotFoundException exception) {
+            throw new InstructionParseException("Variable '" + split[0] + "' does not exist!", exception);
+        }
+        return Map.entry(objectiveID, split[1]);
+    }
+
+    @Override
+    public void start() {
+        Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
+    }
+
+    @Override
+    public void stop() {
+        HandlerList.unregisterAll(this);
+    }
+
+    @Override
+    public String getDefaultDataInstruction() {
+        return "";
+    }
+
+    @Override
+    public String getProperty(final String name, final Profile profile) {
+        return "";
+    }
+
+    /**
+     * Intercepts a player message to eventually store it.
+     *
+     * @param event the event to listen to
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onChat(final AsyncPlayerChatEvent event) {
+        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
+            return;
+        }
+
+        if (cancel) {
+            event.setCancelled(true);
+        }
+
+        if (variable != null) {
+            if (BetonQuest.getInstance().getObjective(variable.getKey()) instanceof final VariableObjective variableObjective) {
+                if (!variableObjective.store(onlineProfile, variable.getValue(), event.getMessage())) {
+                    log.warn("Can't store value in variable objective '" + variable.getKey().getFullID()
+                            + "' because it is not active for the player!");
+                }
+            } else {
+                log.warn("Can't store value in variable objective '" + variable.getKey().getFullID()
+                        + "' because it is not an variable objective!");
+            }
+        }
+
+        completeObjective(onlineProfile);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
@@ -55,6 +55,7 @@ import org.betonquest.betonquest.objectives.ArrowShootObjective;
 import org.betonquest.betonquest.objectives.BlockObjective;
 import org.betonquest.betonquest.objectives.BreedObjective;
 import org.betonquest.betonquest.objectives.BrewObjective;
+import org.betonquest.betonquest.objectives.ChatObjective;
 import org.betonquest.betonquest.objectives.ChestPutObjective;
 import org.betonquest.betonquest.objectives.CommandObjective;
 import org.betonquest.betonquest.objectives.ConsumeObjective;
@@ -339,6 +340,7 @@ public class CoreQuestTypes {
         betonQuest.registerObjectives("block", BlockObjective.class);
         betonQuest.registerObjectives("breed", BreedObjective.class);
         betonQuest.registerObjectives("brew", BrewObjective.class);
+        betonQuest.registerObjectives("chat", ChatObjective.class);
         betonQuest.registerObjectives("chestput", ChestPutObjective.class);
         betonQuest.registerObjectives("command", CommandObjective.class);
         betonQuest.registerObjectives("consume", ConsumeObjective.class);


### PR DESCRIPTION
<!-- Please describe your changes here. -->
to, opposed to the variable's objective input, simply captures a chat message into a defined key.
---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [ ] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
