### PR TITLE
added underscores are now escapable in item names via `\_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `start_new_lines` the amount of new lines that should be printed before the conversation starts
   - `npc_text_fill_new_lines` should lined be filled between the NPC text and the player answer options
 - `world` condition now supports variables for the world name
+- underscores are now escapable in item names and lore via `\_`
 ### Changed
 - `spawn` event now only spawn mobs and no other entities
 ### Deprecated

--- a/docs/Documentation/Features/Items.md
+++ b/docs/Documentation/Features/Items.md
@@ -14,9 +14,16 @@ Every argument is used in two ways: when creating an item and when checking if s
 
 These are arguments that can be applied to every item:
 
-- `name` - the display name of the item. All underscores will be replaced with spaces and you can use `&` color codes. If you want to specifically say that the item must not have any name, use `none` keyword.
+- `name` - the display name of the item. Underscores will be replaced with spaces.
+You can escape them with `\_` and you can also escape the `\` with `\\_`. You can also use `&` color codes. 
+If you want to specifically say that the item must not have any name, use `none` keyword.
 
-- `lore` - text under the item's name. Default styling of lore is purple and italic. All underscores will be replaced with spaces and you can use `&` color codes. To make a new line use `;` character. If you require the item not to have lore at all, use `none` keyword. By default lore will match only if all lines are exactly the same. If you want to accept all items which contain specified lines (and/or more lines), add `lore-containing` argument to the instruction string.
+- `lore` - text under the item's name. Default styling of lore is purple and italic. 
+You can escape them with `\_` and you can also escape the `\` with `\\_`. You can also use `&` color codes.
+To make a new line use `;` character. If you require the item not to have a lore at all, use `none` keyword.
+By default, lore will match only if all lines are exactly the same.
+If you want to accept all items that contain specified lines (and/or more lines),
+add `lore-containing` argument to the instruction string.
 
 - `enchants` - a list of enchantments and their levels. Each enchantment consists of these things, separated by colons:
     - [name](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html)

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/LoreHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/LoreHandler.java
@@ -26,7 +26,7 @@ public class LoreHandler {
         }
         existence = Existence.REQUIRED;
         for (final String line : lore.split(";")) {
-            this.lore.add(line.replaceAll("_", " ").replaceAll("&", "§"));
+            this.lore.add(NameHandler.replaceUnderscore(line).replaceAll("&", "§"));
         }
     }
 
@@ -77,5 +77,4 @@ public class LoreHandler {
                 return false;
         }
     }
-
 }

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/NameHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/NameHandler.java
@@ -15,6 +15,16 @@ public class NameHandler {
     public NameHandler() {
     }
 
+    /**
+     * Replaces all underscores with spaces, except for those that are escaped with a backslash.
+     *
+     * @param input The input string.
+     * @return The input string with all underscores replaced with spaces, except for those that are escaped with a backslash.
+     */
+    protected static String replaceUnderscore(final String input) {
+        return input.replaceAll("(?<!\\\\)_", " ").replaceAll("\\\\_", "_");
+    }
+
     public void set(final String name) throws InstructionParseException {
         if (name.isEmpty()) {
             throw new InstructionParseException("Name cannot be empty");
@@ -22,7 +32,7 @@ public class NameHandler {
         if (QuestItem.NONE_KEY.equalsIgnoreCase(name)) {
             existence = Existence.FORBIDDEN;
         } else {
-            this.name = name.replace('_', ' ').replace('&', '§');
+            this.name = replaceUnderscore(name).replace('&', '§');
             existence = Existence.REQUIRED;
         }
     }
@@ -39,5 +49,4 @@ public class NameHandler {
             case FORBIDDEN -> name == null;
         };
     }
-
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
