### PR TITLE
use raw sound only as fallback if no enum found

### DIFF
--- a/src/main/java/org/betonquest/betonquest/config/Config.java
+++ b/src/main/java/org/betonquest/betonquest/config/Config.java
@@ -17,6 +17,7 @@ import org.betonquest.betonquest.instruction.variable.VariableString;
 import org.betonquest.betonquest.modules.config.QuestManager;
 import org.betonquest.betonquest.notify.Notify;
 import org.bukkit.ChatColor;
+import org.bukkit.Sound;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -318,7 +320,11 @@ public final class Config {
         final Player player = onlineProfile.getPlayer();
         final String rawSound = plugin.getPluginConfig().getString("sounds." + soundName);
         if (!"false".equalsIgnoreCase(rawSound)) {
-            player.playSound(player.getLocation(), rawSound, 1F, 1F);
+            try {
+                player.playSound(player.getLocation(), Sound.valueOf(rawSound), 1F, 1F);
+            } catch (final IllegalArgumentException e) {
+                player.playSound(player.getLocation(), rawSound.toLowerCase(Locale.ROOT), 1F, 1F);
+            }
         }
     }
 


### PR DESCRIPTION
as already done in NotifySound.java

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Fixes [#3071](https://github.com/BetonQuest/BetonQuest/pull/3071/files#r1890148941)

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
