### PR TITLE
fixed mmoprofessionlevelup now respects the change of a class that ar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - broken title check in book `QuestItem`
 - BlockSelector did not match exact block matches and started regex matching causing performance issues during load and reload
 - wrong order of arguments in fire work effects
+- mmoprofessionlevelup now respects the change of a class that are already fit the objective requirements
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.compatibility.mmogroup.mmocore;
 
+import net.Indyuce.mmocore.api.event.PlayerChangeClassEvent;
 import net.Indyuce.mmocore.api.event.PlayerLevelUpEvent;
 import net.Indyuce.mmocore.experience.Profession;
 import org.betonquest.betonquest.BetonQuest;
@@ -46,6 +47,19 @@ public class MMOCoreProfessionObjective extends Objective implements Listener {
         completeObjective(onlineProfile);
     }
 
+    @EventHandler(ignoreCancelled = true)
+    public void onClassChange(final PlayerChangeClassEvent event) {
+        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
+            return;
+        }
+        final int level = event.getData().getCollectionSkills().getLevel(professionName);
+        if (level < targetLevel.getInt(onlineProfile)) {
+            return;
+        }
+        completeObjective(onlineProfile);
+    }
+
     @Override
     public void start() {
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
@@ -65,5 +79,4 @@ public class MMOCoreProfessionObjective extends Objective implements Listener {
     public String getProperty(final String name, final Profile profile) {
         return "";
     }
-
 }


### PR DESCRIPTION
…e already fit the objective requirements

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
