### PR TITLE
`action` objective now supports configuring the hand used for the int…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `traincartsexit` objective that executes when the player exited a train
   - `traincartsride` condition to check if the player is riding a specific named train
 - `scoretag` event and condition
+- `action` objective now supports configuring the hand used for the interaction, preventing multiple objective completions at the same time
 ### Changed
 - `spawn` event now only spawn mobs and no other entities
 - ProSkillAPI rename to Fabled

--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -5,23 +5,28 @@ icon: octicons/codescan-checkmark-16
 
 ## Action: `action`
 
-This objective completes when the player clicks on the given block type. The first argument is the type of the click,
-it can be right, left or any. Next is a [Block Selector](../Data-Formats.md#block-selectors) or `any` if you
-want to count all clicks, even into the air. You can also specify the `loc:` argument, followed by the standard location
-format and the `range:` followed by a number (or variable). The specified location is the center of a sphere, the range it's radius.
-Therefore, these arguments define where the clicked block needs to be, as opposed to "where you must be" in location condition.
-If you add the argument `cancel`, the click will be canceled (chest will not open, button will not be pressed etc.).
-This objective works great with the location condition and the item in hand condition to further limit the counted clicks.
-One could make a magic wand using this.
+This objective completes when the player clicks on the given block type. 
+It works great with the location condition and the item in hand condition to further limit the counted clicks.
 
-The objective contains one property, `location`. It's a string formatted like `X: 100, Y: 200, Z:300`. It does not
-show the radius.
+| Parameter    | Syntax                                                        | Default Value           | Explanation                                                                                                   |
+|--------------|---------------------------------------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------|
+| _Click Type_ | `right`, `left` or `any`                                      | :octicons-x-circle-16:  | What type of click should be handled                                                                          |
+| _Block Type_ | [Block Selector](../Data-Formats.md#block-selectors) or `any` | :octicons-x-circle-16:  | The block which must be clicked, or `any` for even air                                                        |
+| _Location_   | loc:[Location](../Data-Formats.md#unified-location-formating) | Optional. Default: none | Adds an optional location to the objective, only counting blocks clicked at the specific location.            |
+| _range_      | range:number                                                  | 0                       | The range around the location where to count the clicks.                                                      |
+| _cancel_     | Keyword (`cancel`)                                            | Not Set                 | Prevents the player from interacting with the block.                                                          |
+| _hand_       | hand:(`hand`,`off_hand`, `any`)                               | `hand`                  | The hand the player must use to click the block, `any` can the objective cause to be completed multiple times |
 
 !!! example
     ```YAML
     action right DOOR conditions:holding_key loc:100;200;300;world range:5
     action any any conditions:holding_magicWand events:fireSpell #Custom click listener for a wand
     ```
+
+<h5> Variable Properties </h5> 
+
+The objective contains one property, `location`. It's a string formatted like `X: 100, Y: 200, Z:300`. It does not
+show the radius.
 
 ## Arrow Shooting: `arrow`
 


### PR DESCRIPTION
…eraction, preventing multiple objective completions at the same time

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
