### PR TITLE
fixed Schedules could run twice on some systems by an inaccurate time returned java's Instant.now()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `globalpoint` condition where not initialized global points where 0
 - `point` condition where not initialized points where 0
 - `QuestItem` Potions cannot be saved in 1.20.5+
+- Schedules could run twice on some systems by an inaccurate time returned java's Instant.now()
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -157,7 +157,7 @@ public class BetonQuest extends JavaPlugin {
 
     private static final Map<String, Class<? extends NotifyIO>> NOTIFY_IO_TYPES = new HashMap<>();
 
-    private static final Map<String, EventScheduling.ScheduleType<?>> SCHEDULE_TYPES = new HashMap<>();
+    private static final Map<String, EventScheduling.ScheduleType<?, ?>> SCHEDULE_TYPES = new HashMap<>();
 
     /**
      * The indicator for dev versions.
@@ -970,7 +970,7 @@ public class BetonQuest extends JavaPlugin {
      * @param scheduler instance of the scheduler
      * @param <S>       type of schedule
      */
-    public <S extends Schedule> void registerScheduleType(final String name, final Class<S> schedule, final Scheduler<S> scheduler) {
+    public <S extends Schedule> void registerScheduleType(final String name, final Class<S> schedule, final Scheduler<S, ?> scheduler) {
         SCHEDULE_TYPES.put(name, new EventScheduling.ScheduleType<>(schedule, scheduler));
     }
 

--- a/src/main/java/org/betonquest/betonquest/api/schedule/CronSchedule.java
+++ b/src/main/java/org/betonquest/betonquest/api/schedule/CronSchedule.java
@@ -10,10 +10,6 @@ import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.modules.schedule.ScheduleID;
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.util.Optional;
-
 /**
  * A schedule using <a href="https://crontab.guru/">cron syntax</a> for defining time instructions.
  */
@@ -121,23 +117,5 @@ public abstract class CronSchedule extends Schedule {
      */
     public ExecutionTime getExecutionTime() {
         return executionTime;
-    }
-
-    /**
-     * Utility method that simplifies getting the next execution time of this schedule as instant.
-     *
-     * @return Optional containing the next time of execution as instant. Empty if there is no next execution.
-     */
-    public Optional<Instant> getNextExecution() {
-        return executionTime.nextExecution(ZonedDateTime.now()).map(Instant::from);
-    }
-
-    /**
-     * Utility method that simplifies getting the last execution time of this schedule as instant.
-     *
-     * @return Optional containing the last time of execution as instant. Empty if there is no last execution time.
-     */
-    public Optional<Instant> getLastExecution() {
-        return executionTime.lastExecution(ZonedDateTime.now()).map(Instant::from);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/api/schedule/Scheduler.java
+++ b/src/main/java/org/betonquest/betonquest/api/schedule/Scheduler.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.modules.schedule.ScheduleID;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import java.util.Map;
  * <p>
  * When loading the configs,
  * new schedules are parsed and registered in the matching Scheduler by calling {@link #addSchedule(Schedule)}.
- * After everything is loaded {@link #start()} is called. It should start the scheduler.
+ * After everything is loaded {@link #start(Instant)} ()} is called. It should start the scheduler.
  * Once a time defined in the schedule is met,
  * the referenced events shall be executed using {@link #executeEvents(Schedule)}.
  * On shutdown or before reloading all data, {@link #stop()} is called to stop all schedules.
@@ -56,7 +57,7 @@ public abstract class Scheduler<S extends Schedule> {
 
     /**
      * Register a new schedule to the list of schedules managed by this scheduler.
-     * The schedule shall remain inactive till method {@link #start()} is called to activate all schedules.
+     * The schedule shall remain inactive till method {@link #start(Instant)} is called to activate all schedules.
      *
      * @param schedule schedule object to register
      */
@@ -76,8 +77,10 @@ public abstract class Scheduler<S extends Schedule> {
      * <p><b>
      * When overriding this method, make sure to call {@code super.start()} at some point to update the running flag.
      * </b></p>
+     *
+     * @param now the current time when the scheduler is started
      */
-    public void start() {
+    public void start(final Instant now) {
         running = true;
     }
 

--- a/src/main/java/org/betonquest/betonquest/api/schedule/Scheduler.java
+++ b/src/main/java/org/betonquest/betonquest/api/schedule/Scheduler.java
@@ -5,7 +5,6 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.modules.schedule.ScheduleID;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,7 +17,7 @@ import java.util.Map;
  * <p>
  * When loading the configs,
  * new schedules are parsed and registered in the matching Scheduler by calling {@link #addSchedule(Schedule)}.
- * After everything is loaded {@link #start(Instant)} ()} is called. It should start the scheduler.
+ * After everything is loaded {@link #start(Object)} is called. It should start the scheduler.
  * Once a time defined in the schedule is met,
  * the referenced events shall be executed using {@link #executeEvents(Schedule)}.
  * On shutdown or before reloading all data, {@link #stop()} is called to stop all schedules.
@@ -26,9 +25,10 @@ import java.util.Map;
  * </p>
  *
  * @param <S> Type of Schedule
+ * @param <T> Type of time used by the scheduler
  */
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
-public abstract class Scheduler<S extends Schedule> {
+public abstract class Scheduler<S extends Schedule, T> {
     /**
      * Map containing all schedules that belong to this scheduler.
      */
@@ -57,12 +57,20 @@ public abstract class Scheduler<S extends Schedule> {
 
     /**
      * Register a new schedule to the list of schedules managed by this scheduler.
-     * The schedule shall remain inactive till method {@link #start(Instant)} is called to activate all schedules.
+     * The schedule shall remain inactive till method {@link #start(Object)} is called to activate all schedules.
      *
      * @param schedule schedule object to register
      */
     public void addSchedule(final S schedule) {
         schedules.put(schedule.getId(), schedule);
+    }
+
+    /**
+     * Start all schedules that have been added to this scheduler, in the same way as {@link #start(Object)},
+     * but using the current time provided by {@link #getNow()} as the time.
+     */
+    public void start() {
+        start(getNow());
     }
 
     /**
@@ -80,9 +88,16 @@ public abstract class Scheduler<S extends Schedule> {
      *
      * @param now the current time when the scheduler is started
      */
-    public void start(final Instant now) {
+    public void start(final T now) {
         running = true;
     }
+
+    /**
+     * Method to get the current time of the type {@link T} used by the scheduler.
+     *
+     * @return the current time
+     */
+    protected abstract T getNow();
 
     /**
      * <p>

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/EventScheduling.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/EventScheduling.java
@@ -10,6 +10,7 @@ import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -85,13 +86,15 @@ public class EventScheduling {
 
     /**
      * Start all schedulers and activate all schedules.
+     *
+     * @param now the current time when the scheduler is started
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public void startAll() {
+    public void startAll(final Instant now) {
         log.debug("Starting schedulers...");
         for (final ScheduleType<?> type : scheduleTypes.values()) {
             try {
-                type.scheduler.start();
+                type.scheduler.start(now);
             } catch (final Exception e) {
                 log.error("Error while enabling " + type.scheduler + ": " + e.getMessage(), e);
             }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/EventScheduling.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/EventScheduling.java
@@ -10,7 +10,6 @@ import org.betonquest.betonquest.exceptions.ObjectNotFoundException;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,7 +26,7 @@ public class EventScheduling {
      * Map that contains all types of schedulers,
      * with keys being their names and values holding the scheduler and schedule class.
      */
-    private final Map<String, ScheduleType<?>> scheduleTypes;
+    private final Map<String, ScheduleType<?, ?>> scheduleTypes;
 
     /**
      * Creates a new instance of the event scheduling class.
@@ -35,7 +34,7 @@ public class EventScheduling {
      * @param log           the logger that will be used for logging
      * @param scheduleTypes map containing the schedule types, provided by {@link org.betonquest.betonquest.BetonQuest}
      */
-    public EventScheduling(final BetonQuestLogger log, final Map<String, ScheduleType<?>> scheduleTypes) {
+    public EventScheduling(final BetonQuestLogger log, final Map<String, ScheduleType<?, ?>> scheduleTypes) {
         this.log = log;
         this.scheduleTypes = scheduleTypes;
     }
@@ -67,7 +66,7 @@ public class EventScheduling {
                     );
                     final String type = Optional.ofNullable(scheduleConfig.getString("type"))
                             .orElseThrow(() -> new InstructionParseException("Missing type instruction"));
-                    final ScheduleType<?> scheduleType = Optional.ofNullable(scheduleTypes.get(type))
+                    final ScheduleType<?, ?> scheduleType = Optional.ofNullable(scheduleTypes.get(type))
                             .orElseThrow(() -> new InstructionParseException("The schedule type '" + type + "' is not defined"));
                     scheduleType.createAndScheduleNewInstance(scheduleID, scheduleConfig);
                     log.debug(questPackage, "Parsed schedule '" + scheduleID + "'.");
@@ -86,15 +85,13 @@ public class EventScheduling {
 
     /**
      * Start all schedulers and activate all schedules.
-     *
-     * @param now the current time when the scheduler is started
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public void startAll(final Instant now) {
+    public void startAll() {
         log.debug("Starting schedulers...");
-        for (final ScheduleType<?> type : scheduleTypes.values()) {
+        for (final ScheduleType<?, ?> type : scheduleTypes.values()) {
             try {
-                type.scheduler.start(now);
+                type.scheduler.start();
             } catch (final Exception e) {
                 log.error("Error while enabling " + type.scheduler + ": " + e.getMessage(), e);
             }
@@ -107,7 +104,7 @@ public class EventScheduling {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void stopAll() {
         log.debug("Stopping schedulers...");
-        for (final ScheduleType<?> type : scheduleTypes.values()) {
+        for (final ScheduleType<?, ?> type : scheduleTypes.values()) {
             try {
                 type.scheduler.stop();
             } catch (final Exception e) {
@@ -124,7 +121,7 @@ public class EventScheduling {
      * @param <S>           type of the schedule.
      */
     @SuppressWarnings("PMD.PreserveStackTrace")
-    public record ScheduleType<S extends Schedule>(Class<S> scheduleClass, Scheduler<S> scheduler) {
+    public record ScheduleType<S extends Schedule, T>(Class<S> scheduleClass, Scheduler<S, T> scheduler) {
         /* default */ S newScheduleInstance(final ScheduleID scheduleID, final ConfigurationSection scheduleConfig)
                 throws InstructionParseException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
             try {

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/LastExecutionCache.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/LastExecutionCache.java
@@ -67,11 +67,11 @@ public class LastExecutionCache {
      * Save the last execution time of a schedule to the cache in ISO-8601 format
      * (see {@link DateTimeFormatter#ISO_INSTANT}).
      *
+     * @param now      The Instance of now
      * @param schedule id of the schedule
-     * @param time     time to cache as instant
      */
-    public void cacheExecutionTime(final ScheduleID schedule, final Instant time) {
-        cacheRawExecutionTime(schedule, time.toString());
+    public void cacheExecutionTime(final Instant now, final ScheduleID schedule) {
+        cacheRawExecutionTime(schedule, now.toString());
     }
 
     /**
@@ -109,15 +109,14 @@ public class LastExecutionCache {
      * For all schedules that are not in the cache, cache the current time as last execution time.
      * This allows to find missed schedules during shutdown.
      *
+     * @param now       The Instant of now
      * @param schedules ids of the schedules to cache
      */
-    public void cacheStartupTime(final Collection<ScheduleID> schedules) {
-        final Instant startupTime = Instant.now();
+    public void cacheStartupTime(final Instant now, final Collection<ScheduleID> schedules) {
         for (final ScheduleID schedule : schedules) {
             if (!isCached(schedule)) {
-                cacheExecutionTime(schedule, startupTime);
+                cacheExecutionTime(now, schedule);
             }
         }
     }
-
 }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/ExecutorServiceScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/ExecutorServiceScheduler.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.modules.schedule.impl.realtime.daily.RealtimeDailyScheduler;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import java.time.Instant;
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -23,7 +22,7 @@ import java.util.function.Supplier;
  * @param <S> Type of Schedule
  */
 @SuppressWarnings("PMD.DoNotUseThreads")
-public abstract class ExecutorServiceScheduler<S extends Schedule> extends Scheduler<S> {
+public abstract class ExecutorServiceScheduler<S extends Schedule, T> extends Scheduler<S, T> {
     /**
      * Maximum time that the scheduler will wait on shutdown/reload for currently executing schedules.
      */
@@ -83,7 +82,7 @@ public abstract class ExecutorServiceScheduler<S extends Schedule> extends Sched
      * @param now the current time when the scheduler is started
      */
     @Override
-    public void start(final Instant now) {
+    public void start(final T now) {
         super.start(now);
         executor = executorServiceSupplier.get();
         schedules.values().forEach((schedule) -> schedule(now, schedule));
@@ -99,10 +98,10 @@ public abstract class ExecutorServiceScheduler<S extends Schedule> extends Sched
      * schedules.
      * </b></p>
      *
-     * @param now      The Instance of now
+     * @param now      The {@link T} of now
      * @param schedule a schedule from {@link #schedules} map
      */
-    protected abstract void schedule(Instant now, S schedule);
+    protected abstract void schedule(T now, S schedule);
 
     /**
      * <p>

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/ExecutorServiceScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/ExecutorServiceScheduler.java
@@ -7,6 +7,7 @@ import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.modules.schedule.impl.realtime.daily.RealtimeDailyScheduler;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import java.time.Instant;
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -78,12 +79,14 @@ public abstract class ExecutorServiceScheduler<S extends Schedule> extends Sched
      * <p><b>
      * Make sure to call {@code super.start()}, otherwise the executor will not be instantiated.
      * </b></p>
+     *
+     * @param now the current time when the scheduler is started
      */
     @Override
-    public void start() {
-        super.start();
+    public void start(final Instant now) {
+        super.start(now);
         executor = executorServiceSupplier.get();
-        schedules.values().forEach(this::schedule);
+        schedules.values().forEach((schedule) -> schedule(now, schedule));
     }
 
     /**
@@ -96,9 +99,10 @@ public abstract class ExecutorServiceScheduler<S extends Schedule> extends Sched
      * schedules.
      * </b></p>
      *
+     * @param now      The Instance of now
      * @param schedule a schedule from {@link #schedules} map
      */
-    protected abstract void schedule(S schedule);
+    protected abstract void schedule(Instant now, S schedule);
 
     /**
      * <p>

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronScheduler.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
  * The scheduler for {@link RealtimeCronSchedule}.
  */
 @SuppressWarnings("PMD.DoNotUseThreads")
-public class RealtimeCronScheduler extends ExecutorServiceScheduler<RealtimeCronSchedule> {
+public class RealtimeCronScheduler extends ExecutorServiceScheduler<RealtimeCronSchedule, Instant> {
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
      */
@@ -75,6 +75,11 @@ public class RealtimeCronScheduler extends ExecutorServiceScheduler<RealtimeCron
         catchupMissedSchedules(now);
         super.start(now);
         log.debug("Realtime scheduler start complete.");
+    }
+
+    @Override
+    protected Instant getNow() {
+        return Instant.now();
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedule.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailySchedule.java
@@ -62,20 +62,10 @@ public class RealtimeDailySchedule extends Schedule {
      */
     public Instant getNextExecution(final Instant startTime) {
         final OffsetDateTime now = OffsetDateTime.ofInstant(startTime, ZoneId.systemDefault());
-        OffsetDateTime targetTime = getTimeToRun().atOffset(now.getOffset()).atDate(now.toLocalDate());
+        OffsetDateTime targetTime = OffsetDateTime.of(now.toLocalDate(), getTimeToRun(), now.getOffset());
         if (targetTime.isBefore(now)) {
             targetTime = targetTime.plusDays(1);
         }
         return targetTime.toInstant();
-    }
-
-    /**
-     * Get the next execution time as instant.
-     * This method uses {@link Instant#now()} as the start time.
-     *
-     * @return instant when the next run of this schedule will be
-     */
-    public Instant getNextExecution() {
-        return getNextExecution(Instant.now());
     }
 }

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
@@ -58,26 +58,28 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
     }
 
     @Override
-    public void start() {
-        lastExecutionCache.cacheStartupTime(schedules.keySet());
+    public void start(final Instant now) {
+        lastExecutionCache.cacheStartupTime(now, schedules.keySet());
         log.debug("Starting simple scheduler.");
-        catchupMissedSchedules();
-        super.start();
+        catchupMissedSchedules(now);
+        super.start(now);
         log.debug("Simple scheduler start complete.");
     }
 
     /**
      * Search for missed schedule runs during shutdown and rerun them if the catchup strategy says so.
      * The method should guarantee that the schedules are executed in the order they would have occurred.
+     *
+     * @param now The Instant of now
      */
-    private void catchupMissedSchedules() {
+    private void catchupMissedSchedules(final Instant now) {
         log.debug("Collecting missed schedules...");
-        final List<RealtimeDailySchedule> missedSchedules = listMissedSchedules();
+        final List<RealtimeDailySchedule> missedSchedules = listMissedSchedules(now);
         log.debug("Found " + missedSchedules.size() + " missed schedule runs that will be caught up.");
         if (!missedSchedules.isEmpty()) {
             log.debug("Running missed schedules to catch up...");
             for (final RealtimeDailySchedule schedule : missedSchedules) {
-                lastExecutionCache.cacheExecutionTime(schedule.getId(), Instant.now());
+                lastExecutionCache.cacheExecutionTime(now, schedule.getId());
                 executeEvents(schedule);
             }
         }
@@ -91,7 +93,7 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
      * {@link CatchupStrategy#ALL} are there as often as they have been missed.
      * </p>
      * <p>
-     * Uses the Queue returned by {@link #oldestMissedRuns()} to order missed runs.
+     * Uses the Queue returned by {@link #oldestMissedRuns(Instant)} to order missed runs.
      * Each runs schedule will be added to the missed schedules list.
      * </p>
      * <p>
@@ -103,11 +105,12 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
      * added.
      * </p>
      *
+     * @param now The Instant of now
      * @return list of schedules that should be run to catch up any missed schedules
      */
-    private List<RealtimeDailySchedule> listMissedSchedules() {
+    private List<RealtimeDailySchedule> listMissedSchedules(final Instant now) {
         final List<RealtimeDailySchedule> missed = new ArrayList<>();
-        final Queue<MissedRun> missedRuns = oldestMissedRuns();
+        final Queue<MissedRun> missedRuns = oldestMissedRuns(now);
 
         while (!missedRuns.isEmpty()) {
             final MissedRun earliest = missedRuns.poll();
@@ -116,7 +119,7 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
                     "Schedule '" + earliest.schedule.getId() + "' run missed at " + earliest.runTime);
             if (earliest.schedule.getCatchup() == CatchupStrategy.ALL) {
                 final Instant nextExecution = earliest.runTime.plus(1, ChronoUnit.DAYS);
-                if (nextExecution.isBefore(Instant.now())) {
+                if (nextExecution.isBefore(now)) {
                     missedRuns.add(new MissedRun(earliest.schedule, nextExecution));
                 }
             }
@@ -128,15 +131,16 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
      * This method returns the first missed run of each schedule (if a run was missed).
      * The returned queue is ordered by the time when the schedule should have run, in ascending order.
      *
+     * @param now The Instant of now
      * @return queue of missed runs, sorted from old to now
      */
-    private Queue<MissedRun> oldestMissedRuns() {
+    private Queue<MissedRun> oldestMissedRuns(final Instant now) {
         final Queue<MissedRun> missedRuns = new PriorityQueue<>(schedules.size() + 1, Comparator.comparing(MissedRun::runTime));
         for (final RealtimeDailySchedule schedule : schedules.values()) {
             if (schedule.getCatchup() != CatchupStrategy.NONE) {
                 final Optional<Instant> lastExecutionTime = lastExecutionCache.getLastExecutionTime(schedule.getId());
                 final Optional<Instant> nextExecution = lastExecutionTime.map(schedule::getNextExecution);
-                if (nextExecution.isPresent() && nextExecution.get().isBefore(Instant.now())) {
+                if (nextExecution.isPresent() && nextExecution.get().isBefore(now)) {
                     missedRuns.add(new MissedRun(schedule, nextExecution.get()));
                 }
             }
@@ -145,12 +149,13 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
     }
 
     @Override
-    protected void schedule(final RealtimeDailySchedule schedule) {
+    protected void schedule(final Instant now, final RealtimeDailySchedule schedule) {
+        final Instant nextExecution = schedule.getNextExecution(now);
         executor.schedule(() -> {
-            lastExecutionCache.cacheExecutionTime(schedule.getId(), Instant.now());
+            lastExecutionCache.cacheExecutionTime(nextExecution, schedule.getId());
             executeEvents(schedule);
-            schedule(schedule);
-        }, Instant.now().until(schedule.getNextExecution(), ChronoUnit.MILLIS), TimeUnit.MILLISECONDS);
+            schedule(nextExecution, schedule);
+        }, ChronoUnit.MILLIS.between(now, nextExecution), TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
+++ b/src/main/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduler.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  * The scheduler for {@link RealtimeDailySchedule}.
  */
 @SuppressWarnings("PMD.DoNotUseThreads")
-public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDailySchedule> {
+public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDailySchedule, Instant> {
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
      */
@@ -64,6 +64,11 @@ public class RealtimeDailyScheduler extends ExecutorServiceScheduler<RealtimeDai
         catchupMissedSchedules(now);
         super.start(now);
         log.debug("Simple scheduler start complete.");
+    }
+
+    @Override
+    protected Instant getNow() {
+        return Instant.now();
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
@@ -15,7 +15,6 @@ import org.betonquest.betonquest.quest.registry.processor.EventProcessor;
 import org.betonquest.betonquest.quest.registry.processor.ObjectiveProcessor;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 
@@ -75,7 +74,7 @@ public class QuestRegistry {
      * @param objectiveTypes      the available objective types
      */
     public QuestRegistry(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory, final BetonQuest plugin,
-                         final Map<String, EventScheduling.ScheduleType<?>> scheduleTypes,
+                         final Map<String, EventScheduling.ScheduleType<?, ?>> scheduleTypes,
                          final QuestTypeRegistries questTypeRegistries,
                          final Map<String, Class<? extends Objective>> objectiveTypes) {
         this.log = log;
@@ -123,7 +122,7 @@ public class QuestRegistry {
                 + objectiveProcessor.size() + " objectives and " + conversationProcessor.size() + " conversations loaded from "
                 + packages.size() + " packages.");
 
-        eventScheduling.startAll(Instant.now());
+        eventScheduling.startAll();
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
@@ -15,6 +15,7 @@ import org.betonquest.betonquest.quest.registry.processor.EventProcessor;
 import org.betonquest.betonquest.quest.registry.processor.ObjectiveProcessor;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 
@@ -122,7 +123,7 @@ public class QuestRegistry {
                 + objectiveProcessor.size() + " objectives and " + conversationProcessor.size() + " conversations loaded from "
                 + packages.size() + " packages.");
 
-        eventScheduling.startAll();
+        eventScheduling.startAll(Instant.now());
     }
 
     /**

--- a/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
@@ -4,6 +4,7 @@ import com.cronutils.model.Cron;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.betonquest.betonquest.api.schedule.CronSchedule.REBOOT_CRON_DEFINITION;
@@ -32,7 +33,8 @@ public class CronRebootScheduleTest extends CronScheduleBaseTest {
         final Cron cron = schedule.getTimeCron();
         assertNotNull(cron, "time cron should not be null");
         assertDoesNotThrow(cron::validate, "Cron should be valid");
-        assertEquals(Optional.empty(), schedule.getNextExecution(), "Schedule should not provide a next execution time");
-        assertEquals(Optional.empty(), schedule.getLastExecution(), "Schedule should not provide a last execution time");
+        final ZonedDateTime now = ZonedDateTime.now();
+        assertEquals(Optional.empty(), schedule.getExecutionTime().nextExecution(now), "Schedule should not provide a next execution time");
+        assertEquals(Optional.empty(), schedule.getExecutionTime().lastExecution(now), "Schedule should not provide a last execution time");
     }
 }

--- a/src/test/java/org/betonquest/betonquest/api/schedule/CronScheduleBaseTest.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/CronScheduleBaseTest.java
@@ -5,6 +5,7 @@ import com.cronutils.model.Cron;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static com.cronutils.model.field.expression.FieldExpression.always;
@@ -46,8 +47,9 @@ public class CronScheduleBaseTest extends ScheduleBaseTest {
         assertTrue(expected.equivalent(cron), "Cron expression should be as expected");
         assertFalse(schedule.shouldRunOnReboot(), "Schedule should not run on reboot");
 
-        assertNotEquals(Optional.empty(), schedule.getNextExecution(), "Schedule should provide next execution time");
-        assertNotEquals(Optional.empty(), schedule.getLastExecution(), "Schedule should provide last execution time");
+        final ZonedDateTime now = ZonedDateTime.now();
+        assertNotEquals(Optional.empty(), schedule.getExecutionTime().nextExecution(now), "Schedule should provide next execution time");
+        assertNotEquals(Optional.empty(), schedule.getExecutionTime().lastExecution(now), "Schedule should provide last execution time");
     }
 
     @Test

--- a/src/test/java/org/betonquest/betonquest/api/schedule/FictiveTime.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/FictiveTime.java
@@ -1,0 +1,7 @@
+package org.betonquest.betonquest.api.schedule;
+
+/**
+ * Fictive time class used for testing.
+ */
+public record FictiveTime() {
+}

--- a/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,17 +20,12 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 class SchedulerTest {
-    /**
-     * The current time used in the tests.
-     */
-    private final Instant now = Instant.now();
-
     @Mock
     private BetonQuestLogger logger;
 
     @Test
     void testAddSchedule() {
-        final Scheduler<Schedule> scheduler = new MockedScheduler(logger);
+        final Scheduler<Schedule, FictiveTime> scheduler = new MockedScheduler(logger);
         final ScheduleID scheduleID = mock(ScheduleID.class);
         final Schedule schedule = mock(Schedule.class);
         when(schedule.getId()).thenReturn(scheduleID);
@@ -42,20 +36,20 @@ class SchedulerTest {
 
     @Test
     void testStart() {
-        final Scheduler<Schedule> scheduler = new MockedScheduler(logger);
+        final Scheduler<Schedule, FictiveTime> scheduler = new MockedScheduler(logger);
         assertFalse(scheduler.isRunning(), "isRunning should be false before start is called");
-        scheduler.start(now);
+        scheduler.start();
         assertTrue(scheduler.isRunning(), "isRunning should be true after start is called");
     }
 
     @Test
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     void testStop() {
-        final Scheduler<Schedule> scheduler = new MockedScheduler(logger);
+        final Scheduler<Schedule, FictiveTime> scheduler = new MockedScheduler(logger);
         final ScheduleID scheduleID = mock(ScheduleID.class);
         final Schedule schedule = mock(Schedule.class);
         scheduler.schedules.put(scheduleID, schedule);
-        scheduler.start(now);
+        scheduler.start();
         assertTrue(scheduler.isRunning(), "isRunning should be true after start is called");
         scheduler.stop();
         assertFalse(scheduler.isRunning(), "isRunning should be false before stop is called");
@@ -66,7 +60,7 @@ class SchedulerTest {
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void testExecuteEvents() {
         try (MockedStatic<BetonQuest> betonQuest = mockStatic(BetonQuest.class)) {
-            final Scheduler<Schedule> scheduler = new MockedScheduler(logger);
+            final Scheduler<Schedule, FictiveTime> scheduler = new MockedScheduler(logger);
             final Schedule schedule = mock(Schedule.class);
             when(schedule.getId()).thenReturn(mock(ScheduleID.class));
             final EventID eventA = mock(EventID.class);
@@ -81,7 +75,7 @@ class SchedulerTest {
     /**
      * Class extending a scheduler without any changes.
      */
-    private static final class MockedScheduler extends Scheduler<Schedule> {
+    private static final class MockedScheduler extends Scheduler<Schedule, FictiveTime> {
         /**
          * Default constructor.
          *
@@ -89,6 +83,11 @@ class SchedulerTest {
          */
         public MockedScheduler(final BetonQuestLogger logger) {
             super(logger);
+        }
+
+        @Override
+        protected FictiveTime getNow() {
+            return new FictiveTime();
         }
     }
 }

--- a/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -20,6 +21,11 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 class SchedulerTest {
+    /**
+     * The current time used in the tests.
+     */
+    private final Instant now = Instant.now();
+
     @Mock
     private BetonQuestLogger logger;
 
@@ -38,7 +44,7 @@ class SchedulerTest {
     void testStart() {
         final Scheduler<Schedule> scheduler = new MockedScheduler(logger);
         assertFalse(scheduler.isRunning(), "isRunning should be false before start is called");
-        scheduler.start();
+        scheduler.start(now);
         assertTrue(scheduler.isRunning(), "isRunning should be true after start is called");
     }
 
@@ -49,7 +55,7 @@ class SchedulerTest {
         final ScheduleID scheduleID = mock(ScheduleID.class);
         final Schedule schedule = mock(Schedule.class);
         scheduler.schedules.put(scheduleID, schedule);
-        scheduler.start();
+        scheduler.start(now);
         assertTrue(scheduler.isRunning(), "isRunning should be true after start is called");
         scheduler.stop();
         assertFalse(scheduler.isRunning(), "isRunning should be false before stop is called");

--- a/src/test/java/org/betonquest/betonquest/modules/logger/handler/history/BukkitSchedulerCleaningLogQueueTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/logger/handler/history/BukkitSchedulerCleaningLogQueueTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class BukkitSchedulerCleaningLogQueueTest {
     /**
-     * Fixed instant representing now.
+     * The current time used in the tests.
      */
     private final Instant now = Instant.now();
 

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/EventSchedulingTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/EventSchedulingTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,11 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 class EventSchedulingTest {
+    /**
+     * The current time used in the tests.
+     */
+    private final Instant now = Instant.now();
+
     /**
      * Event Scheduling instance.
      */
@@ -79,23 +85,23 @@ class EventSchedulingTest {
     void testStartAll() {
         final Scheduler<?> schedulerA = registerMockedType("typeA");
         final Scheduler<?> schedulerB = registerMockedType("typeB");
-        scheduling.startAll();
-        verify(schedulerA).start();
-        verify(schedulerB).start();
+        scheduling.startAll(now);
+        verify(schedulerA).start(now);
+        verify(schedulerB).start(now);
     }
 
     @Test
     void testStartWithError() {
         final Scheduler<?> throwingScheduler = registerMockedType("throwing");
-        doThrow(RuntimeException.class).when(throwingScheduler).start();
+        doThrow(RuntimeException.class).when(throwingScheduler).start(now);
         final List<? extends Scheduler<?>> schedulers = IntStream.range(0, 10)
                 .mapToObj(i -> "type" + (char) (i + 'A'))
                 .map(this::registerMockedType)
                 .toList();
-        scheduling.startAll();
-        verify(throwingScheduler).start();
+        scheduling.startAll(now);
+        verify(throwingScheduler).start(now);
         for (final Scheduler<?> scheduler : schedulers) {
-            verify(scheduler).start();
+            verify(scheduler).start(now);
         }
     }
 
@@ -192,7 +198,6 @@ class EventSchedulingTest {
         scheduling.loadData(pack);
         verify(simpleType, times(0)).createAndScheduleNewInstance(any(), any());
         verify(cronType).createAndScheduleNewInstance(argThat(id -> "testRealtime".equals(id.getBaseID())), any());
-
     }
 
     /**

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/EventSchedulingTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/EventSchedulingTest.java
@@ -6,6 +6,7 @@ import org.betonquest.betonquest.api.bukkit.config.custom.multi.MultiConfigurati
 import org.betonquest.betonquest.api.bukkit.config.custom.multi.MultiSectionConfiguration;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.schedule.FictiveTime;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -19,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -35,11 +35,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class EventSchedulingTest {
     /**
-     * The current time used in the tests.
-     */
-    private final Instant now = Instant.now();
-
-    /**
      * Event Scheduling instance.
      */
     private EventScheduling scheduling;
@@ -47,7 +42,7 @@ class EventSchedulingTest {
     /**
      * Map holding all schedule types for {@link #scheduling}.
      */
-    private Map<String, ScheduleType<?>> scheduleTypes;
+    private Map<String, ScheduleType<?, ?>> scheduleTypes;
 
     @BeforeEach
     void setUp() {
@@ -56,15 +51,15 @@ class EventSchedulingTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Scheduler<?> registerMockedType(final String name) {
-        final Scheduler<MockedSchedule> mockedScheduler = mock(Scheduler.class);
+    private Scheduler<?, FictiveTime> registerMockedType(final String name) {
+        final Scheduler<MockedSchedule, FictiveTime> mockedScheduler = mock(Scheduler.class);
         scheduleTypes.put(name, new ScheduleType<>(MockedSchedule.class, mockedScheduler));
         return mockedScheduler;
     }
 
     @SuppressWarnings("unchecked")
-    private ScheduleType<?> registerSpyType(final String name) {
-        final ScheduleType<Schedule> spyType = spy(new ScheduleType<Schedule>(Schedule.class, mock(Scheduler.class)));
+    private ScheduleType<?, FictiveTime> registerSpyType(final String name) {
+        final ScheduleType<Schedule, FictiveTime> spyType = spy(new ScheduleType<Schedule, FictiveTime>(Schedule.class, mock(Scheduler.class)));
         scheduleTypes.put(name, spyType);
         return spyType;
     }
@@ -83,32 +78,32 @@ class EventSchedulingTest {
 
     @Test
     void testStartAll() {
-        final Scheduler<?> schedulerA = registerMockedType("typeA");
-        final Scheduler<?> schedulerB = registerMockedType("typeB");
-        scheduling.startAll(now);
-        verify(schedulerA).start(now);
-        verify(schedulerB).start(now);
+        final Scheduler<?, FictiveTime> schedulerA = registerMockedType("typeA");
+        final Scheduler<?, FictiveTime> schedulerB = registerMockedType("typeB");
+        scheduling.startAll();
+        verify(schedulerA).start();
+        verify(schedulerB).start();
     }
 
     @Test
     void testStartWithError() {
-        final Scheduler<?> throwingScheduler = registerMockedType("throwing");
-        doThrow(RuntimeException.class).when(throwingScheduler).start(now);
-        final List<? extends Scheduler<?>> schedulers = IntStream.range(0, 10)
+        final Scheduler<?, FictiveTime> throwingScheduler = registerMockedType("throwing");
+        doThrow(RuntimeException.class).when(throwingScheduler).start();
+        final List<? extends Scheduler<?, FictiveTime>> schedulers = IntStream.range(0, 10)
                 .mapToObj(i -> "type" + (char) (i + 'A'))
                 .map(this::registerMockedType)
                 .toList();
-        scheduling.startAll(now);
-        verify(throwingScheduler).start(now);
-        for (final Scheduler<?> scheduler : schedulers) {
-            verify(scheduler).start(now);
+        scheduling.startAll();
+        verify(throwingScheduler).start();
+        for (final Scheduler<?, FictiveTime> scheduler : schedulers) {
+            verify(scheduler).start();
         }
     }
 
     @Test
     void testStopAll() {
-        final Scheduler<?> schedulerA = registerMockedType("typeA");
-        final Scheduler<?> schedulerB = registerMockedType("typeB");
+        final Scheduler<?, FictiveTime> schedulerA = registerMockedType("typeA");
+        final Scheduler<?, FictiveTime> schedulerB = registerMockedType("typeB");
         scheduling.stopAll();
         verify(schedulerA).stop();
         verify(schedulerB).stop();
@@ -116,15 +111,15 @@ class EventSchedulingTest {
 
     @Test
     void testStopWithError() {
-        final Scheduler<?> throwingScheduler = registerMockedType("throwing");
+        final Scheduler<?, FictiveTime> throwingScheduler = registerMockedType("throwing");
         doThrow(RuntimeException.class).when(throwingScheduler).stop();
-        final List<? extends Scheduler<?>> schedulers = IntStream.range(0, 10)
+        final List<? extends Scheduler<?, FictiveTime>> schedulers = IntStream.range(0, 10)
                 .mapToObj(i -> "type" + (char) (i + 'A'))
                 .map(this::registerMockedType)
                 .toList();
         scheduling.stopAll();
         verify(throwingScheduler).stop();
-        for (final Scheduler<?> scheduler : schedulers) {
+        for (final Scheduler<?, FictiveTime> scheduler : schedulers) {
             verify(scheduler).stop();
         }
     }
@@ -132,9 +127,9 @@ class EventSchedulingTest {
     @Test
     void testLoad() throws KeyConflictException, InvalidSubConfigurationException, InstructionParseException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
         doNothing().when(simpleType).createAndScheduleNewInstance(any(), any());
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         doNothing().when(cronType).createAndScheduleNewInstance(any(), any());
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageExample.yml");
         scheduling.loadData(pack);
@@ -145,8 +140,8 @@ class EventSchedulingTest {
     @Test
     void testLoadParseException() throws KeyConflictException, InvalidSubConfigurationException, InstructionParseException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageExample.yml");
         doThrow(new InstructionParseException("error parsing schedule")).when(simpleType).createAndScheduleNewInstance(any(), any());
         scheduling.loadData(pack);
@@ -157,8 +152,8 @@ class EventSchedulingTest {
     @Test
     void testLoadUncheckedException() throws KeyConflictException, InvalidSubConfigurationException, InstructionParseException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageExample.yml");
         doThrow(new InvocationTargetException(new IllegalArgumentException())).when(simpleType).createAndScheduleNewInstance(any(), any());
         scheduling.loadData(pack);
@@ -169,8 +164,8 @@ class EventSchedulingTest {
     @Test
     void testLoadCreationException() throws KeyConflictException, InvalidSubConfigurationException, InstructionParseException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageExample.yml");
         doThrow(new NoSuchMethodException()).when(simpleType).createAndScheduleNewInstance(any(), any());
         scheduling.loadData(pack);
@@ -181,8 +176,8 @@ class EventSchedulingTest {
     @Test
     void testLoadNoSchedules() throws KeyConflictException, InvalidSubConfigurationException, InstructionParseException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageNoSchedules.yml");
         scheduling.loadData(pack);
         verify(simpleType, times(0)).createAndScheduleNewInstance(any(), any());
@@ -192,8 +187,8 @@ class EventSchedulingTest {
     @Test
     void testLoadNameWithSpace() throws InstructionParseException, InvocationTargetException, NoSuchMethodException,
             InstantiationException, IllegalAccessException, KeyConflictException, InvalidSubConfigurationException {
-        final ScheduleType<?> simpleType = registerSpyType("realtime-daily");
-        final ScheduleType<?> cronType = registerSpyType("realtime-cron");
+        final ScheduleType<?, FictiveTime> simpleType = registerSpyType("realtime-daily");
+        final ScheduleType<?, FictiveTime> cronType = registerSpyType("realtime-cron");
         final QuestPackage pack = mockQuestPackage("src/test/resources/modules.schedule/packageNameWithSpace.yml");
         scheduling.loadData(pack);
         verify(simpleType, times(0)).createAndScheduleNewInstance(any(), any());

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/ScheduleTypeTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/ScheduleTypeTest.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.modules.schedule;
 
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.schedule.FictiveTime;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
@@ -57,43 +58,43 @@ class ScheduleTypeTest {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Schedule> Scheduler<T> mockScheduler() {
+    private <T extends Schedule> Scheduler<T, FictiveTime> mockScheduler() {
         return mock(Scheduler.class);
     }
 
     @Test
     void testCreate() {
-        final Scheduler<MockedSchedule> scheduler = mockScheduler();
-        final ScheduleType<MockedSchedule> type = new ScheduleType<>(MockedSchedule.class, scheduler);
+        final Scheduler<MockedSchedule, FictiveTime> scheduler = mockScheduler();
+        final ScheduleType<MockedSchedule, FictiveTime> type = new ScheduleType<>(MockedSchedule.class, scheduler);
         assertDoesNotThrow(() -> type.newScheduleInstance(scheduleID, section), "");
     }
 
     @Test
     void testCreateThrowingUnchecked() {
-        final Scheduler<ThrowingUncheckedSchedule> scheduler = mockScheduler();
-        final ScheduleType<ThrowingUncheckedSchedule> type = new ScheduleType<>(ThrowingUncheckedSchedule.class, scheduler);
+        final Scheduler<ThrowingUncheckedSchedule, FictiveTime> scheduler = mockScheduler();
+        final ScheduleType<ThrowingUncheckedSchedule, FictiveTime> type = new ScheduleType<>(ThrowingUncheckedSchedule.class, scheduler);
         assertThrows(InvocationTargetException.class, () -> type.newScheduleInstance(scheduleID, section), "");
     }
 
     @Test
     void testCreateInvalidConstructor() {
-        final Scheduler<InvalidConstructorSchedule> scheduler = mockScheduler();
-        final ScheduleType<InvalidConstructorSchedule> type = new ScheduleType<>(InvalidConstructorSchedule.class, scheduler);
+        final Scheduler<InvalidConstructorSchedule, FictiveTime> scheduler = mockScheduler();
+        final ScheduleType<InvalidConstructorSchedule, FictiveTime> type = new ScheduleType<>(InvalidConstructorSchedule.class, scheduler);
         assertThrows(NoSuchMethodException.class, () -> type.newScheduleInstance(scheduleID, section), "");
     }
 
     @Test
     void testCreateInvalidInstruction() {
         when(section.getString("time")).thenReturn(null);
-        final Scheduler<MockedSchedule> scheduler = mockScheduler();
-        final ScheduleType<MockedSchedule> type = new ScheduleType<>(MockedSchedule.class, scheduler);
+        final Scheduler<MockedSchedule, FictiveTime> scheduler = mockScheduler();
+        final ScheduleType<MockedSchedule, FictiveTime> type = new ScheduleType<>(MockedSchedule.class, scheduler);
         assertThrows(InstructionParseException.class, () -> type.newScheduleInstance(scheduleID, section), "");
     }
 
     @Test
     void testAddSchedule() {
-        final Scheduler<MockedSchedule> scheduler = mockScheduler();
-        final ScheduleType<MockedSchedule> type = new ScheduleType<>(MockedSchedule.class, scheduler);
+        final Scheduler<MockedSchedule, FictiveTime> scheduler = mockScheduler();
+        final ScheduleType<MockedSchedule, FictiveTime> type = new ScheduleType<>(MockedSchedule.class, scheduler);
         assertDoesNotThrow(() -> type.createAndScheduleNewInstance(scheduleID, section), "");
         verify(scheduler).addSchedule(any());
     }

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
@@ -122,7 +122,7 @@ class RealtimeCronSchedulerTest {
     @Test
     void testStartWithMissedSchedulesStrategyAll() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
-        final Instant lastExecution = now.minusSeconds(60);
+        final Instant lastExecution = now.minusSeconds(65);
         when(cache.getLastExecutionTime(SCHEDULE_ID)).thenReturn(Optional.of(lastExecution));
 
         final RealtimeCronScheduler scheduler = new RealtimeCronScheduler(logger, cache);

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/cron/RealtimeCronSchedulerTest.java
@@ -34,6 +34,11 @@ class RealtimeCronSchedulerTest {
         when(SCHEDULE_ID.toString()).thenReturn("test.schedule");
     }
 
+    /**
+     * The current time used in the tests.
+     */
+    private final Instant now = Instant.now();
+
     @Mock
     private BetonQuestLogger logger;
 
@@ -50,7 +55,7 @@ class RealtimeCronSchedulerTest {
     void testStartWithoutSchedules() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
         final RealtimeCronScheduler scheduler = spy(new RealtimeCronScheduler(logger, cache));
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");
@@ -58,7 +63,7 @@ class RealtimeCronSchedulerTest {
         verify(logger, times(1)).debug("Found 0 missed schedule runs that will be caught up.");
         verify(logger, times(1)).debug("Realtime scheduler start complete.");
         verifyNoMoreInteractions(logger);
-        verify(scheduler, never()).schedule(any());
+        verify(scheduler, never()).schedule(any(), any());
     }
 
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
@@ -73,7 +78,7 @@ class RealtimeCronSchedulerTest {
         when(schedule.getExecutionTime()).thenReturn(executionTime);
 
         scheduler.addSchedule(schedule);
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");
@@ -89,7 +94,7 @@ class RealtimeCronSchedulerTest {
     @Test
     void testStartWithMissedSchedulesStrategyOne() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
-        final Instant lastExecution = Instant.now().minusSeconds(60);
+        final Instant lastExecution = now.minusSeconds(60);
         when(cache.getLastExecutionTime(SCHEDULE_ID)).thenReturn(Optional.of(lastExecution));
 
         final RealtimeCronScheduler scheduler = new RealtimeCronScheduler(logger, cache);
@@ -99,7 +104,7 @@ class RealtimeCronSchedulerTest {
         when(executionTime.nextExecution(any())).thenReturn(Optional.of(nextMissedExecution));
         when(schedule.getExecutionTime()).thenReturn(executionTime);
         scheduler.addSchedule(schedule);
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");
@@ -117,7 +122,7 @@ class RealtimeCronSchedulerTest {
     @Test
     void testStartWithMissedSchedulesStrategyAll() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
-        final Instant lastExecution = Instant.now().minusSeconds(61);
+        final Instant lastExecution = now.minusSeconds(60);
         when(cache.getLastExecutionTime(SCHEDULE_ID)).thenReturn(Optional.of(lastExecution));
 
         final RealtimeCronScheduler scheduler = new RealtimeCronScheduler(logger, cache);
@@ -134,7 +139,7 @@ class RealtimeCronSchedulerTest {
                 Optional.of(nextMissedExecution4));
         when(schedule.getExecutionTime()).thenReturn(executionTime);
         scheduler.addSchedule(schedule);
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");
@@ -154,17 +159,17 @@ class RealtimeCronSchedulerTest {
     @Test
     void testStartWithoutMissedSchedulesStrategyAll() {
         final LastExecutionCache cache = mock(LastExecutionCache.class);
-        final Instant lastExecution = Instant.now().minusSeconds(40);
+        final Instant lastExecution = now.minusSeconds(40);
         when(cache.getLastExecutionTime(SCHEDULE_ID)).thenReturn(Optional.of(lastExecution));
 
         final RealtimeCronScheduler scheduler = new RealtimeCronScheduler(logger, cache);
         final RealtimeCronSchedule schedule = getSchedule(CatchupStrategy.ALL, false);
         final ExecutionTime executionTime = mock(ExecutionTime.class);
-        final ZonedDateTime nextExecution = Instant.now().plusSeconds(20).atZone(ZoneId.systemDefault());
+        final ZonedDateTime nextExecution = now.plusSeconds(20).atZone(ZoneId.systemDefault());
         when(executionTime.nextExecution(any())).thenReturn(Optional.of(nextExecution));
         when(schedule.getExecutionTime()).thenReturn(executionTime);
         scheduler.addSchedule(schedule);
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");
@@ -196,7 +201,7 @@ class RealtimeCronSchedulerTest {
                 Optional.empty());
         when(schedule.getExecutionTime()).thenReturn(executionTime);
         scheduler.addSchedule(schedule);
-        scheduler.start();
+        scheduler.start(now);
 
         verify(logger, times(1)).debug("Starting realtime scheduler.");
         verify(logger, times(1)).debug("Collecting reboot schedules...");

--- a/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduleTest.java
+++ b/src/test/java/org/betonquest/betonquest/modules/schedule/impl/realtime/daily/RealtimeDailyScheduleTest.java
@@ -60,8 +60,9 @@ class RealtimeDailyScheduleTest extends ScheduleBaseTest {
         when(section.getString("time")).thenReturn(targetTime.format(TIME_FORMAT));
         final RealtimeDailySchedule schedule = new RealtimeDailySchedule(scheduleID, section);
         assertEquals(targetTime.toLocalTime(), schedule.getTimeToRun(), "Returned time should be correct");
-        final Instant expected = targetTime.toInstant(OffsetDateTime.now().getOffset());
-        assertEquals(expected, schedule.getNextExecution(), "Next execution time should be as expected");
+        final OffsetDateTime now = OffsetDateTime.now();
+        final Instant expected = targetTime.toInstant(now.getOffset());
+        assertEquals(expected, schedule.getNextExecution(now.toInstant()), "Next execution time should be as expected");
     }
 
     @Test
@@ -70,7 +71,8 @@ class RealtimeDailyScheduleTest extends ScheduleBaseTest {
         when(section.getString("time")).thenReturn(targetTime.format(TIME_FORMAT));
         final RealtimeDailySchedule schedule = new RealtimeDailySchedule(scheduleID, section);
         assertEquals(targetTime.toLocalTime(), schedule.getTimeToRun(), "Returned time should be correct");
-        final Instant expected = targetTime.toInstant(OffsetDateTime.now().getOffset());
-        assertEquals(expected, schedule.getNextExecution(), "Next execution time should be as expected");
+        final OffsetDateTime now = OffsetDateTime.now();
+        final Instant expected = targetTime.toInstant(now.getOffset());
+        assertEquals(expected, schedule.getNextExecution(now.toInstant()), "Next execution time should be as expected");
     }
 }

--- a/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactoryIntegrationTest.java
+++ b/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactoryIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class JournalEventFactoryIntegrationTest {
     /**
-     * Fixed present time instant.
+     * The current time used in the tests.
      */
     private final Instant now = Instant.now();
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
