### PR TITLE
Allow `Variable` to throw on resolving

### DIFF
--- a/docs/API/Legacy-API.md
+++ b/docs/API/Legacy-API.md
@@ -93,7 +93,7 @@ All variables need to extend `Variable` class.
 In the constructor you must parse the instruction and extract all information about your variable's behavior.
 Then you have to override the `String getValue(String playerID)` method.
 It should return the value of the variable for the supplied player.
-If it's impossible, it should return an empty String.
+If it's impossible, in the old it should return an empty String and in the new throw with a descriptive message.
 Registering variables is done via `BetonQuest.registerVariable(String name, Class<? extends Variable> variable)` method.
 
 ## Reading `Instruction` object

--- a/src/main/java/org/betonquest/betonquest/api/common/function/QuestCallable.java
+++ b/src/main/java/org/betonquest/betonquest/api/common/function/QuestCallable.java
@@ -1,0 +1,20 @@
+package org.betonquest.betonquest.api.common.function;
+
+import org.betonquest.betonquest.exceptions.QuestException;
+
+/**
+ * A {@link java.util.concurrent.Callable} that may throw a {@link QuestException}.
+ *
+ * @param <R> the result type of the method call
+ */
+@FunctionalInterface
+public interface QuestCallable<R> {
+
+    /**
+     * Calls the method and gets the result.
+     *
+     * @return result of the check
+     * @throws QuestException when the method execution fails
+     */
+    R call() throws QuestException;
+}

--- a/src/main/java/org/betonquest/betonquest/api/common/function/QuestConsumer.java
+++ b/src/main/java/org/betonquest/betonquest/api/common/function/QuestConsumer.java
@@ -1,0 +1,19 @@
+package org.betonquest.betonquest.api.common.function;
+
+import org.betonquest.betonquest.exceptions.QuestException;
+
+/**
+ * A simple {@link org.bukkit.util.Consumer} that can throw a {@link QuestException}.
+ *
+ * @param <T> the type of the input to the operation
+ */
+@FunctionalInterface
+public interface QuestConsumer<T> {
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param arg the input argument
+     * @throws QuestException when the method execution fails
+     */
+    void accept(T arg) throws QuestException;
+}

--- a/src/main/java/org/betonquest/betonquest/api/common/function/QuestFunction.java
+++ b/src/main/java/org/betonquest/betonquest/api/common/function/QuestFunction.java
@@ -1,0 +1,22 @@
+package org.betonquest.betonquest.api.common.function;
+
+import org.betonquest.betonquest.exceptions.QuestException;
+
+/**
+ * A simple {@link java.util.function.Function} that can throw a {@link QuestException}.
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
+@FunctionalInterface
+public interface QuestFunction<T, R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param arg the function argument
+     * @return the function result
+     * @throws QuestException if the resolving fails
+     */
+    R apply(T arg) throws QuestException;
+}

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/PlayerVariable.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/PlayerVariable.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.api.quest.variable;
 
 import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 /**
  * Interface for quest-variables that are checked for a profile. It represents the normal variable as described in the
@@ -12,6 +13,7 @@ public interface PlayerVariable {
      *
      * @param profile the {@link Profile} to get the value for
      * @return the value of this variable
+     * @throws QuestException when the value could not be retrieved
      */
-    String getValue(Profile profile);
+    String getValue(Profile profile) throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/PlayerlessVariable.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/PlayerlessVariable.java
@@ -1,5 +1,7 @@
 package org.betonquest.betonquest.api.quest.variable;
 
+import org.betonquest.betonquest.exceptions.QuestException;
+
 /**
  * Interface for "static" quest-variables.
  * It represents the "static" variable as described in the BetonQuest user documentation.
@@ -10,6 +12,7 @@ public interface PlayerlessVariable {
      * Gets the resolved value.
      *
      * @return the value of this variable
+     * @throws QuestException when the value could not be retrieved
      */
-    String getValue();
+    String getValue() throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/nullable/NullableVariable.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/nullable/NullableVariable.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.api.quest.variable.nullable;
 
 import org.betonquest.betonquest.api.profiles.Profile;
