### PR TITLE
fixed missing escape in wiki example for notify

### DIFF
--- a/docs/_snippets/events.yml
+++ b/docs/_snippets/events.yml
@@ -47,7 +47,7 @@ notify: |-
   theSame: "notify Hello %player%! io:chat"
 
   #This one displays a title and a subtitle:
-  myTitle: "notify This is a title.\nThis is a subtitle. io:title"
+  myTitle: "notify This is a title.\\nThis is a subtitle. io:title"
 
   #Plays a sound:
   mySound: "notify io:sound sound:x.y.z"


### PR DESCRIPTION
<!-- Please describe your changes here. -->

---

### Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigPatcher)?
- [x]  ... solve all TODOs?
- [x]  ... remove any commented out code?
- [x]  ... add [debug messages](https://betonquest.org/DEV/API/Logging/)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
