### PR TITLE
fix cron tests on windows

### DIFF
--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
@@ -117,7 +117,7 @@ class RealtimeCronSchedulerTest {
     @Test
     void testStartWithMissedSchedulesStrategyAll() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
-        final Instant lastExecution = Instant.now().minusSeconds(60);
+        final Instant lastExecution = Instant.now().minusSeconds(61);
         when(cache.getLastExecutionTime(SCHEDULE_ID)).thenReturn(Optional.of(lastExecution));
 
         final RealtimeCronScheduler scheduler = new RealtimeCronScheduler(logger, cache);


### PR DESCRIPTION
The error is that Windows just uses 7 decimal places instead of the full (at least 9) decimal places, so we adjust the test case to have a clearly expected result from the test: when it is at the same time, catch up (except for Windows, obviously)

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
