### PR TITLE
fixed global-/point condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - LuckPerms integration not pushing the permission update to the connected servers correctly.
 - `crafting` objective where complex recipes are not recognized
 - `hieght` condition where variable locations threw an exception
+- `globalpoint` condition where not initialized global points where 0
+- `point` condition where not initialized global points where 0
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `crafting` objective where complex recipes are not recognized
 - `hieght` condition where variable locations threw an exception
 - `globalpoint` condition where not initialized global points where 0
-- `point` condition where not initialized global points where 0
+- `point` condition where not initialized points where 0
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/src/main/java/org/betonquest/betonquest/quest/condition/point/GlobalPointCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/point/GlobalPointCondition.java
@@ -1,11 +1,14 @@
 package org.betonquest.betonquest.quest.condition.point;
 
+import org.betonquest.betonquest.Point;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.nullable.NullableCondition;
 import org.betonquest.betonquest.database.GlobalData;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * A condition that checks if global data has a certain amount of points.
@@ -49,8 +52,17 @@ public class GlobalPointCondition implements NullableCondition {
 
     @Override
     public boolean check(@Nullable final Profile profile) throws QuestRuntimeException {
-        final int points = globalData.hasPointsFromCategory(category);
-        final int pCount = count.getValue(profile).intValue();
+        final List<Point> points = globalData.getPoints();
+        for (final Point point : points) {
+            if (point.getCategory().equals(category)) {
+                return checkPoints(point.getCount(), profile);
+            }
+        }
+        return false;
+    }
+
+    private boolean checkPoints(final int points, @Nullable final Profile profile) throws QuestRuntimeException {
+        final int pCount = this.count.getValue(profile).intValue();
         return equal ? points == pCount : points >= pCount;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/condition/point/PointCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/point/PointCondition.java
@@ -1,10 +1,13 @@
 package org.betonquest.betonquest.quest.condition.point;
 
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.Point;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
+
+import java.util.List;
 
 /**
  * A condition that checks if a player has a certain amount of points.
@@ -48,8 +51,17 @@ public class PointCondition implements PlayerCondition {
 
     @Override
     public boolean check(final Profile profile) throws QuestRuntimeException {
-        final int points = betonQuest.getPlayerData(profile).hasPointsFromCategory(category);
-        final int pCount = count.getValue(profile).intValue();
+        final List<Point> points = betonQuest.getPlayerData(profile).getPoints();
+        for (final Point point : points) {
+            if (point.getCategory().equals(category)) {
+                return checkPoints(point.getCount(), profile);
+            }
+        }
+        return false;
+    }
+
+    private boolean checkPoints(final int points, final Profile profile) throws QuestRuntimeException {
+        final int pCount = this.count.getValue(profile).intValue();
         return equal ? points == pCount : points >= pCount;
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Fixed an issue, where not initiated points were 0 and not null, so the conditions retuned true on check for 0

---

### Related Issues

<!-- Issue number if existing. -->
Closes #3016 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
