### PR TITLE
Fix Potion `QuestItems` couldn't be added in 1.20.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `hieght` condition where variable locations threw an exception
 - `globalpoint` condition where not initialized global points where 0
 - `point` condition where not initialized points where 0
+- `QuestItem` Potions cannot be saved in 1.20.5+
 ### Security
 
 ## [2.1.3] - 2024-08-06

--- a/src/main/java/org/betonquest/betonquest/item/QuestItem.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItem.java
@@ -82,7 +82,7 @@ public class QuestItem {
     private final FlagHandler flags = new FlagHandler();
 
     /**
-     * Creates new instance of the quest item using the ID
+     * Creates new instance of the quest item using the ID.
      *
      * @param itemID ID of the item
      * @throws InstructionParseException when item parsing goes wrong
@@ -171,7 +171,7 @@ public class QuestItem {
     }
 
     /**
-     * Converts ItemStack to string, which can be later parsed by QuestItem
+     * Converts ItemStack to string, which can be later parsed by QuestItem.
      *
      * @param item ItemStack to convert
      * @return converted string
@@ -242,18 +242,7 @@ public class QuestItem {
                 }
             }
             if (meta instanceof final PotionMeta potionMeta) {
-                final PotionData pData = potionMeta.getBasePotionData();
-                effects = " type:" + pData.getType() + (pData.isExtended() ? " extended" : "")
-                        + (pData.isUpgraded() ? " upgraded" : "");
-                if (potionMeta.hasCustomEffects()) {
-                    final StringBuilder string = new StringBuilder();
-                    for (final PotionEffect effect : potionMeta.getCustomEffects()) {
-                        final int power = effect.getAmplifier() + 1;
-                        final int duration = (effect.getDuration() - (effect.getDuration() % 20)) / 20;
-                        string.append(effect.getType().getName()).append(':').append(power).append(':').append(duration).append(',');
-                    }
-                    effects += " effects:" + string.substring(0, string.length() - 1);
-                }
+                effects = PotionHandler.metaToString(potionMeta);
             }
             if (meta instanceof final LeatherArmorMeta armorMeta
                     && !armorMeta.getColor().equals(Bukkit.getServer().getItemFactory().getDefaultLeatherColor())) {
@@ -413,13 +402,8 @@ public class QuestItem {
                 return false;
             }
         }
-        if (meta instanceof final PotionMeta potionMeta) {
-            if (!potion.checkBase(potionMeta.getBasePotionData())) {
-                return false;
-            }
-            if (!potion.checkCustom(potionMeta.getCustomEffects())) {
-                return false;
-            }
+        if (meta instanceof final PotionMeta potionMeta && !potion.checkMeta(potionMeta)) {
+            return false;
         }
         if (meta instanceof final BookMeta bookMeta) {
             if (!book.checkTitle(bookMeta.getTitle())) {

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/PotionHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/PotionHandler.java
@@ -1,10 +1,12 @@
 package org.betonquest.betonquest.item.typehandler;
 
+import io.papermc.lib.PaperLib;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.item.QuestItem;
 import org.betonquest.betonquest.item.QuestItem.Existence;
 import org.betonquest.betonquest.item.QuestItem.Number;
 import org.betonquest.betonquest.utils.Utils;
+import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -17,7 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-@SuppressWarnings("PMD.CommentRequired")
+@SuppressWarnings({"PMD.CommentRequired", "PMD.TooManyMethods"})
 public class PotionHandler {
     private PotionType type = PotionType.WATER;
 
@@ -38,6 +40,60 @@ public class PotionHandler {
     private boolean exact = true;
 
     public PotionHandler() {
+    }
+
+    /**
+     * Converts the Meta into the string equivalent used by Quest Items.
+     *
+     * @param potionMeta the meta to parse into string
+     * @return the representing string or an empty string, when no representative data is present
+     */
+    public static String metaToString(final PotionMeta potionMeta) {
+        // TODO version switch:
+        //  Remove this code when only 1.20.5+ is supported
+        final String baseEffect = PaperLib.isVersion(20, 5) ? getBasePotionEffects(potionMeta)
+                : getBasePotionEffectsPre_1_21(potionMeta);
+        return addCustomEffects(potionMeta, baseEffect);
+    }
+
+    @SuppressWarnings("PMD.MethodNamingConventions")
+    private static String getBasePotionEffectsPre_1_21(final PotionMeta potionMeta) {
+        final PotionData pData = potionMeta.getBasePotionData();
+        return " type:" + pData.getType() + (pData.isExtended() ? " extended" : "")
+                + (pData.isUpgraded() ? " upgraded" : "");
+    }
+
+    private static String getBasePotionEffects(final PotionMeta potionMeta) {
+        if (!potionMeta.hasBasePotionType()) {
+            return "";
+        }
+        final PotionType type = potionMeta.getBasePotionType();
+        final String minimalString = type.getKey().asMinimalString();
+        final String longPrefix = "long_";
+        final String strongPrefix = "strong_";
+        final String effects;
+        if (minimalString.startsWith(longPrefix)) {
+            effects = minimalString.substring(longPrefix.length()) + " extended";
+        } else if (minimalString.startsWith(strongPrefix)) {
+            effects = minimalString.substring(strongPrefix.length()) + " upgraded";
+        } else {
+            effects = minimalString;
+        }
+        return " type:" + effects;
+    }
+
+    private static String addCustomEffects(final PotionMeta potionMeta, final String effects) {
+        final List<PotionEffect> customEffects = potionMeta.getCustomEffects();
+        if (customEffects.isEmpty()) {
+            return effects;
+        }
+        final StringBuilder string = new StringBuilder();
+        for (final PotionEffect effect : customEffects) {
+            final int power = effect.getAmplifier() + 1;
+            final int duration = (effect.getDuration() - (effect.getDuration() % 20)) / 20;
+            string.append(effect.getType().getName()).append(':').append(power).append(':').append(duration).append(',');
+        }
+        return effects + " effects:" + string.substring(0, string.length() - 1);
     }
 
     public void setType(final String type) throws InstructionParseException {
@@ -94,12 +150,16 @@ public class PotionHandler {
         customE = Existence.REQUIRED;
     }
 
-    public boolean checkBase(final PotionData base) {
+    public boolean checkMeta(final PotionMeta potionMeta) {
+        return checkBase(potionMeta.getBasePotionData()) && checkCustom(potionMeta.getCustomEffects());
+    }
+
+    public boolean checkBase(@Nullable final PotionData base) {
         switch (typeE) {
             case WHATEVER:
                 return true;
             case REQUIRED:
-                if (base.getType() != type) {
+                if (base == null || base.getType() != type) {
                     return false;
                 }
                 if (extendedE == Existence.REQUIRED && base.isExtended() != extended) {
@@ -252,5 +312,4 @@ public class PotionHandler {
             }
         }
     }
-
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Also moved most of the un-/parse logic into the PotionHandler (why was it even in the Item Class?).

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
