### PR TITLE
fixed setup-docs-dependencies.py not work correctly with MKDOCS_MATERIAL_INSIDERS_ENABLED set

### DIFF
--- a/config/setup-docs-dependencies.py
+++ b/config/setup-docs-dependencies.py
@@ -10,22 +10,20 @@ common_dependencies = [
 
 def get_install_requires():
     mkdocs_token = os.environ.get('MKDOCS_MATERIAL_INSIDERS')
-
     if mkdocs_token:
         mkdocs_enabled = os.environ.get('MKDOCS_MATERIAL_INSIDERS_ENABLED')
-        if not mkdocs_enabled:
-            print("\033[93m"
-                  + "Warning: 'MKDOCS_MATERIAL_INSIDERS' is set "
-                  + "but 'MKDOCS_MATERIAL_INSIDERS_ENABLED' is not set to 'true', "
-                  + "so if you serve mkdocs you will serve the normal version!"
-                  + "\033[0m")
-        return [
-            f'git+https://{mkdocs_token}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.33-insiders-4.53.12',
-            'pillow',
-            'cairosvg',
-        ] + common_dependencies
-    else:
-        return ['mkdocs-material==9.5.33'] + common_dependencies
+        if mkdocs_enabled == 'true':
+            return [
+                f'git+https://{mkdocs_token}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.33-insiders-4.53.12',
+                'pillow',
+                'cairosvg',
+            ] + common_dependencies
+        print("\033[93m"
+              + "Warning: 'MKDOCS_MATERIAL_INSIDERS' is set "
+              + "but 'MKDOCS_MATERIAL_INSIDERS_ENABLED' is not set to 'true', "
+              + "so if you serve mkdocs you will serve the normal version!"
+              + "\033[0m")
+    return ['mkdocs-material==9.5.33'] + common_dependencies
 
 
 subprocess.run(['pip', 'install'] + get_install_requires())


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
