### PR TITLE
[DOCS] fix markdown code block

### DIFF
--- a/docs/Participate/Process/Docs/Guidelines.md
+++ b/docs/Participate/Process/Docs/Guidelines.md
@@ -12,7 +12,7 @@ Tables and other special syntax are exempt from this rule.
 
 Links can be created using Markdown's link syntax:
 
-``` linenums="1"
+```markdown linenums="1"
 Click the [highlighted words](Contributing.md).
 ```
 Result: Click the [highlighted words](../../Overview.md).


### PR DESCRIPTION
this generated a warning which caused the docs build to fail due to `--strict`


### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
