### PR TITLE
Add PlayerUpdatePointEvent event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- A Bukkit event which fires when a player's points change
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/main/java/org/betonquest/betonquest/api/PlayerUpdatePointEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/PlayerUpdatePointEvent.java
@@ -1,0 +1,75 @@
+package org.betonquest.betonquest.api;
+
+import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.api.profiles.ProfileEvent;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a player's points are updated.
+ */
+public class PlayerUpdatePointEvent extends ProfileEvent {
+    /**
+     * HandlerList of this event.
+     */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /**
+     * The category whose points were updated.
+     */
+    private final String category;
+
+    /**
+     * The updated total points count of the involved category.
+     */
+    private final int newCount;
+
+    /**
+     * Creates a new PlayerAddPointEvent.
+     *
+     * @param who the {@link Profile} whose points was added
+     * @param category the category whose points were updated
+     * @param newCount the updated total points count of the involved category
+     */
+    public PlayerUpdatePointEvent(final Profile who, final String category, final int newCount) {
+        super(who);
+        this.category = category;
+        this.newCount = newCount;
+    }
+
+    /**
+     * Gets the HandlerList of this event.
+     *
+     * @return the HandlerList
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * Gets the category whose points were updated.
+     *
+     * @return the category whose points were updated
+     */
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * Gets the total updated points count of the involved category.
+     *
+     * @return the total updated points count of the involved category
+     */
+    public int getNewCount() {
+        return newCount;
+    }
+
+    /**
+     * Gets the HandlerList of this event.
+     *
+     * @return the HandlerList
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/database/PlayerData.java
+++ b/src/main/java/org/betonquest/betonquest/database/PlayerData.java
@@ -8,6 +8,7 @@ import org.betonquest.betonquest.Pointer;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.PlayerTagAddEvent;
 import org.betonquest.betonquest.api.PlayerTagRemoveEvent;
+import org.betonquest.betonquest.api.PlayerUpdatePointEvent;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.config.Config;
@@ -282,12 +283,14 @@ public class PlayerData implements TagData {
                     saver.add(new Record(UpdateType.ADD_POINTS,
                             profileID, category, String.valueOf(point.getCount() + count)));
                     point.addPoints(count);
+                    BetonQuest.getInstance().callSyncBukkitEvent(new PlayerUpdatePointEvent(profile, category, point.getCount()));
                     return;
                 }
             }
             // if not then create new point category with given amount of points
             points.add(new Point(category, count));
             saver.add(new Record(UpdateType.ADD_POINTS, profileID, category, String.valueOf(count)));
+            BetonQuest.getInstance().callSyncBukkitEvent(new PlayerUpdatePointEvent(profile, category, count));
         }
     }
 
@@ -304,6 +307,7 @@ public class PlayerData implements TagData {
             points.removeIf(point -> point.getCategory().equalsIgnoreCase(category));
             points.add(new Point(category, count));
             saver.add(new Record(UpdateType.ADD_POINTS, profileID, category, String.valueOf(count)));
+            BetonQuest.getInstance().callSyncBukkitEvent(new PlayerUpdatePointEvent(profile, category, count));
         }
     }
 
@@ -322,6 +326,7 @@ public class PlayerData implements TagData {
             }
             if (pointToRemove != null) {
                 points.remove(pointToRemove);
+                BetonQuest.getInstance().callSyncBukkitEvent(new PlayerUpdatePointEvent(profile, category, 0));
             }
             saver.add(new Record(UpdateType.REMOVE_POINTS, profileID, category));
         }


### PR DESCRIPTION
<!-- Please describe your changes here. -->

This makes it possible for other plugins to listen to ~~quest's~~ player's point updates via the API. We needed this as we use these points to determine the status of the quest, and we need to keep their status up-to-date whenever their points change.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