+import org.betonquest.betonquest.exceptions.QuestException;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -14,6 +15,7 @@ public interface NullableVariable {
      * @return the resolved variable value; or an empty string if the variable
      * cannot be resolved, this might indicate that the profile cannot be null
      * in this specific case
+     * @throws QuestException when the value could not be retrieved
      */
-    String getValue(@Nullable Profile profile);
+    String getValue(@Nullable Profile profile) throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/nullable/NullableVariableAdapter.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/nullable/NullableVariableAdapter.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.api.quest.variable.nullable;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.api.quest.variable.PlayerlessVariable;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 /**
  * An adapter to handle both the {@link PlayerVariable} and {@link PlayerlessVariable}
@@ -24,12 +25,12 @@ public final class NullableVariableAdapter implements PlayerVariable, Playerless
     }
 
     @Override
-    public String getValue(final Profile profile) {
+    public String getValue(final Profile profile) throws QuestException {
         return variable.getValue(profile);
     }
 
     @Override
-    public String getValue() {
+    public String getValue() throws QuestException {
         return variable.getValue(null);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariable.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariable.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.api.quest.variable.online;
 
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 /**
  * Player Variable that needs an online profile to function correctly.
@@ -11,6 +12,7 @@ public interface OnlineVariable {
      *
      * @param profile the {@link OnlineProfile} to get the value for
      * @return the value of this variable
+     * @throws QuestException when the value could not be retrieved
      */
-    String getValue(OnlineProfile profile);
+    String getValue(OnlineProfile profile) throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariableAdapter.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariableAdapter.java
@@ -1,7 +1,5 @@
 package org.betonquest.betonquest.api.quest.variable.online;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
@@ -26,16 +24,13 @@ public final class OnlineVariableAdapter implements PlayerVariable {
 
     /**
      * Create a variable that resolves the given online variable.
-     * If the player is not online it logs a message into the debug log.
+     * If the player is not online it will throw with an info message.
      *
      * @param onlineVariable variable to resolve for online players
-     * @param log            log to write to if the player is not online
-     * @param questPackage   quest package to reference in the log
      */
-    public OnlineVariableAdapter(final OnlineVariable onlineVariable, final BetonQuestLogger log, final QuestPackage questPackage) {
+    public OnlineVariableAdapter(final OnlineVariable onlineVariable) {
         this(onlineVariable, profile -> {
-            log.debug(questPackage, profile + " is offline, cannot get variable value because it's not persistent.");
-            return "";
+            throw new QuestException(profile + " is offline, cannot get variable value because it's not persistent.");
         });
     }
 

--- a/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariableAdapter.java
+++ b/src/main/java/org/betonquest/betonquest/api/quest/variable/online/OnlineVariableAdapter.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 import java.util.Optional;
 
@@ -51,8 +52,11 @@ public final class OnlineVariableAdapter implements PlayerVariable {
     }
 
     @Override
-    public String getValue(final Profile profile) {
+    public String getValue(final Profile profile) throws QuestException {
         final Optional<OnlineProfile> onlineProfile = profile.getOnlineProfile();
-        return onlineProfile.map(onlineVariable::getValue).orElseGet(() -> fallbackVariable.getValue(profile));
+        if (onlineProfile.isPresent()) {
+            return onlineVariable.getValue(onlineProfile.get());
+        }
+        return fallbackVariable.getValue(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/variable/npc/CitizensVariable.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/variable/npc/CitizensVariable.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.compatibility.citizens.variable.npc;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import org.betonquest.betonquest.api.quest.variable.PlayerlessVariable;
+import org.betonquest.betonquest.exceptions.QuestException;
 import org.betonquest.betonquest.variables.LocationVariable;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,10 +45,10 @@ public class CitizensVariable implements PlayerlessVariable {
     }
 
     @Override
-    public String getValue() {
+    public String getValue() throws QuestException {
         final NPC npc = CitizensAPI.getNPCRegistry().getById(npcId);
         if (npc == null) {
-            return "";
+            throw new QuestException("No NPC with id '" + npcId + "' found!");
         }
 
         return key.resolve(npc, location);

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/VaultIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/VaultIntegrator.java
@@ -55,7 +55,7 @@ public class VaultIntegrator implements Integrator {
 
             registries.getEventTypes().register("money", new MoneyEventFactory(economy, loggerFactory, data, plugin.getVariableProcessor()));
             registries.getConditionTypes().register("money", new MoneyConditionFactory(economy, data));
-            registries.getVariableTypes().register("money", new MoneyVariableFactory(economy, loggerFactory));
+            registries.getVariableTypes().register("money", new MoneyVariableFactory(economy));
         }
 
         final RegisteredServiceProvider<Permission> permissionProvider = servicesManager.getRegistration(Permission.class);

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariable.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariable.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.compatibility.vault.variable;
 
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.exceptions.QuestException;
@@ -11,14 +12,14 @@ public class MoneyVariable implements PlayerVariable {
     /**
      * Function to get the displayed money amount from a profile.
      */
-    private final MoneyVariableFactory.QuestExceptionFunction<Profile, String> function;
+    private final QuestFunction<Profile, String> function;
 
     /**
      * Create a new Money variable.
      *
      * @param function the function to get the displayed money amount from a profile
      */
-    public MoneyVariable(final MoneyVariableFactory.QuestExceptionFunction<Profile, String> function) {
+    public MoneyVariable(final QuestFunction<Profile, String> function) {
         this.function = function;
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariable.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariable.java
@@ -1,11 +1,8 @@
 package org.betonquest.betonquest.compatibility.vault.variable;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.exceptions.QuestException;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Resolves to amount of money.
@@ -17,36 +14,16 @@ public class MoneyVariable implements PlayerVariable {
     private final MoneyVariableFactory.QuestExceptionFunction<Profile, String> function;
 
     /**
-     * Custom {@link BetonQuestLogger} instance for this class.
-     */
-    private final BetonQuestLogger log;
-
-    /**
-     * Pack used for logging identification.
-     */
-    private final QuestPackage pack;
-
-    /**
+     * Create a new Money variable.
+     *
      * @param function the function to get the displayed money amount from a profile
-     * @param log      the custom {@link BetonQuestLogger} instance for exception logging
-     * @param pack     the pack used for logging identification
      */
-    public MoneyVariable(final MoneyVariableFactory.QuestExceptionFunction<Profile, String> function, final BetonQuestLogger log, final QuestPackage pack) {
+    public MoneyVariable(final MoneyVariableFactory.QuestExceptionFunction<Profile, String> function) {
         this.function = function;
-        this.log = log;
-        this.pack = pack;
     }
 
     @Override
-    public String getValue(@Nullable final Profile profile) {
-        if (profile == null) {
-            return "";
-        }
-        try {
-            return function.apply(profile);
-        } catch (final QuestException e) {
-            log.warn(pack, "Unable to get money variable value: " + e.getMessage(), e);
-            return "";
-        }
+    public String getValue(final Profile profile) throws QuestException {
+        return function.apply(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariableFactory.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariableFactory.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.compatibility.vault.variable;
 
 import net.milkbowl.vault.economy.Economy;
 import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariableFactory;
@@ -41,7 +42,7 @@ public class MoneyVariableFactory implements PlayerVariableFactory {
     @Override
     public PlayerVariable parsePlayer(final Instruction instruction) throws QuestException {
         final String instructionString = instruction.next();
-        final QuestExceptionFunction<Profile, String> function;
+        final QuestFunction<Profile, String> function;
         if (MONEY_AMOUNT.equalsIgnoreCase(instructionString)) {
             function = profile -> String.valueOf(economy.getBalance(profile.getPlayer()));
         } else if (instructionString.toLowerCase(Locale.ROOT).startsWith(MONEY_LEFT)) {
@@ -51,22 +52,5 @@ public class MoneyVariableFactory implements PlayerVariableFactory {
             throw new QuestException("No type specified");
         }
         return new MoneyVariable(function);
-    }
-
-    /**
-     * A simple {@link java.util.function.Function} that can throw a QuestException.
-     *
-     * @param <T> the type of the input to the function
-     * @param <R> the type of the result of the function
-     */
-    public interface QuestExceptionFunction<T, R> {
-        /**
-         * Applies this function to the given argument.
-         *
-         * @param arg the function argument
-         * @return the function result
-         * @throws QuestException if the resolving fails
-         */
-        R apply(T arg) throws QuestException;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariableFactory.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/vault/variable/MoneyVariableFactory.java
@@ -2,7 +2,6 @@ package org.betonquest.betonquest.compatibility.vault.variable;
 
 import net.milkbowl.vault.economy.Economy;
 import org.betonquest.betonquest.Instruction;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariableFactory;
@@ -31,19 +30,12 @@ public class MoneyVariableFactory implements PlayerVariableFactory {
     private final Economy economy;
 
     /**
-     * Logger factory to create new class specific loggers.
-     */
-    private final BetonQuestLoggerFactory loggerFactory;
-
-    /**
      * Create a new Factory to create Vault Money Variables.
      *
-     * @param economy       the economy where the balance will be got
-     * @param loggerFactory the logger factory to create new class specific loggers
+     * @param economy the economy where the balance will be got
      */
-    public MoneyVariableFactory(final Economy economy, final BetonQuestLoggerFactory loggerFactory) {
+    public MoneyVariableFactory(final Economy economy) {
         this.economy = economy;
-        this.loggerFactory = loggerFactory;
     }
 
     @Override
@@ -58,7 +50,7 @@ public class MoneyVariableFactory implements PlayerVariableFactory {
         } else {
             throw new QuestException("No type specified");
         }
-        return new MoneyVariable(function, loggerFactory.create(MoneyVariable.class), instruction.getPackage());
+        return new MoneyVariable(function);
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/instruction/variable/Variable.java
+++ b/src/main/java/org/betonquest/betonquest/instruction/variable/Variable.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.instruction.variable;
 
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.QuestException;
@@ -41,13 +42,13 @@ public class Variable<T> {
      * @throws QuestException if the variables could not be created or resolved to the given type
      */
     public Variable(final VariableProcessor variableProcessor, final QuestPackage pack, final String input,
-                    final TypeResolver<T> resolver) throws QuestException {
+                    final QuestFunction<String, T> resolver) throws QuestException {
         final Map<String, org.betonquest.betonquest.api.Variable> variables = getVariables(variableProcessor, pack, input);
         if (variables.isEmpty()) {
-            final T resolved = resolver.resolve(input);
+            final T resolved = resolver.apply(input);
             value = profile -> resolved;
         } else {
-            value = profile -> resolver.resolve(getString(input, variables, profile));
+            value = profile -> resolver.apply(getString(input, variables, profile));
         }
     }
 
@@ -102,41 +103,18 @@ public class Variable<T> {
      * @throws QuestException if the variable could not be resolved
      */
     public T getValue(@Nullable final Profile profile) throws QuestException {
-        return value.resolve(profile);
+        return value.apply(profile);
     }
 
     /**
-     * Resolves the value of the variable to the given type.
+     * Resolves the value of the variable with a Nullable Profile.
      *
      * @param <T> the type of the variable
      */
     @FunctionalInterface
-    public interface TypeResolver<T> {
-        /**
-         * Converts the resolved variable to the given type.
-         *
-         * @param variable the variable to resolve
-         * @return the resolved variable
-         * @throws QuestException if the variable could not be resolved
-         */
-        T resolve(String variable) throws QuestException;
-    }
-
-    /**
-     * Resolves the value of the variable.
-     *
-     * @param <T> the type of the variable
-     */
-    @FunctionalInterface
-    private interface ValueResolver<T> {
-        /**
-         * Gets the value of the variable.
-         *
-         * @param profile the profile of the player to resolve the variables for
-         * @return the value of the variable
-         * @throws QuestException when the variable could not be resolved
-         */
-        T resolve(@Nullable Profile profile) throws QuestException;
+    private interface ValueResolver<T> extends QuestFunction<Profile, T> {
+        @Override
+        T apply(@Nullable Profile arg) throws QuestException;
     }
 
     /**

--- a/src/main/java/org/betonquest/betonquest/notify/NotifySound.java
+++ b/src/main/java/org/betonquest/betonquest/notify/NotifySound.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.notify;
 
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.common.function.QuestConsumer;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profiles.OnlineProfile;
 import org.betonquest.betonquest.api.profiles.Profile;
@@ -34,7 +35,7 @@ class NotifySound {
 
     private static final String[] SOUND_OPTIONS = {KEY_SOUND_LOCATION, KEY_SOUND_PLAYER_OFFSET, KEY_SOUND_CATEGORY, KEY_SOUND_VOLUME, KEY_SOUND_PITCH};
 
-    private final SoundPlayer soundPlayer;
+    private final QuestConsumer<OnlineProfile> soundPlayer;
 
     private final QuestPackage pack;
 
@@ -42,7 +43,7 @@ class NotifySound {
         this.pack = notify.pack;
         final Map<String, String> data = notify.data;
 
-        final SoundPlayer tempSoundPlayer = checkInput(data);
+        final QuestConsumer<OnlineProfile> tempSoundPlayer = checkInput(data);
         if (tempSoundPlayer != null) {
             soundPlayer = tempSoundPlayer;
             return;
@@ -74,7 +75,7 @@ class NotifySound {
         soundPlayer = getSoundPlayer(sound, soundString, variableLocation, playerOffset, playerOffsetDistance, soundCategory, volume, pitch);
     }
 
-    private SoundPlayer getSoundPlayer(@Nullable final Sound sound, final String soundString, @Nullable final VariableLocation variableLocation, @Nullable final VariableVector playerOffset, @Nullable final Float playerOffsetDistance, final SoundCategory soundCategory, final float volume, final float pitch) {
+    private QuestConsumer<OnlineProfile> getSoundPlayer(@Nullable final Sound sound, final String soundString, @Nullable final VariableLocation variableLocation, @Nullable final VariableVector playerOffset, @Nullable final Float playerOffsetDistance, final SoundCategory soundCategory, final float volume, final float pitch) {
         return (onlineProfile) -> {
             final Location finalLocation = getLocation(onlineProfile, variableLocation, playerOffset, playerOffsetDistance);
             final Player player = onlineProfile.getPlayer();
@@ -117,7 +118,7 @@ class NotifySound {
     }
 
     @Nullable
-    private SoundPlayer checkInput(final Map<String, String> data) throws QuestException {
+    private QuestConsumer<OnlineProfile> checkInput(final Map<String, String> data) throws QuestException {
         if (!data.containsKey(KEY_SOUND)) {
             if (Arrays.stream(SOUND_OPTIONS).anyMatch(data::containsKey)) {
                 throw new QuestException("You must specify a 'sound' if you want to use sound options!");
@@ -177,11 +178,6 @@ class NotifySound {
     }
 
     protected void sendSound(final OnlineProfile onlineProfile) throws QuestException {
-        soundPlayer.play(onlineProfile);
-    }
-
-    @FunctionalInterface
-    private interface SoundPlayer {
-        void play(OnlineProfile onlineProfile) throws QuestException;
+        soundPlayer.accept(onlineProfile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/PrimaryServerThreadType.java
+++ b/src/main/java/org/betonquest/betonquest/quest/PrimaryServerThreadType.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest;
 
+import org.betonquest.betonquest.api.common.function.QuestCallable;
 import org.betonquest.betonquest.exceptions.QuestException;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
@@ -95,18 +96,5 @@ public class PrimaryServerThreadType<T, R> {
             }
             throw new QuestException(e);
         }
-    }
-
-    /**
-     * Calls the quest method that may throw a {@link QuestException}.
-     */
-    protected interface QuestCallable<R> {
-        /**
-         * Calls the method and gets the result.
-         *
-         * @return result of the check
-         * @throws QuestException when a QuestException is thrown during method execution
-         */
-        R call() throws QuestException;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/stage/StageEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/stage/StageEvent.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.event.stage;
 
+import org.betonquest.betonquest.api.common.function.QuestConsumer;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.exceptions.QuestException;
@@ -11,32 +12,19 @@ public class StageEvent implements Event {
     /**
      * The action to perform.
      */
-    private final StageAction action;
+    private final QuestConsumer<Profile> action;
 
     /**
      * Creates the stage event.
      *
-     * @param action the action to perform
+     * @param action the stage action to perform
      */
-    public StageEvent(final StageAction action) {
+    public StageEvent(final QuestConsumer<Profile> action) {
         this.action = action;
     }
 
     @Override
     public void execute(final Profile profile) throws QuestException {
-        action.execute(profile);
-    }
-
-    /**
-     * The stage action interface.
-     */
-    public interface StageAction {
-        /**
-         * Execute the action.
-         *
-         * @param profile the profile to execute the action for
-         * @throws QuestException when the action fails
-         */
-        void execute(Profile profile) throws QuestException;
+        action.accept(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/legacy/LegacyVariableFactoryAdapter.java
+++ b/src/main/java/org/betonquest/betonquest/quest/legacy/LegacyVariableFactoryAdapter.java
@@ -2,6 +2,8 @@ package org.betonquest.betonquest.quest.legacy;
 
 import org.betonquest.betonquest.Instruction;
 import org.betonquest.betonquest.api.Variable;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.PlayerQuestFactory;
 import org.betonquest.betonquest.api.quest.PlayerlessQuestFactory;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
@@ -14,21 +16,29 @@ import org.jetbrains.annotations.Nullable;
  */
 public class LegacyVariableFactoryAdapter extends LegacyFactoryAdapter<PlayerVariable, PlayerlessVariable, Variable> {
     /**
+     * The custom logger for the LegacyAdapter.
+     */
+    private final BetonQuestLogger logger;
+
+    /**
      * Create the factory from an {@link PlayerQuestFactory} and/or {@link PlayerlessQuestFactory}.
      * <p>
      * When no player factory is given the playerless factory is required.
      *
      * @param playerFactory     the player factory to use
      * @param playerlessFactory the playerless factory to use
+     * @param loggerFactory     the logger factory to create new custom logger with
      */
     public LegacyVariableFactoryAdapter(@Nullable final PlayerQuestFactory<PlayerVariable> playerFactory,
-                                        @Nullable final PlayerlessQuestFactory<PlayerlessVariable> playerlessFactory) {
+                                        @Nullable final PlayerlessQuestFactory<PlayerlessVariable> playerlessFactory,
+                                        final BetonQuestLoggerFactory loggerFactory) {
         super(playerFactory, playerlessFactory);
+        logger = loggerFactory.create(LegacyVariableAdapter.class);
     }
 
     @Override
     protected Variable getAdapter(final Instruction instruction, @Nullable final PlayerVariable playerType,
                                   @Nullable final PlayerlessVariable playerlessType) {
-        return new LegacyVariableAdapter(instruction, playerType, playerlessType);
+        return new LegacyVariableAdapter(instruction, playerType, playerlessType, logger);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
@@ -395,7 +395,7 @@ public class CoreQuestTypes {
         variables.register("npc", new NpcNameVariableFactory(betonQuest));
         variables.register("objective", ObjectivePropertyVariable.class);
         variables.register("point", PointVariable.class);
-        variables.register("player", new PlayerNameVariableFactory(loggerFactory));
+        variables.register("player", new PlayerNameVariableFactory());
         variables.register("randomnumber", RandomNumberVariable.class);
         variables.register("tag", TagVariable.class);
         variables.register("version", VersionVariable.class);

--- a/src/main/java/org/betonquest/betonquest/quest/registry/type/VariableTypeRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/type/VariableTypeRegistry.java
@@ -17,6 +17,11 @@ import org.jetbrains.annotations.Nullable;
  */
 public class VariableTypeRegistry extends QuestTypeRegistry<PlayerVariable, PlayerlessVariable, Variable> {
     /**
+     * Logger factory for creating new custom loggers.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    /**
      * Create a new variable type registry.
      *
      * @param log           the logger that will be used for logging
@@ -24,6 +29,7 @@ public class VariableTypeRegistry extends QuestTypeRegistry<PlayerVariable, Play
      */
     public VariableTypeRegistry(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory) {
         super(log, loggerFactory, "variable");
+        this.loggerFactory = loggerFactory;
     }
 
     @Override
@@ -36,6 +42,6 @@ public class VariableTypeRegistry extends QuestTypeRegistry<PlayerVariable, Play
     protected LegacyTypeFactory<Variable> getLegacyFactoryAdapter(
             @Nullable final PlayerQuestFactory<PlayerVariable> playerFactory,
             @Nullable final PlayerlessQuestFactory<PlayerlessVariable> playerlessFactory) {
-        return new LegacyVariableFactoryAdapter(playerFactory, playerlessFactory);
+        return new LegacyVariableFactoryAdapter(playerFactory, playerlessFactory, loggerFactory);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/eval/EvalVariable.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/eval/EvalVariable.java
@@ -41,11 +41,7 @@ public class EvalVariable implements NullableVariable {
     }
 
     @Override
-    public String getValue(@Nullable final Profile profile) {
-        try {
-            return new VariableString(variableProcessor, pack, "%" + evaluation.getValue(profile) + "%").getValue(profile);
-        } catch (final QuestException e) {
-            return "";
-        }
+    public String getValue(@Nullable final Profile profile) throws QuestException {
+        return new VariableString(variableProcessor, pack, "%" + evaluation.getValue(profile) + "%").getValue(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameType.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameType.java
@@ -1,8 +1,7 @@
 package org.betonquest.betonquest.quest.variable.name;
 
 import org.betonquest.betonquest.api.profiles.Profile;
-
-import java.util.function.Function;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 /**
  * The type of the {@link PlayerNameVariable}.
@@ -17,7 +16,7 @@ public enum PlayerNameType {
      */
     DISPLAY(profile -> profile.getOnlineProfile()
             .map(online -> online.getPlayer().getDisplayName())
-            .orElseThrow(() -> new IllegalStateException(profile.getPlayer().getName() + " is offline, cannot get display name."))),
+            .orElseThrow(() -> new QuestException(profile.getPlayer().getName() + " is offline, cannot get display name."))),
     /**
      * The player's UUID.
      */
@@ -26,13 +25,27 @@ public enum PlayerNameType {
     /**
      * Method to get the variable value from a profile.
      */
-    private final Function<Profile, String> valueExtractor;
+    private final QEThrowingFunction valueExtractor;
 
-    PlayerNameType(final Function<Profile, String> valueExtractor) {
+    PlayerNameType(final QEThrowingFunction valueExtractor) {
         this.valueExtractor = valueExtractor;
     }
 
-    /* default */ String extractValue(final Profile profile) {
+    /* default */ String extractValue(final Profile profile) throws QuestException {
         return valueExtractor.apply(profile);
+    }
+
+    /**
+     * A function that can throw.
+     */
+    private interface QEThrowingFunction {
+        /**
+         * Applies the function.
+         *
+         * @param profile the profile to apply to
+         * @return the applied value
+         * @throws QuestException when the argument is invalid for the type
+         */
+        String apply(Profile profile) throws QuestException;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameType.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameType.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.variable.name;
 
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.exceptions.QuestException;
 
@@ -25,27 +26,13 @@ public enum PlayerNameType {
     /**
      * Method to get the variable value from a profile.
      */
-    private final QEThrowingFunction valueExtractor;
+    private final QuestFunction<Profile, String> valueExtractor;
 
-    PlayerNameType(final QEThrowingFunction valueExtractor) {
+    PlayerNameType(final QuestFunction<Profile, String> valueExtractor) {
         this.valueExtractor = valueExtractor;
     }
 
     /* default */ String extractValue(final Profile profile) throws QuestException {
         return valueExtractor.apply(profile);
-    }
-
-    /**
-     * A function that can throw.
-     */
-    private interface QEThrowingFunction {
-        /**
-         * Applies the function.
-         *
-         * @param profile the profile to apply to
-         * @return the applied value
-         * @throws QuestException when the argument is invalid for the type
-         */
-        String apply(Profile profile) throws QuestException;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameVariable.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameVariable.java
@@ -1,25 +1,14 @@
 package org.betonquest.betonquest.quest.variable.name;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profiles.Profile;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
+import org.betonquest.betonquest.exceptions.QuestException;
 
 /**
  * This variable resolves into the player's name. It can have optional "display"
  * argument, which will resolve it to the display name.
  */
 public class PlayerNameVariable implements PlayerVariable {
-    /**
-     * Custom {@link BetonQuestLogger} instance for this class.
-     */
-    private final BetonQuestLogger log;
-
-    /**
-     * QuestPackage to use in logging.
-     */
-    private final QuestPackage questPackage;
-
     /**
      * The type of the variable.
      */
@@ -28,23 +17,14 @@ public class PlayerNameVariable implements PlayerVariable {
     /**
      * Creates a new PlayerNameVariable from the given instruction.
      *
-     * @param type         the type to extract the variable value from the profile
-     * @param log          the logger to use when there was an error during variable resolving
-     * @param questPackage the quest package used for the error logging
+     * @param type the type to extract the variable value from the profile
      */
-    public PlayerNameVariable(final PlayerNameType type, final BetonQuestLogger log, final QuestPackage questPackage) {
+    public PlayerNameVariable(final PlayerNameType type) {
         this.type = type;
-        this.log = log;
-        this.questPackage = questPackage;
     }
 
     @Override
-    public String getValue(final Profile profile) {
-        try {
-            return type.extractValue(profile);
-        } catch (final IllegalStateException e) {
-            log.warn(questPackage, e.getMessage(), e);
-            return "";
-        }
+    public String getValue(final Profile profile) throws QuestException {
+        return type.extractValue(profile);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameVariableFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/name/PlayerNameVariableFactory.java
@@ -1,47 +1,30 @@
 package org.betonquest.betonquest.quest.variable.name;
 
 import org.betonquest.betonquest.Instruction;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariable;
 import org.betonquest.betonquest.api.quest.variable.PlayerVariableFactory;
 import org.betonquest.betonquest.exceptions.QuestException;
-
-import java.util.Locale;
 
 /**
  * Factory to create {@link PlayerNameVariable}s from {@link Instruction}s.
  */
 public class PlayerNameVariableFactory implements PlayerVariableFactory {
-    /**
-     * Logger Factory to create new logger for the created
-     */
-    private final BetonQuestLoggerFactory loggerFactory;
 
     /**
      * Create a PlayerName variable factory.
-     *
-     * @param loggerFactory the logger factory to create a new custom logger for the constructed variable
      */
-    public PlayerNameVariableFactory(final BetonQuestLoggerFactory loggerFactory) {
-        this.loggerFactory = loggerFactory;
+    public PlayerNameVariableFactory() {
+
     }
 
     @Override
     public PlayerVariable parsePlayer(final Instruction instruction) throws QuestException {
-        final PlayerNameType type = getType(instruction);
-        return new PlayerNameVariable(type, loggerFactory.create(PlayerNameVariable.class), instruction.getPackage());
-    }
-
-    private PlayerNameType getType(final Instruction instruction) throws QuestException {
-        if (!instruction.hasNext()) {
-            return PlayerNameType.NAME;
+        final PlayerNameType type;
+        if (instruction.hasNext()) {
+            type = instruction.getEnum(PlayerNameType.class);
+        } else {
+            type = PlayerNameType.NAME;
         }
-        final String type = instruction.next().toLowerCase(Locale.ROOT);
-        return switch (type) {
-            case "name" -> PlayerNameType.NAME;
-            case "display" -> PlayerNameType.DISPLAY;
-            case "uuid" -> PlayerNameType.UUID;
-            default -> throw new QuestException("Unknown type specified: " + type);
-        };
+        return new PlayerNameVariable(type);
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
- [x] Discuss if the OnlineVariable Adapter should also just throw (The event and condition equivalent do not).

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
