### PR TITLE
`variable` condition can now be used in a static context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `enitity` condition now supports variables for the entity name
 - `mmochangeclass` objective for MMOCore that listens for a player changing their class
 - `removeentity` event now supports variables for the entity name
+- `variable` condition can now be used in a static context
 ### Changed
 - `spawn` event now only spawn mobs and no other entities
 - ProSkillAPI rename to Fabled

--- a/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Conditions-List.md
@@ -529,6 +529,8 @@ exactAtTwelveAtPlayersHome: "time 12-12 world:%ph.player_home_world%"
 
 ## Variable: `variable`
 
+**static**
+
 This condition checks if a variable value matches given [regular expression](../Data-Formats.md#regex-regular-expressions)
 
 | Parameter   | Syntax          | Default Value          | Explanation                                                                                                                                |

--- a/src/main/java/org/betonquest/betonquest/quest/condition/variable/VariableCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/variable/VariableCondition.java
@@ -2,16 +2,17 @@ package org.betonquest.betonquest.quest.condition.variable;
 
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.Profile;
-import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.nullable.NullableCondition;
 import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.betonquest.betonquest.instruction.variable.VariableString;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.regex.PatternSyntaxException;
 
 /**
  * Checks if the variable value matches given pattern.
  */
-public class VariableCondition implements PlayerCondition {
+public class VariableCondition implements NullableCondition {
 
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
@@ -49,7 +50,7 @@ public class VariableCondition implements PlayerCondition {
     }
 
     @Override
-    public boolean check(final Profile profile) throws QuestRuntimeException {
+    public boolean check(@Nullable final Profile profile) throws QuestRuntimeException {
         final String resolvedVariable = variable.getValue(profile);
         final String resolvedRegex = regex.getValue(profile);
         try {

--- a/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
@@ -277,7 +277,7 @@ public class CoreQuestTypes {
         conditionTypes.register("tag", new TagConditionFactory(betonQuest));
         conditionTypes.registerCombined("testforblock", new BlockConditionFactory(data));
         conditionTypes.registerCombined("time", new TimeConditionFactory(data, variableProcessor));
-        conditionTypes.register("variable", new VariableConditionFactory(loggerFactory, data, variableProcessor));
+        conditionTypes.registerCombined("variable", new VariableConditionFactory(loggerFactory, data, variableProcessor));
         conditionTypes.registerCombined("weather", new WeatherConditionFactory(data, variableProcessor));
         conditionTypes.register("world", new WorldConditionFactory(loggerFactory, data, variableProcessor));
     }


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
