### PR TITLE
No longer set damage in QuestItem if none set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - custom sounds from resourcepacks could not be used in conversation start and end sound
 - `chestput` objective caused that no chest could be opened on the server when `multipleaccess` was forbidden(default)
 - providing wrong commit sha to the download command now gives a proper error message
+- no longer set damage in `QuestItem` if none set
 ### Security
 
 ## [2.2.0] - 2024-12-01

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/DurabilityHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/DurabilityHandler.java
@@ -3,12 +3,15 @@ package org.betonquest.betonquest.item.typehandler;
 import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.item.QuestItem.Number;
 import org.bukkit.inventory.meta.Damageable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
 
 @SuppressWarnings("PMD.CommentRequired")
 public class DurabilityHandler implements ItemMetaHandler<Damageable> {
+    private boolean isSet;
+
     private int durability;
 
     private Number number = Number.WHATEVER;
@@ -27,8 +30,12 @@ public class DurabilityHandler implements ItemMetaHandler<Damageable> {
     }
 
     @Override
+    @Nullable
     public String serializeToString(final Damageable damageable) {
-        return "durability:" + damageable.getDamage();
+        if (damageable.hasDamage()) {
+            return "durability:" + damageable.getDamage();
+        }
+        return null;
     }
 
     @Override
@@ -41,7 +48,9 @@ public class DurabilityHandler implements ItemMetaHandler<Damageable> {
 
     @Override
     public void populate(final Damageable damageableMeta) {
-        damageableMeta.setDamage(get());
+        if (isSet) {
+            damageableMeta.setDamage(durability);
+        }
     }
 
     @Override
@@ -53,6 +62,7 @@ public class DurabilityHandler implements ItemMetaHandler<Damageable> {
         final Map.Entry<Number, Integer> itemDurability = HandlerUtil.getNumberValue(durability, "item durability");
         this.number = itemDurability.getKey();
         this.durability = itemDurability.getValue();
+        isSet = true;
     }
 
     public int get() {


### PR DESCRIPTION
<!-- Please describe your changes here. -->
This led to some issues with the new Data Components where it actually makes a difference if it is not set or 0.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
