### PR TITLE
LuckPerms push server wide update fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - BlockSelector did not match exact block matches and started regex matching causing performance issues during load and reload
 - wrong order of arguments in fire work effects
 - non-static `variables` causing cross conversation validation to break
+- LuckPerms integration not pushing the permission update to the connected servers correctly.
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/LuckPermsIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/LuckPermsIntegrator.java
@@ -45,7 +45,7 @@ public class LuckPermsIntegrator implements Integrator {
             luckPermsAPI = provider.getProvider();
             tagCalculator = TagCalculatorUtils.getTagContextCalculator();
             luckPermsAPI.getContextManager().registerCalculator(tagCalculator);
-            instance.registerNonStaticEvent("luckperms", new LuckPermsEventFactory(luckPermsAPI));
+            instance.getQuestRegistries().getEventTypes().register("luckperms", new LuckPermsEventFactory(luckPermsAPI));
         }
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
@@ -14,12 +14,12 @@ import java.util.List;
  */
 public final class TagCalculatorUtils {
     /**
-     * The BetonQuest tag
+     * The BetonQuest tag.
      */
     public static final String KEY_LOCAL = "betonquest:tag:";
 
     /**
-     * The global BetonQuest tag
+     * The global BetonQuest tag.
      */
     public static final String KEY_GLOBAL = "betonquest:globaltag:";
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsNodeBuilder.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsNodeBuilder.java
@@ -37,12 +37,12 @@ public record LuckPermsNodeBuilder(List<VariableString> permissions, VariableStr
      */
     public List<Node> getNodes(final Profile profile) throws QuestRuntimeException {
         final List<Node> buildNodes = new ArrayList<>();
-        final String resolvedValue = value.getString(profile);
+        final String resolvedValue = value.getValue(profile);
         final MutableContextSet contextSet = parseContextSet(contexts, profile);
         final long resolvedExpiry = expiry.getValue(profile).longValue();
         final TimeUnit resolvedTimeUnit = getTimeUnit(timeUnit, profile);
         for (final VariableString permission : permissions) {
-            Node node = getNode(permission.getString(profile));
+            Node node = getNode(permission.getValue(profile));
             if (!resolvedValue.isEmpty()) {
                 node = addValue(node, Boolean.parseBoolean(resolvedValue));
             }
@@ -60,7 +60,7 @@ public record LuckPermsNodeBuilder(List<VariableString> permissions, VariableStr
 
     @SuppressWarnings("PMD.LocalVariableCouldBeFinal")
     private @NotNull TimeUnit getTimeUnit(final VariableString data, final Profile profile) throws QuestRuntimeException {
-        final String time = data.getString(profile);
+        final String time = data.getValue(profile);
         TimeUnit unit;
         try {
             unit = TimeUnit.valueOf(time.toUpperCase(Locale.ROOT));
@@ -84,10 +84,10 @@ public record LuckPermsNodeBuilder(List<VariableString> permissions, VariableStr
         return builder.toBuilder().context(contextSet).build();
     }
 
-    private MutableContextSet parseContextSet(final List<VariableString> contexts, final Profile profile) {
+    private MutableContextSet parseContextSet(final List<VariableString> contexts, final Profile profile) throws QuestRuntimeException {
         final MutableContextSet contextSet = MutableContextSet.create();
         for (final VariableString context : contexts) {
-            final String[] split = context.getString(profile).split(";");
+            final String[] split = context.getValue(profile).split(";");
             contextSet.add(split[0], split[1]);
         }
         return contextSet;

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/permission/LuckPermsPermissionEvent.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Event to add permissions to a player using LuckPerms
+ * Event to add permissions to a player using LuckPerms.
  */
 public class LuckPermsPermissionEvent implements Event {
 
@@ -60,8 +60,8 @@ public class LuckPermsPermissionEvent implements Event {
         for (final Node node : buildNodes) {
             nodeApply.apply(data, node);
         }
-        userManager.saveUser(user);
-        luckPermsAPI.getMessagingService().ifPresent(service -> service.pushUserUpdate(user));
+        userManager.saveUser(user).thenAcceptAsync(result -> luckPermsAPI.getMessagingService().ifPresent(service
+                -> service.pushUserUpdate(user)));
     }
 
     private User getUser(final CompletableFuture<User> userFuture) throws QuestRuntimeException {


### PR DESCRIPTION
<!-- Please describe your changes here. -->
* Fixed the update push to the server network on permission change on player. It got executed too early in the process.
* Small refactor to get rid of the deprecated internals of bq.
* fixed two jd warnings because of a missing `.` on the end of a sentence.
---

### Related Issues
The Update didnt got applied on the proxy. The Problem was the execution order of the push event.  The Proxy updated the user data before the update was finished processing. By using the returned CompletableFuture of the save method, this is fixed.
Tested it and it works now.

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#reviewers-checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
