### PR TITLE
Move profile logic to interface

### DIFF
--- a/docs/API/Legacy-API.md
+++ b/docs/API/Legacy-API.md
@@ -92,7 +92,7 @@ You can't fire an event directly using an instruction string.
 
 ```JAVA title="Example"
 final QuestPackage questPackage = Config.getPackages().get("myPackage") //(1)!
-final Profile playerProfile = PlayerConverter.getID(player); //(2)!
+final Profile playerProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player); //(2)!
 
 BetonQuest.getInstance().getQuestAPI().event(playerProfile, new EventID(questPackage, eventID));
 ```

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -14,6 +14,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.logger.CachingBetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.bstats.BStatsMetrics;
@@ -56,12 +57,12 @@ import org.betonquest.betonquest.logger.handler.history.HistoryHandler;
 import org.betonquest.betonquest.menu.RPGMenu;
 import org.betonquest.betonquest.notify.Notify;
 import org.betonquest.betonquest.playerhider.PlayerHider;
+import org.betonquest.betonquest.profile.UUIDProfileProvider;
 import org.betonquest.betonquest.quest.registry.CoreQuestTypes;
 import org.betonquest.betonquest.quest.registry.QuestRegistry;
 import org.betonquest.betonquest.quest.registry.QuestTypeRegistries;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
 import org.betonquest.betonquest.schedule.LastExecutionCache;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.versioning.Version;
 import org.betonquest.betonquest.versioning.java.JREVersionPrinter;
 import org.betonquest.betonquest.web.DownloadSource;
@@ -235,6 +236,11 @@ public class BetonQuest extends JavaPlugin {
     private LastExecutionCache lastExecutionCache;
 
     /**
+     * The profile provider instance
+     */
+    private ProfileProvider profileProvider;
+
+    /**
      * The required default constructor without arguments for plugin creation.
      */
     public BetonQuest() {
@@ -248,6 +254,15 @@ public class BetonQuest extends JavaPlugin {
      */
     public static BetonQuest getInstance() {
         return instance;
+    }
+
+    /**
+     * Get the profile provider.
+     *
+     * @return The profile provider.
+     */
+    public ProfileProvider getProfileProvider() {
+        return profileProvider;
     }
 
     /**
@@ -350,6 +365,7 @@ public class BetonQuest extends JavaPlugin {
         this.configAccessorFactory = registerAndGetService(ConfigAccessorFactory.class, new DefaultConfigAccessorFactory());
         this.configurationFileFactory = registerAndGetService(ConfigurationFileFactory.class, new DefaultConfigurationFileFactory(
                 loggerFactory, loggerFactory.create(DefaultConfigurationFileFactory.class), configAccessorFactory));
+        this.profileProvider = registerAndGetService(ProfileProvider.class, new UUIDProfileProvider());
 
         this.log = loggerFactory.create(this);
         pluginTag = ChatColor.GRAY + "[" + ChatColor.DARK_GRAY + getDescription().getName() + ChatColor.GRAY + "]" + ChatColor.RESET + " ";
@@ -465,7 +481,7 @@ public class BetonQuest extends JavaPlugin {
         Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
             Compatibility.postHook();
             loadData();
-            playerDataStorage.initProfiles(PlayerConverter.getOnlineProfiles());
+            playerDataStorage.initProfiles(profileProvider.getOnlineProfiles());
 
             try {
                 playerHider = new PlayerHider(this, questTypeAPI);
@@ -617,7 +633,7 @@ public class BetonQuest extends JavaPlugin {
         Compatibility.reload();
         // load all events, conditions, objectives, conversations etc.
         loadData();
-        playerDataStorage.reloadProfiles(PlayerConverter.getOnlineProfiles());
+        playerDataStorage.reloadProfiles(getProfileProvider().getOnlineProfiles());
 
         if (playerHider != null) {
             playerHider.stop();
@@ -636,7 +652,7 @@ public class BetonQuest extends JavaPlugin {
             questRegistry.stopAllEventSchedules();
         }
         // suspend all conversations
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        for (final OnlineProfile onlineProfile : getProfileProvider().getOnlineProfiles()) {
             final Conversation conv = Conversation.getConversation(onlineProfile);
             if (conv != null) {
                 conv.suspend();

--- a/src/main/java/org/betonquest/betonquest/api/profile/ProfileProvider.java
+++ b/src/main/java/org/betonquest/betonquest/api/profile/ProfileProvider.java
@@ -1,0 +1,36 @@
+package org.betonquest.betonquest.api.profile;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Interface for implementing a profile provider.
+ * Profile providers are responsible for creating {@link Profile}s and
+ * {@link OnlineProfile}s for players.
+ */
+public interface ProfileProvider {
+    /**
+     * Get a {@link Profile} for an offline player.
+     *
+     * @param offlinePlayer the offline player to get the profile for
+     * @return the profile
+     */
+    Profile getProfile(OfflinePlayer offlinePlayer);
+
+    /**
+     * Get an {@link OnlineProfile} for a player.
+     *
+     * @param player the player to get the profile for
+     * @return the online profile
+     */
+    OnlineProfile getProfile(Player player);
+
+    /**
+     * Get all online profiles.
+     *
+     * @return all online profiles
+     */
+    List<OnlineProfile> getOnlineProfiles();
+}

--- a/src/main/java/org/betonquest/betonquest/command/BackpackCommand.java
+++ b/src/main/java/org/betonquest/betonquest/command/BackpackCommand.java
@@ -1,10 +1,11 @@
 package org.betonquest.betonquest.command;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.feature.Backpack;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -41,7 +42,8 @@ public class BackpackCommand implements CommandExecutor {
         if ("backpack".equalsIgnoreCase(cmd.getName())) {
             // command sender must be a player, console can't have a backpack
             if (sender instanceof Player) {
-                final OnlineProfile onlineProfile = PlayerConverter.getID((Player) sender);
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                final OnlineProfile onlineProfile = profileProvider.getProfile((Player) sender);
                 log.debug("Executing /backpack command for " + onlineProfile);
                 new Backpack(pluginMessage, onlineProfile);
             }

--- a/src/main/java/org/betonquest/betonquest/command/CancelQuestCommand.java
+++ b/src/main/java/org/betonquest/betonquest/command/CancelQuestCommand.java
@@ -1,9 +1,10 @@
 package org.betonquest.betonquest.command;
 
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.feature.Backpack;
 import org.betonquest.betonquest.feature.Backpack.DisplayType;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -33,7 +34,8 @@ public class CancelQuestCommand implements CommandExecutor {
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
         if ("cancelquest".equalsIgnoreCase(cmd.getName())) {
             if (sender instanceof Player) {
-                new Backpack(pluginMessage, PlayerConverter.getID((Player) sender), DisplayType.CANCEL);
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                new Backpack(pluginMessage, profileProvider.getProfile((Player) sender), DisplayType.CANCEL);
             }
             return true;
         }

--- a/src/main/java/org/betonquest/betonquest/command/CompassCommand.java
+++ b/src/main/java/org/betonquest/betonquest/command/CompassCommand.java
@@ -1,9 +1,10 @@
 package org.betonquest.betonquest.command;
 
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.feature.Backpack;
 import org.betonquest.betonquest.feature.Backpack.DisplayType;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -33,7 +34,8 @@ public class CompassCommand implements CommandExecutor {
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
         if ("compass".equalsIgnoreCase(cmd.getName())) {
             if (sender instanceof Player) {
-                new Backpack(pluginMessage, PlayerConverter.getID((Player) sender), DisplayType.COMPASS);
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                new Backpack(pluginMessage, profileProvider.getProfile((Player) sender), DisplayType.COMPASS);
             }
             return true;
         }

--- a/src/main/java/org/betonquest/betonquest/command/JournalCommand.java
+++ b/src/main/java/org/betonquest/betonquest/command/JournalCommand.java
@@ -1,7 +1,8 @@
 package org.betonquest.betonquest.command;
 
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.data.PlayerDataStorage;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -37,7 +38,8 @@ public class JournalCommand implements CommandExecutor {
             // command sender must be a player, console can't have journal
             if (sender instanceof Player) {
                 // giving the player his journal
-                dataStorage.get(PlayerConverter.getID((Player) sender)).getJournal().addToInv();
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                dataStorage.get(profileProvider.getProfile((Player) sender)).getJournal().addToInv();
             }
             return true;
         }

--- a/src/main/java/org/betonquest/betonquest/command/LangCommand.java
+++ b/src/main/java/org/betonquest/betonquest/command/LangCommand.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.command;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.config.PluginMessage;
@@ -10,7 +11,6 @@ import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.feature.journal.Journal;
 import org.betonquest.betonquest.notify.Notify;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -71,7 +71,8 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
         if (!(sender instanceof final Player player)) {
             return true;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final ProfileProvider profileProvider = betonQuest.getProfileProvider();
+        final OnlineProfile onlineProfile = profileProvider.getProfile(player);
         if (args.length == 0) {
             sender.sendMessage(pluginMessage.getMessage(onlineProfile, "language_missing"));
             return true;

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensConversationStarter.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/CitizensConversationStarter.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.compatibility.citizens.event.move.CitizensMoveController;
 import org.betonquest.betonquest.config.Config;
@@ -16,7 +17,6 @@ import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.conversation.CombatTagger;
 import org.betonquest.betonquest.id.ConversationID;
 import org.betonquest.betonquest.notify.Notify;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
@@ -33,6 +33,7 @@ import java.util.UUID;
 /**
  * Starts new conversations with Citizen NPCs.
  */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class CitizensConversationStarter {
     /**
      * The section in which the assignments from NPCs to conversations are stored.
@@ -154,7 +155,8 @@ public class CitizensConversationStarter {
         if (citizensMoveController.blocksTalking(npc)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getClicker());
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final OnlineProfile onlineProfile = profileProvider.getProfile(event.getClicker());
         if (CombatTagger.isTagged(onlineProfile)) {
 
             final String message = pluginMessage.getMessage(onlineProfile, "busy");

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/objective/NPCInteractObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/objective/NPCInteractObjective.java
@@ -7,10 +7,10 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.objective.EntityInteractObjective.Interaction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -82,7 +82,8 @@ public class NPCInteractObjective extends Objective implements Listener {
     }
 
     private void onNPCClick(final NPCClickEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getClicker());
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final OnlineProfile onlineProfile = profileProvider.getProfile(event.getClicker());
         if (event.getNPC().getId() != npcId || !containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/citizens/objective/NPCRangeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/citizens/objective/NPCRangeObjective.java
@@ -6,10 +6,10 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
@@ -119,19 +119,21 @@ public class NPCRangeObjective extends Objective {
 
     private void loop() throws QuestException {
         final List<UUID> profilesInside = new ArrayList<>();
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
         for (final int npcId : npcIds) {
             final NPC npc = CitizensAPI.getNPCRegistry().getById(npcId);
             if (npc == null) {
                 throw new QuestException("NPC with ID " + npcId + " does not exist");
             }
-            for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+            for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
                 if (!profilesInside.contains(onlineProfile.getProfileUUID()) && isInside(onlineProfile, npc.getStoredLocation())) {
                     profilesInside.add(onlineProfile.getProfileUUID());
                 }
             }
         }
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
-            checkPlayer(onlineProfile.getProfileUUID(), onlineProfile, profilesInside.contains(onlineProfile.getProfileUUID()));
+        for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
+            checkPlayer(onlineProfile.getProfileUUID(), onlineProfile,
+                    profilesInside.contains(onlineProfile.getProfileUUID()));
         }
     }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibRunnable.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibRunnable.java
@@ -7,10 +7,10 @@ import net.citizensnpcs.api.npc.NPC;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.compatibility.protocollib.hider.NPCHider;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
@@ -75,7 +75,8 @@ public class EffectLibRunnable extends BukkitRunnable {
 
     private List<OnlineProfile> checkActiveEffects() {
         final List<OnlineProfile> activePlayerEffects = new ArrayList<>();
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
             if (!BetonQuest.getInstance().getQuestTypeAPI().conditions(onlineProfile, effectConfiguration.conditions())) {
                 continue;
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/fabled/FabledKillListener.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/fabled/FabledKillListener.java
@@ -1,7 +1,8 @@
 package org.betonquest.betonquest.compatibility.fabled;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.MobKillNotifier;
-import org.betonquest.betonquest.util.PlayerConverter;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -35,6 +36,7 @@ public class FabledKillListener implements Listener {
         if (target.getHealth() > event.getDamage()) {
             return;
         }
-        MobKillNotifier.addKill(PlayerConverter.getID(player), target);
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        MobKillNotifier.addKill(profileProvider.getProfile(player), target);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesMobKillListener.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/heroes/HeroesMobKillListener.java
@@ -1,8 +1,8 @@
 package org.betonquest.betonquest.compatibility.heroes;
 
 import com.herocraftonline.heroes.api.events.HeroKillCharacterEvent;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.MobKillNotifier;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -25,6 +25,6 @@ public class HeroesMobKillListener implements Listener {
      */
     @EventHandler(ignoreCancelled = true)
     public void onHeroesKill(final HeroKillCharacterEvent event) {
-        MobKillNotifier.addKill(PlayerConverter.getID(event.getAttacker().getPlayer()), event.getDefender().getEntity());
+        MobKillNotifier.addKill(BetonQuest.getInstance().getProfileProvider().getProfile(event.getAttacker().getPlayer()), event.getDefender().getEntity());
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
@@ -4,11 +4,11 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.compatibility.HookException;
 import org.betonquest.betonquest.compatibility.Integrator;
 import org.betonquest.betonquest.compatibility.citizens.CitizensHologramLoop;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
@@ -210,7 +210,8 @@ public final class HologramProvider implements Integrator {
          */
         @EventHandler
         public void onPlayerJoin(final PlayerJoinEvent event) {
-            HologramRunner.refresh(PlayerConverter.getID(event.getPlayer()));
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            HologramRunner.refresh(profileProvider.getProfile(event.getPlayer()));
         }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramWrapper.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramWrapper.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.compatibility.holograms.lines.AbstractLine;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Location;
 
 import java.util.List;
@@ -49,7 +48,7 @@ public record HologramWrapper(int interval, List<BetonHologram> holograms, boole
             return;
         }
 
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        for (final OnlineProfile onlineProfile : BetonQuest.getInstance().getProfileProvider().getOnlineProfiles()) {
             updateVisibilityForPlayer(onlineProfile);
         }
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HologramPlaceholder.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HologramPlaceholder.java
@@ -1,11 +1,12 @@
 package org.betonquest.betonquest.compatibility.holograms.holographicdisplays;
 
 import me.filoghost.holographicdisplays.api.placeholder.IndividualPlaceholder;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,7 +46,8 @@ public class HologramPlaceholder implements IndividualPlaceholder {
         if (arguments == null) {
             return "";
         }
-        final Profile profile = PlayerConverter.getID(player);
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final Profile profile = profileProvider.getProfile(player);
         try {
             return variableProcessor.getValue(arguments, profile);
         } catch (final QuestException e) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveJoinJob.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveJoinJob.java
@@ -7,9 +7,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -37,7 +37,8 @@ public class ObjectiveJoinJob extends Objective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onJobsJoinEvent(final JobsJoinEvent event) {
         if (event.getJob().getName().equalsIgnoreCase(this.sJobName)) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer().getPlayer());
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            final OnlineProfile onlineProfile = profileProvider.getProfile(event.getPlayer().getPlayer());
             if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
                 completeObjective(onlineProfile);
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLeaveJob.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLeaveJob.java
@@ -7,9 +7,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -37,7 +37,8 @@ public class ObjectiveLeaveJob extends Objective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onJobsLeaveEvent(final JobsLeaveEvent event) {
         if (event.getJob().getName().equalsIgnoreCase(this.sJobName)) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer().getPlayer());
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            final OnlineProfile onlineProfile = profileProvider.getProfile(event.getPlayer().getPlayer());
             if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
                 completeObjective(onlineProfile);
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLevelUpEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectiveLevelUpEvent.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -36,7 +35,7 @@ public class ObjectiveLevelUpEvent extends Objective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onJobsLevelUpEvent(final JobsLevelUpEvent event) {
         if (event.getJobName().equalsIgnoreCase(this.sJobName)) {
-            final Profile profile = PlayerConverter.getID(event.getPlayer().getPlayer());
+            final Profile profile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer().getPlayer());
             if (containsPlayer(profile) && checkConditions(profile)) {
                 completeObjective(profile);
             }

--- a/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectivePaymentEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/ObjectivePaymentEvent.java
@@ -5,12 +5,12 @@ import com.gamingmesh.jobs.container.CurrencyType;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -31,7 +31,8 @@ public class ObjectivePaymentEvent extends Objective implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onJobsPaymentEvent(final JobsPaymentEvent event) {
-        final Profile profile = PlayerConverter.getID(event.getPlayer());
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final Profile profile = profileProvider.getProfile(event.getPlayer());
         if (containsPlayer(profile) && checkConditions(profile)) {
             final PaymentData playerData = getPaymentData(profile);
             final double previousAmount = playerData.amount;

--- a/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/luckperms/TagCalculatorUtils.java
@@ -3,7 +3,6 @@ package org.betonquest.betonquest.compatibility.luckperms;
 import net.luckperms.api.context.ContextCalculator;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.database.PlayerData;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public final class TagCalculatorUtils {
     public static ContextCalculator<Player> getTagContextCalculator() {
         return (player, contextConsumer) -> {
             if (player.isOnline()) {
-                final PlayerData data = BetonQuest.getInstance().getPlayerDataStorage().get(PlayerConverter.getID(player));
+                final PlayerData data = BetonQuest.getInstance().getPlayerDataStorage().get(BetonQuest.getInstance().getProfileProvider().getProfile(player));
                 data.getTags().forEach(tag -> contextConsumer.accept(KEY_LOCAL + tag, "true"));
             }
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/magic/MagicIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/magic/MagicIntegrator.java
@@ -4,7 +4,6 @@ import com.elmakers.mine.bukkit.api.event.SpellInventoryEvent;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.compatibility.Integrator;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -49,7 +48,7 @@ public class MagicIntegrator implements Integrator, Listener {
     @EventHandler(ignoreCancelled = true)
     public void onSpellInventoryEvent(final SpellInventoryEvent event) {
         if (!event.isOpening()) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(event.getMage().getPlayer());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getMage().getPlayer());
             plugin.getPlayerDataStorage().get(onlineProfile).getJournal().update();
         }
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mcmmo/MCMMOQuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mcmmo/MCMMOQuestItemHandler.java
@@ -2,8 +2,8 @@ package org.betonquest.betonquest.compatibility.mcmmo;
 
 import com.gmail.nossr50.events.skills.salvage.McMMOPlayerSalvageCheckEvent;
 import com.gmail.nossr50.events.skills.unarmed.McMMOPlayerDisarmEvent;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.feature.journal.Journal;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -31,7 +31,7 @@ public class MCMMOQuestItemHandler implements Listener {
     public void onQuestItemDisarm(final McMMOPlayerDisarmEvent event) {
         if (Utils.isQuestItem(event.getPlayer().getInventory().getItemInMainHand())) {
             event.setCancelled(true);
-        } else if (Journal.isJournal(PlayerConverter.getID(event.getPlayer()), event.getPlayer().getInventory().getItemInMainHand())) {
+        } else if (Journal.isJournal(BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer()), event.getPlayer().getInventory().getItemInMainHand())) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreBreakCustomBlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreBreakCustomBlockObjective.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -32,7 +31,7 @@ public class MMOCoreBreakCustomBlockObjective extends CountingObjective implemen
 
     @EventHandler(ignoreCancelled = true)
     public void onBlockBreak(final CustomBlockMineEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             final String blockId = getBlockId(event.getBlockInfo().getBlock());
             if (desiredBlockId.equals(blockId)) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreChangeClassObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreChangeClassObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -45,7 +44,7 @@ public class MMOCoreChangeClassObjective extends Objective implements Listener {
      */
     @EventHandler(ignoreCancelled = true)
     public void onClassChange(final PlayerChangeClassEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/MMOCoreProfessionObjective.java
@@ -9,7 +9,6 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -32,7 +31,7 @@ public class MMOCoreProfessionObjective extends Objective implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onLevelUp(final PlayerLevelUpEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsApplyGemObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsApplyGemObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -39,7 +38,7 @@ public class MMOItemsApplyGemObjective extends Objective implements Listener {
         if (!gemStone.getId().equals(gemID)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsCraftObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsCraftObjective.java
@@ -13,7 +13,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -50,7 +49,7 @@ public class MMOItemsCraftObjective extends CountingObjective implements Listene
      */
     @EventHandler
     public void onItemCraft(final CraftItemEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getWhoClicked());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getWhoClicked());
         final ItemStack craftedItem = event.getRecipe().getResult();
         if (event.getSlotType() == InventoryType.SlotType.RESULT
                 && containsPlayer(onlineProfile)
@@ -69,7 +68,7 @@ public class MMOItemsCraftObjective extends CountingObjective implements Listene
     public void onRecipeUse(final MythicCraftItemEvent event) {
         final HumanEntity humanEntity = event.getTrigger().getWhoClicked();
         final Player crafter = (Player) humanEntity;
-        final OnlineProfile onlineProfile = PlayerConverter.getID(crafter);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(crafter);
         final ItemStack craftedItem = event.getCache().getResultOfOperation().getResultInventory().getFirst();
 
         if (containsPlayer(onlineProfile)
@@ -86,7 +85,7 @@ public class MMOItemsCraftObjective extends CountingObjective implements Listene
      */
     @EventHandler(ignoreCancelled = true)
     public void onRecipeUse(final PlayerUseCraftingStationEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         final StationAction action = event.getInteraction();
         final Recipe usedRecipe = event.getRecipe();
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsUpgradeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOItemsUpgradeObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -33,7 +32,7 @@ public class MMOItemsUpgradeObjective extends Objective implements Listener {
         if (!upgradedItem.getId().equals(itemID) || !upgradedItem.getType().getId().equals(itemType)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -82,7 +81,7 @@ public class MythicLibSkillObjective extends Objective implements Listener {
             return;
         }
 
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobKillObjective.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.VariableString;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -102,7 +101,7 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
         if (deathRadiusAllPlayers > 0) {
             executeForEveryoneInRange(event, deathRadiusAllPlayers, key);
         } else if (event.getKiller() instanceof Player) {
-            checkKill(event, PlayerConverter.getID((Player) event.getKiller()), key);
+            checkKill(event, BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getKiller()), key);
         } else if (neutralDeathRadiusAllPlayers > 0) {
             executeForEveryoneInRange(event, neutralDeathRadiusAllPlayers, key);
         }
@@ -112,7 +111,7 @@ public class MythicMobKillObjective extends CountingObjective implements Listene
         final Location center = BukkitAdapter.adapt(event.getMob().getLocation());
         for (final Player player : center.getWorld().getPlayers()) {
             if (isValidPlayer(player) && player.getLocation().distanceSquared(center) <= range) {
-                checkKill(event, PlayerConverter.getID(player), key);
+                checkKill(event, BetonQuest.getInstance().getProfileProvider().getProfile(player), key);
             }
         }
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/placeholderapi/BetonQuestPlaceholder.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/placeholderapi/BetonQuestPlaceholder.java
@@ -2,11 +2,11 @@ package org.betonquest.betonquest.compatibility.placeholderapi;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -111,8 +111,11 @@ public class BetonQuestPlaceholder extends PlaceholderExpansion {
      */
     @Override
     public String onPlaceholderRequest(@Nullable final Player player, final String identifier) {
-        final Profile profile = player == null ? null : PlayerConverter.getID(player);
         try {
+            if (player == null) {
+                return variableProcessor.getValue(identifier, null);
+            }
+            final Profile profile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             return variableProcessor.getValue(identifier, profile);
         } catch (final QuestException e) {
             log.warn("Could not parse through PAPI requested variable: " + identifier, e);

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
@@ -11,8 +11,8 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.papermc.lib.PaperLib;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -241,7 +241,7 @@ public class EntityHider implements Listener {
                     final int index = event.getPacketType().equals(PacketType.Play.Server.PLAYER_COMBAT_KILL) ? 1 : 0;
 
                     final Integer entityID = event.getPacket().getIntegers().readSafely(index);
-                    if (entityID != null && !isVisible(PlayerConverter.getID(event.getPlayer()), entityID)) {
+                    if (entityID != null && !isVisible(BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer()), entityID)) {
                         event.setCancelled(true);
                     }
                 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/MythicHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/MythicHider.java
@@ -4,7 +4,6 @@ import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
 import io.lumine.mythic.bukkit.events.MythicMobDespawnEvent;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
@@ -76,7 +75,7 @@ public final class MythicHider extends BukkitRunnable implements Listener {
      * Updates the visibility of tracked mobs for all players.
      */
     public void applyVisibility() {
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        for (final OnlineProfile onlineProfile : BetonQuest.getInstance().getProfileProvider().getOnlineProfiles()) {
             for (final Entity mob : mythicmobs.keySet()) {
                 applyVisibility(onlineProfile, mob);
             }
@@ -115,7 +114,7 @@ public final class MythicHider extends BukkitRunnable implements Listener {
      * @param mythicMob the mob to update the visibility for
      */
     public void applyVisibility(final Entity mythicMob) {
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        for (final OnlineProfile onlineProfile : BetonQuest.getInstance().getProfileProvider().getOnlineProfiles()) {
             applyVisibility(onlineProfile, mythicMob);
         }
     }
@@ -130,7 +129,7 @@ public final class MythicHider extends BukkitRunnable implements Listener {
         final Set<UUID> profileUUIDS = new HashSet<>();
         profileUUIDS.add(onlineProfile.getProfileUUID());
         mythicmobs.put(mythicMob, profileUUIDS);
-        for (final OnlineProfile onlinePlayer : PlayerConverter.getOnlineProfiles()) { //Hiding the mob for all players besides passed in online
+        for (final OnlineProfile onlinePlayer : BetonQuest.getInstance().getProfileProvider().getOnlineProfiles()) { // Hiding the mob for all players besides passed in online
             if (!onlinePlayer.equals(onlineProfile)) {
                 applyVisibility(onlinePlayer, mythicMob);
             }
@@ -155,7 +154,7 @@ public final class MythicHider extends BukkitRunnable implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerJoin(final PlayerJoinEvent event) {
-        applyVisibility(PlayerConverter.getID(event.getPlayer()));
+        applyVisibility(BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer()));
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/NPCHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/NPCHider.java
@@ -8,10 +8,10 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.id.ConditionID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
@@ -187,7 +187,8 @@ public final class NPCHider extends BukkitRunnable implements Listener {
         if (!npcID.getOwningRegistry().equals(CitizensAPI.getNPCRegistry())) {
             return;
         }
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
             applyVisibility(onlineProfile, npcID.getId());
         }
     }
@@ -196,7 +197,8 @@ public final class NPCHider extends BukkitRunnable implements Listener {
      * Updates the visibility of all NPCs for all onlineProfiles.
      */
     public void applyVisibility() {
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
             for (final Integer npcID : npcs.keySet()) {
                 applyVisibility(onlineProfile, npcID);
             }
@@ -221,6 +223,7 @@ public final class NPCHider extends BukkitRunnable implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerJoin(final PlayerJoinEvent event) {
-        Bukkit.getScheduler().runTask(BetonQuest.getInstance(), () -> applyVisibility(PlayerConverter.getID(event.getPlayer())));
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        Bukkit.getScheduler().runTask(BetonQuest.getInstance(), () -> applyVisibility(profileProvider.getProfile(event.getPlayer())));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/quests/ConditionRequirement.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/quests/ConditionRequirement.java
@@ -1,12 +1,12 @@
 package org.betonquest.betonquest.compatibility.quests;
 
 import me.pikamug.quests.module.BukkitCustomRequirement;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.id.ConditionID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -57,7 +57,7 @@ public class ConditionRequirement extends BukkitCustomRequirement {
                 log.warn("Error while running quest reward - Player with UUID '" + uuid + "' not found.");
                 return false;
             }
-            final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             final ConditionID condition = new ConditionID(null, string);
             return questTypeAPI.condition(onlineProfile, condition);
         } catch (final QuestException e) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/quests/EventReward.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/quests/EventReward.java
@@ -1,12 +1,12 @@
 package org.betonquest.betonquest.compatibility.quests;
 
 import me.pikamug.quests.module.BukkitCustomReward;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.id.EventID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -57,7 +57,7 @@ public class EventReward extends BukkitCustomReward {
                 log.warn("Error while running quest reward - Player with UUID '" + uuid + "' not found.");
                 return;
             }
-            final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             final EventID event = new EventID(null, string);
             questTypeAPI.event(onlineProfile, event);
         } catch (final QuestException e) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptConditionBQ.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptConditionBQ.java
@@ -7,9 +7,9 @@ import ch.njol.util.Kleenean;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.ConditionID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -51,7 +51,8 @@ public class SkriptConditionBQ extends Condition {
     public boolean check(final Event event) {
         final String conditionID = condition.getSingle(event);
         try {
-            return BetonQuest.getInstance().getQuestTypeAPI().condition(PlayerConverter.getID(player.getSingle(event)), new ConditionID(null, conditionID));
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            return BetonQuest.getInstance().getQuestTypeAPI().condition(profileProvider.getProfile(player.getSingle(event)), new ConditionID(null, conditionID));
         } catch (final QuestException e) {
             log.warn("Error while checking Skript condition - could not load condition with ID '" + conditionID + "': " + e.getMessage(), e);
             return false;

--- a/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptEffectBQ.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptEffectBQ.java
@@ -7,9 +7,9 @@ import ch.njol.util.Kleenean;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.EventID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -55,7 +55,8 @@ public class SkriptEffectBQ extends Effect {
             public void run() {
                 final String eventID = SkriptEffectBQ.this.event.getSingle(event);
                 try {
-                    BetonQuest.getInstance().getQuestTypeAPI().event(PlayerConverter.getID(player.getSingle(event)), new EventID(null, eventID));
+                    final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                    BetonQuest.getInstance().getQuestTypeAPI().event(profileProvider.getProfile(player.getSingle(event)), new EventID(null, eventID));
                 } catch (final QuestException e) {
                     log.warn("Error when running Skript event - could not load '" + eventID + "' event: " + e.getMessage(), e);
                 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
@@ -10,7 +10,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.compatibility.traincarts.TrainCartsUtils;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableString;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -53,7 +52,7 @@ public class TrainCartsExitObjective extends Objective implements Listener {
         if (!(event.getEntity() instanceof final Player player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsRideObjective.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsRideObjective.java
@@ -13,7 +13,6 @@ import org.betonquest.betonquest.compatibility.traincarts.TrainCartsUtils;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableString;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -81,7 +80,7 @@ public class TrainCartsRideObjective extends CountingObjective implements Listen
         if (!(event.getEntity() instanceof final Player player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return;
         }
@@ -101,7 +100,7 @@ public class TrainCartsRideObjective extends CountingObjective implements Listen
         if (!(event.getEntity() instanceof final Player player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         stopCount(onlineProfile);
     }
 
@@ -112,7 +111,7 @@ public class TrainCartsRideObjective extends CountingObjective implements Listen
      */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onQuit(final PlayerQuitEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         stopCount(onlineProfile);
     }
 
@@ -127,7 +126,7 @@ public class TrainCartsRideObjective extends CountingObjective implements Listen
         while (!startTimes.isEmpty()) {
             final Player player = Bukkit.getPlayer(startTimes.keySet().iterator().next());
             if (player != null) {
-                final OnlineProfile profile = PlayerConverter.getID(player);
+                final OnlineProfile profile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
                 stopCount(profile);
             }
         }

--- a/src/main/java/org/betonquest/betonquest/conversation/CombatTagger.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/CombatTagger.java
@@ -3,7 +3,6 @@ package org.betonquest.betonquest.conversation;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -61,10 +60,10 @@ public class CombatTagger implements Listener {
     public void onDamage(final EntityDamageByEntityEvent event) {
         final List<Profile> profiles = new ArrayList<>();
         if (event.getEntity() instanceof Player) {
-            profiles.add(PlayerConverter.getID((Player) event.getEntity()));
+            profiles.add(BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getEntity()));
         }
         if (event.getDamager() instanceof Player) {
-            profiles.add(PlayerConverter.getID((Player) event.getDamager()));
+            profiles.add(BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getDamager()));
         }
         for (final Profile profile : profiles) {
             final BukkitRunnable run = TAGGERS.get(profile);
@@ -88,7 +87,7 @@ public class CombatTagger implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDeath(final PlayerDeathEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getEntity());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getEntity());
         final BukkitRunnable runnable = TAGGERS.remove(onlineProfile);
         if (runnable != null) {
             runnable.cancel();

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -11,6 +11,7 @@ import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.config.PluginMessage;
@@ -23,7 +24,6 @@ import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.id.ConversationID;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.notify.Notify;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -483,9 +483,10 @@ public class Conversation implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onDamage(final EntityDamageByEntityEvent event) {
         // prevent damage to (or from) player while in conversation
-        if (event.getEntity() instanceof Player && PlayerConverter.getID((Player) event.getEntity()).equals(onlineProfile)
-                || event.getDamager() instanceof Player
-                && PlayerConverter.getID((Player) event.getDamager()).equals(onlineProfile)) {
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        if (event.getEntity() instanceof Player && profileProvider.getProfile((Player) event.getEntity()).equals(onlineProfile)
+            || event.getDamager() instanceof Player
+            && profileProvider.getProfile((Player) event.getDamager()).equals(onlineProfile)) {
             event.setCancelled(true);
         }
     }
@@ -722,7 +723,8 @@ public class Conversation implements Listener {
                 }
 
                 printNPCText();
-                final ConversationOptionEvent optionEvent = new ConversationOptionEvent(PlayerConverter.getID(player), conv, nextNPCOption, conv.nextNPCOption);
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                final ConversationOptionEvent optionEvent = new ConversationOptionEvent(profileProvider.getProfile(player), conv, nextNPCOption, conv.nextNPCOption);
 
                 new BukkitRunnable() {
 
@@ -835,7 +837,8 @@ public class Conversation implements Listener {
                 selectOption(resolvePointers(playerOption), false);
                 printNPCText();
 
-                final ConversationOptionEvent event = new ConversationOptionEvent(PlayerConverter.getID(player), conv, playerOption, conv.nextNPCOption);
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                final ConversationOptionEvent event = new ConversationOptionEvent(profileProvider.getProfile(player), conv, playerOption, conv.nextNPCOption);
 
                 new BukkitRunnable() {
                     @Override

--- a/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
@@ -5,8 +5,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.ConfigurationFile;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.util.LocalChatPaginator;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -145,7 +146,8 @@ public class InventoryConvIO implements Listener, ConversationIO {
             Bukkit.getScheduler().runTask(BetonQuest.getInstance(), () -> player.closeInventory());
             final Interceptor interceptor = conv.getInterceptor();
             if (interceptor != null) {
-                interceptor.sendMessage(BetonQuest.getInstance().getPluginMessage().getMessage(PlayerConverter.getID(player), "conversation_spectator"));
+                final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+                interceptor.sendMessage(BetonQuest.getInstance().getPluginMessage().getMessage(profileProvider.getProfile(player), "conversation_spectator"));
             }
             return;
         }
@@ -361,7 +363,8 @@ public class InventoryConvIO implements Listener, ConversationIO {
 
     @EventHandler
     public void onConsume(final PlayerItemConsumeEvent event) {
-        if (Conversation.containsPlayer(PlayerConverter.getID(event.getPlayer()))) {
+        final Profile profile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
+        if (Conversation.containsPlayer(profile)) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
+++ b/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
@@ -58,7 +58,7 @@ public class PlayerDataStorage {
     public void initProfiles(final Collection<OnlineProfile> onlineProfiles) {
         for (final OnlineProfile onlineProfile : onlineProfiles) {
             final PlayerData playerData = new PlayerData(pluginMessage, onlineProfile);
-            playerDataMap.put(onlineProfile, playerData);
+            put(onlineProfile, playerData);
             playerData.startObjectives();
             playerData.getJournal().update();
             if (playerData.getActiveConversation() != null) {
@@ -122,7 +122,9 @@ public class PlayerDataStorage {
      * @throws IllegalArgumentException when there is no data and the player is offline
      */
     public PlayerData get(final Profile profile) {
+        log.debug("get: " + profile.getProfileName() + " " + profile.getProfileUUID() + " " + profile.getPlayer().getName());
         PlayerData playerData = playerDataMap.get(profile);
+        log.debug("playerData loaded: " + playerData);
         if (playerData == null) {
             if (profile.getOnlineProfile().isPresent()) {
                 playerData = new PlayerData(pluginMessage, profile);

--- a/src/main/java/org/betonquest/betonquest/database/PlayerData.java
+++ b/src/main/java/org/betonquest/betonquest/database/PlayerData.java
@@ -88,6 +88,7 @@ public class PlayerData implements TagData {
         this.pluginMessage = pluginMessage;
         this.profile = profile;
         this.profileID = profile.getProfileUUID().toString();
+        BetonQuest.getInstance().getLogger().info("Loading player data for " + profile.getProfileUUID().toString());
         loadAllPlayerData();
     }
 
@@ -105,7 +106,8 @@ public class PlayerData implements TagData {
                  ResultSet journalResults = con.querySQL(QueryType.SELECT_JOURNAL, profileID);
                  ResultSet pointResults = con.querySQL(QueryType.SELECT_POINTS, profileID);
                  ResultSet backpackResults = con.querySQL(QueryType.SELECT_BACKPACK, profileID);
-                 ResultSet profileResult = con.querySQL(QueryType.SELECT_PLAYER, profileID)) {
+                 ResultSet profileResult = con.querySQL(QueryType.SELECT_PLAYER_PROFILE, profileID);
+                 ResultSet playerResult = con.querySQL(QueryType.SELECT_PLAYER, profile.getPlayerUUID().toString())) {
 
                 while (objectiveResults.next()) {
                     objectives.put(objectiveResults.getString("objective"), objectiveResults.getString("instructions"));
@@ -128,8 +130,8 @@ public class PlayerData implements TagData {
                 }
 
                 if (profileResult.next()) {
-                    loadLanguage(profileResult);
-                    loadActiveConversation(profileResult);
+                    loadLanguage(playerResult);
+                    loadActiveConversation(playerResult);
                 } else {
                     setupProfile();
                 }
@@ -169,7 +171,7 @@ public class PlayerData implements TagData {
         saver.add(new Record(UpdateType.ADD_PLAYER, profile.getPlayer().getUniqueId().toString(),
                 profileID, "default"));
         saver.add(new Record(UpdateType.ADD_PLAYER_PROFILE, profile.getPlayer().getUniqueId().toString(),
-                profileID, BetonQuest.getInstance().getPluginConfig().getString("profiles.initial_name", "default")));
+                profileID, profile.getProfileName()));
     }
 
     private void addItemToBackpack(final ResultSet backpackResults) throws SQLException {

--- a/src/main/java/org/betonquest/betonquest/database/QueryType.java
+++ b/src/main/java/org/betonquest/betonquest/database/QueryType.java
@@ -14,6 +14,7 @@ public enum QueryType {
     SELECT_JOURNAL(prefix -> "SELECT pointer, date FROM " + prefix + "journal WHERE profileID = ?;"),
     SELECT_BACKPACK(prefix -> "SELECT instruction, amount FROM " + prefix + "backpack WHERE profileID = ?;"),
     SELECT_PLAYER(prefix -> "SELECT language, conversation FROM " + prefix + "player WHERE playerID = ?;"),
+    SELECT_PLAYER_PROFILE(prefix -> "SELECT name FROM " + prefix + "player_profile WHERE profileID = ?;"),
 
     SELECT_PLAYERS_TAGS(prefix -> "SELECT profileID FROM " + prefix + "tags GROUP BY profileID;"),
     SELECT_PLAYERS_JOURNAL(prefix -> "SELECT profileID FROM " + prefix + "journal GROUP BY profileID;"),

--- a/src/main/java/org/betonquest/betonquest/database/UpdateType.java
+++ b/src/main/java/org/betonquest/betonquest/database/UpdateType.java
@@ -41,7 +41,7 @@ public enum UpdateType {
     /**
      * Add single player to the database. PlayerID, active_profile, language.
      */
-    ADD_PLAYER(prefix -> "INSERT INTO " + prefix + "player (playerID, active_profile, language) VALUES (?, ?, ?);"),
+    ADD_PLAYER(prefix -> "INSERT OR IGNORE INTO " + prefix + "player (playerID, active_profile, language) VALUES (?, ?, ?);"),
     /**
      * Add single profile to the database. ProfileID.
      */

--- a/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/QuestItemHandler.java
@@ -1,10 +1,11 @@
 package org.betonquest.betonquest.item;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.feature.journal.Journal;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -40,7 +41,7 @@ import java.util.ListIterator;
 /**
  * Handler for Journals.
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods", "PMD.CommentRequired", "PMD.CyclomaticComplexity"})
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods", "PMD.CommentRequired", "PMD.CyclomaticComplexity", "PMD.CouplingBetweenObjects"})
 public class QuestItemHandler implements Listener {
     /**
      * Storage for player data.
@@ -61,7 +62,8 @@ public class QuestItemHandler implements Listener {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final OnlineProfile onlineProfile = profileProvider.getProfile(event.getPlayer());
         final ItemStack item = event.getItemDrop().getItemStack();
         if (Journal.isJournal(onlineProfile, item)) {
             if (isJournalSlotLocked()) {
@@ -84,7 +86,7 @@ public class QuestItemHandler implements Listener {
         if (event.getWhoClicked().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getWhoClicked());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getWhoClicked());
         ItemStack item = null;
         switch (event.getAction()) {
             case PICKUP_ALL:
@@ -150,7 +152,7 @@ public class QuestItemHandler implements Listener {
         if (event.getWhoClicked().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getWhoClicked());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getWhoClicked());
         if (Journal.isJournal(onlineProfile, event.getOldCursor()) || Utils.isQuestItem(event.getOldCursor())) {
             event.setCancelled(true);
         }
@@ -162,7 +164,7 @@ public class QuestItemHandler implements Listener {
             return;
         }
         final ItemStack item = event.getPlayerItem();
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (Journal.isJournal(onlineProfile, item) || Utils.isQuestItem(item)) {
             event.setCancelled(true);
         }
@@ -173,7 +175,7 @@ public class QuestItemHandler implements Listener {
         if (event.getEntity().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getEntity());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getEntity());
         // check if there is data for this player; NPCs don't have data
         if (onlineProfile.getOnlineProfile().isEmpty()) {
             return;
@@ -213,7 +215,7 @@ public class QuestItemHandler implements Listener {
             }
         }
         if (Boolean.parseBoolean(Config.getConfigString("journal.give_on_respawn"))) {
-            dataStorage.get(PlayerConverter.getID(event.getPlayer())).getJournal().addToInv();
+            dataStorage.get(BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer())).getJournal().addToInv();
         }
     }
 
@@ -227,7 +229,7 @@ public class QuestItemHandler implements Listener {
             final ItemStack item = (event.getHand() == EquipmentSlot.HAND) ? event.getPlayer().getInventory().getItemInMainHand()
                     : event.getPlayer().getInventory().getItemInOffHand();
 
-            final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
             if (Journal.isJournal(onlineProfile, item) || Utils.isQuestItem(item)) {
                 event.setCancelled(true);
             }
@@ -279,7 +281,8 @@ public class QuestItemHandler implements Listener {
             return;
         }
         if (item.getType() == Material.WRITTEN_BOOK) {
-            if (Utils.isQuestItem(item) || Journal.isJournal(PlayerConverter.getID(event.getPlayer()), item)) {
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            if (Utils.isQuestItem(item) || Journal.isJournal(profileProvider.getProfile(event.getPlayer()), item)) {
                 event.setUseInteractedBlock(Event.Result.DENY);
             }
         } else if (!EnchantmentTarget.TOOL.includes(item.getType()) && Utils.isQuestItem(item)) {
@@ -313,7 +316,7 @@ public class QuestItemHandler implements Listener {
         if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (isJournalSlotLocked() && (Journal.isJournal(onlineProfile, event.getMainHandItem())
                 || Journal.isJournal(onlineProfile, event.getOffHandItem()))) {
             event.setCancelled(true);

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/HeadHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/HeadHandler.java
@@ -4,7 +4,6 @@ import io.papermc.lib.PaperLib;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -173,7 +172,7 @@ public abstract class HeadHandler implements ItemMetaHandler<SkullMeta> {
         }
         if (owner != null) {
             final OfflinePlayer player = Bukkit.getOfflinePlayer(owner);
-            return PlayerConverter.getID(player);
+            return BetonQuest.getInstance().getProfileProvider().getProfile(player);
         }
         return null;
     }

--- a/src/main/java/org/betonquest/betonquest/listener/JoinQuitListener.java
+++ b/src/main/java/org/betonquest/betonquest/listener/JoinQuitListener.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.listener;
 
 import io.papermc.lib.PaperLib;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.GlobalObjectives;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
@@ -14,7 +15,6 @@ import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.feature.journal.Journal;
 import org.betonquest.betonquest.objective.ResourcePackObjective;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -75,7 +75,7 @@ public class JoinQuitListener implements Listener {
         if (event.getLoginResult() != Result.ALLOWED) {
             return;
         }
-        final Profile profile = PlayerConverter.getID(Bukkit.getOfflinePlayer(event.getUniqueId()));
+        final Profile profile = BetonQuest.getInstance().getProfileProvider().getProfile(Bukkit.getOfflinePlayer(event.getUniqueId()));
         playerDataStorage.put(profile, new PlayerData(pluginMessage, profile));
     }
 
@@ -86,7 +86,7 @@ public class JoinQuitListener implements Listener {
      */
     @EventHandler(ignoreCancelled = true)
     public void onPlayerJoin(final PlayerJoinEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         final PlayerData playerData = playerDataStorage.get(onlineProfile);
         playerData.startObjectives();
         GlobalObjectives.startAll(onlineProfile, playerDataStorage);
@@ -120,7 +120,7 @@ public class JoinQuitListener implements Listener {
      */
     @EventHandler
     public void onPlayerQuit(final PlayerQuitEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         for (final Objective objective : questTypeAPI.getPlayerObjectives(onlineProfile)) {
             objective.pauseObjectiveForPlayer(onlineProfile);
         }

--- a/src/main/java/org/betonquest/betonquest/listener/MobKillListener.java
+++ b/src/main/java/org/betonquest/betonquest/listener/MobKillListener.java
@@ -1,7 +1,8 @@
 package org.betonquest.betonquest.listener;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.MobKillNotifier;
-import org.betonquest.betonquest.util.PlayerConverter;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,8 +22,9 @@ public class MobKillListener implements Listener {
     public void onKill(final EntityDeathEvent event) {
         final LivingEntity entity = event.getEntity();
         final Player killer = entity.getKiller();
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
         if (killer != null) {
-            MobKillNotifier.addKill(PlayerConverter.getID(killer), entity);
+            MobKillNotifier.addKill(profileProvider.getProfile(killer), entity);
         }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/menu/Menu.java
+++ b/src/main/java/org/betonquest/betonquest/menu/Menu.java
@@ -6,6 +6,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.id.EventID;
@@ -14,7 +15,6 @@ import org.betonquest.betonquest.instruction.variable.VariableString;
 import org.betonquest.betonquest.item.QuestItem;
 import org.betonquest.betonquest.menu.command.SimpleCommand;
 import org.betonquest.betonquest.menu.config.SimpleYMLSection;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -248,7 +248,7 @@ public class Menu extends SimpleYMLSection implements Listener {
             return;
         }
         event.setCancelled(true);
-        final OnlineProfile onlineprofile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineprofile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!mayOpen(onlineprofile)) {
             rpgMenu.getConfiguration().sendMessage(event.getPlayer(), "menu_do_not_open");
             return;
@@ -280,7 +280,8 @@ public class Menu extends SimpleYMLSection implements Listener {
     public void runCloseEvents(final Player player) {
         log.debug(pack, "Menu " + menuID + ": Running close events");
         for (final EventID event : this.closeEvents) {
-            BetonQuest.getInstance().getQuestTypeAPI().event(PlayerConverter.getID(player), event);
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            BetonQuest.getInstance().getQuestTypeAPI().event(profileProvider.getProfile(player), event);
             log.debug(pack, "Menu " + menuID + ": Run event " + event);
         }
     }
@@ -365,7 +366,7 @@ public class Menu extends SimpleYMLSection implements Listener {
                 sender.sendMessage("Command can only be run by players!");
                 return false;
             }
-            final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             if (mayOpen(onlineProfile)) {
                 log.debug(pack, onlineProfile + " run bound command of " + menuID);
                 rpgMenu.openMenu(onlineProfile, menuID);

--- a/src/main/java/org/betonquest/betonquest/menu/MenuItem.java
+++ b/src/main/java/org/betonquest/betonquest/menu/MenuItem.java
@@ -13,7 +13,6 @@ import org.betonquest.betonquest.id.ItemID;
 import org.betonquest.betonquest.instruction.Item;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.menu.config.SimpleYMLSection;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -176,7 +175,7 @@ public class MenuItem extends SimpleYMLSection {
     }
 
     private boolean executeEvents(final List<EventID> variables, final Player player) {
-        final OnlineProfile profile = PlayerConverter.getID(player);
+        final OnlineProfile profile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         for (final EventID eventID : variables) {
             log.debug(pack, "Item " + name + ": Run event " + eventID);
             BetonQuest.getInstance().getQuestTypeAPI().event(profile, eventID);

--- a/src/main/java/org/betonquest/betonquest/menu/command/RPGMenuCommand.java
+++ b/src/main/java/org/betonquest/betonquest/menu/command/RPGMenuCommand.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.quest.QuestException;
@@ -12,7 +13,6 @@ import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.menu.MenuID;
 import org.betonquest.betonquest.menu.RPGMenu;
 import org.betonquest.betonquest.menu.config.RPGMenuConfig;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -159,8 +159,8 @@ public class RPGMenuCommand extends SimpleCommand {
                     this.menu.getConfiguration().sendMessage(sender, "command_no_menu");
                     return false;
                 }
-                //open the menu and send feedback
-                this.menu.openMenu(PlayerConverter.getID(player), menu);
+                // open the menu and send feedback
+                this.menu.openMenu(BetonQuest.getInstance().getProfileProvider().getProfile(player), menu);
                 this.menu.getConfiguration().sendMessage(sender, "command_open_successful", menu.toString());
                 break;
             case "reload":

--- a/src/main/java/org/betonquest/betonquest/menu/config/RPGMenuConfig.java
+++ b/src/main/java/org/betonquest/betonquest/menu/config/RPGMenuConfig.java
@@ -3,7 +3,6 @@ package org.betonquest.betonquest.menu.config;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.config.Config;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -111,7 +110,7 @@ public class RPGMenuConfig extends SimpleYMLSection {
     public String getMessage(final CommandSender sender, final String key, final String... replace) {
         String lang = null;
         if (sender instanceof Player) {
-            lang = BetonQuest.getInstance().getPlayerDataStorage().get(PlayerConverter.getID((Player) sender)).getLanguage();
+            lang = BetonQuest.getInstance().getPlayerDataStorage().get(BetonQuest.getInstance().getProfileProvider().getProfile((Player) sender)).getLanguage();
         }
         return getMessage(lang, key, replace);
     }

--- a/src/main/java/org/betonquest/betonquest/notify/NotifyIO.java
+++ b/src/main/java/org/betonquest/betonquest/notify/NotifyIO.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.notify;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +39,8 @@ public abstract class NotifyIO {
     }
 
     public void sendNotify(final String message) throws QuestException {
-        for (final OnlineProfile onlineProfile : PlayerConverter.getOnlineProfiles()) {
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        for (final OnlineProfile onlineProfile : profileProvider.getOnlineProfiles()) {
             sendNotify(message, onlineProfile);
         }
     }
@@ -69,8 +70,9 @@ public abstract class NotifyIO {
         if (dataString == null) {
             return defaultData;
         }
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
         return new VariableNumber(BetonQuest.getInstance().getVariableProcessor(), pack, dataString)
-                .getValue(PlayerConverter.getID(player)).floatValue();
+                .getValue(profileProvider.getProfile(player)).floatValue();
     }
 
     protected final int getIntegerData(final String dataKey, final int defaultData) throws QuestException {

--- a/src/main/java/org/betonquest/betonquest/objective/AbstractLocationObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/AbstractLocationObjective.java
@@ -1,11 +1,11 @@
 package org.betonquest.betonquest.objective;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -87,7 +87,7 @@ public abstract class AbstractLocationObjective extends Objective implements Lis
      */
     @EventHandler(ignoreCancelled = true)
     public void onPlayerQuit(final PlayerQuitEvent event) {
-        playersInsideRegion.remove(PlayerConverter.getID(event.getPlayer()).getProfileUUID());
+        playersInsideRegion.remove(BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer()).getProfileUUID());
     }
 
     /**
@@ -146,7 +146,7 @@ public abstract class AbstractLocationObjective extends Objective implements Lis
     }
 
     private void checkLocation(final Player player, final Location location) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/ActionObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ActionObjective.java
@@ -10,7 +10,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.util.BlockSelector;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -97,7 +96,7 @@ public class ActionObjective extends Objective implements Listener {
     @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     @EventHandler(priority = EventPriority.LOWEST)
     public void onInteract(final PlayerInteractEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || !action.match(event.getAction()) || slot != null && slot != event.getHand()) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/ArrowShootObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ArrowShootObjective.java
@@ -9,7 +9,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
@@ -52,7 +51,7 @@ public class ArrowShootObjective extends Objective implements Listener {
         if (!(arrow.getShooter() instanceof final Player player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/BlockObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/BlockObjective.java
@@ -10,7 +10,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.util.BlockSelector;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
@@ -81,7 +80,7 @@ public class BlockObjective extends CountingObjective implements Listener {
         if (event.isCancelled() && !ignorecancel) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && selector.match(event.getBlock(), exactMatch) && checkConditions(onlineProfile)) {
             if (!checkLocation(event.getBlock().getLocation(), onlineProfile)) {
                 return;
@@ -98,7 +97,7 @@ public class BlockObjective extends CountingObjective implements Listener {
         if (event.isCancelled() && !ignorecancel) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && selector.match(event.getBlock(), exactMatch) && checkConditions(onlineProfile)) {
             if (!checkLocation(event.getBlock().getLocation(), onlineProfile)) {
                 return;

--- a/src/main/java/org/betonquest/betonquest/objective/BreedObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/BreedObjective.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -29,7 +28,7 @@ public class BreedObjective extends CountingObjective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBreeding(final EntityBreedEvent event) {
         if (event.getEntityType() == type && event.getBreeder() instanceof Player) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getBreeder());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getBreeder());
             if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
                 getCountingData(onlineProfile).progress();
                 completeIfDoneOrNotify(onlineProfile);

--- a/src/main/java/org/betonquest/betonquest/objective/BrewObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/BrewObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.item.QuestItem;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.BrewingStand;
@@ -47,7 +46,7 @@ public class BrewObjective extends CountingObjective implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onIngredientPut(final InventoryClickEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getWhoClicked());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getWhoClicked());
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/ChestPutObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ChestPutObjective.java
@@ -14,7 +14,6 @@ import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.notify.Notify;
 import org.betonquest.betonquest.quest.condition.chest.ChestItemCondition;
 import org.betonquest.betonquest.quest.event.chest.ChestTakeEvent;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -79,7 +78,7 @@ public class ChestPutObjective extends Objective implements Listener {
      */
     @EventHandler
     public void onChestOpen(final InventoryOpenEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getPlayer());
         try {
             if (!checkIsInventory(loc.getValue(onlineProfile))) {
                 return;
@@ -115,7 +114,7 @@ public class ChestPutObjective extends Objective implements Listener {
         if (!(event.getPlayer() instanceof Player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getPlayer());
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/CommandObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/CommandObjective.java
@@ -10,7 +10,6 @@ import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableString;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -47,7 +46,7 @@ public class CommandObjective extends Objective implements Listener {
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
     @EventHandler(priority = EventPriority.LOWEST)
     public void onCommand(final PlayerCommandPreprocessEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             final String replaceCommand = command.getString(onlineProfile);
             if (foundMatch(event.getMessage(), replaceCommand)) {

--- a/src/main/java/org/betonquest/betonquest/objective/ConsumeObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ConsumeObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.item.QuestItem;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -49,7 +48,7 @@ public class ConsumeObjective extends CountingObjective implements Listener {
      */
     @EventHandler(ignoreCancelled = true)
     public void onConsume(final PlayerItemConsumeEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && item.compare(event.getItem()) && checkConditions(onlineProfile)) {
             getCountingData(onlineProfile).progress();
             completeIfDoneOrNotify(onlineProfile);

--- a/src/main/java/org/betonquest/betonquest/objective/CraftingObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/CraftingObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.item.QuestItem;
 import org.betonquest.betonquest.util.InventoryUtils;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -52,7 +51,7 @@ public class CraftingObjective extends CountingObjective implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCrafting(final CraftItemEvent event) {
         if (event.getWhoClicked() instanceof final Player player) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             if (containsPlayer(onlineProfile) && item.compare(event.getInventory().getResult()) && checkConditions(onlineProfile)) {
                 getCountingData(onlineProfile).progress(calculateCraftAmount(event));
                 completeIfDoneOrNotify(onlineProfile);

--- a/src/main/java/org/betonquest/betonquest/objective/DieObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/DieObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
@@ -54,7 +53,7 @@ public class DieObjective extends Objective implements Listener {
             return;
         }
         if (event.getEntity() instanceof final Player player) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
             if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
                 completeObjective(onlineProfile);
             }
@@ -66,7 +65,7 @@ public class DieObjective extends Objective implements Listener {
         if (cancel || location == null) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             getLocation(onlineProfile).ifPresent(event::setRespawnLocation);
             completeObjective(onlineProfile);
@@ -78,7 +77,7 @@ public class DieObjective extends Objective implements Listener {
         if (!cancel || !(event.getEntity() instanceof final Player player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (containsPlayer(onlineProfile) && player.getHealth() - event.getFinalDamage() <= 0
                 && checkConditions(onlineProfile)) {
             event.setCancelled(true);

--- a/src/main/java/org/betonquest/betonquest/objective/EnchantObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/EnchantObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.item.QuestItem;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.EventHandler;
@@ -46,7 +45,7 @@ public class EnchantObjective extends CountingObjective implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onEnchant(final EnchantItemEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getEnchanter());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getEnchanter());
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/EntityInteractObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/EntityInteractObjective.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.VariableString;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -147,7 +146,7 @@ public class EntityInteractObjective extends CountingObjective {
         }
         // check if the entity is correctly marked
         if (marked != null) {
-            final String value = marked.getString(PlayerConverter.getID(player));
+            final String value = marked.getString(BetonQuest.getInstance().getProfileProvider().getProfile(player));
             final NamespacedKey key = new NamespacedKey(BetonQuest.getInstance(), "betonquest-marked");
             final String dataContainerValue = entity.getPersistentDataContainer().get(key, PersistentDataType.STRING);
             if (dataContainerValue == null || !dataContainerValue.equals(value)) {
@@ -155,7 +154,7 @@ public class EntityInteractObjective extends CountingObjective {
             }
         }
         // check if the profile has this objective
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile) || !checkConditions(onlineProfile)) {
             return false;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/EquipItemObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/EquipItemObjective.java
@@ -9,7 +9,6 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.item.QuestItem;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -42,7 +41,7 @@ public class EquipItemObjective extends Objective implements Listener {
 
     @EventHandler
     public void onEquipmentChange(final PlayerArmorChangeEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile)
                 && event.getSlotType() == slotType
                 && questItems.compare(event.getNewItem())

--- a/src/main/java/org/betonquest/betonquest/objective/ExperienceObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ExperienceObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -108,7 +107,7 @@ public class ExperienceObjective extends Objective implements Listener {
     public void onLevelChangeEvent(final PlayerLevelChangeEvent event) {
         final Player player = event.getPlayer();
         final double newAmount = player.getLevel() + player.getExp();
-        onExperienceChange(PlayerConverter.getID(player), newAmount, true);
+        onExperienceChange(BetonQuest.getInstance().getProfileProvider().getProfile(player), newAmount, true);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
@@ -116,14 +115,14 @@ public class ExperienceObjective extends Objective implements Listener {
         final Player player = event.getPlayer();
         Bukkit.getScheduler().runTask(BetonQuest.getInstance(), () -> {
             final double newAmount = player.getLevel() + player.getExp();
-            onExperienceChange(PlayerConverter.getID(player), newAmount, false);
+            onExperienceChange(BetonQuest.getInstance().getProfileProvider().getProfile(player), newAmount, false);
         });
     }
 
     @EventHandler
     public void onPlayerJoin(final PlayerJoinEvent event) {
         final Player player = event.getPlayer();
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         final double newAmount = player.getLevel() + player.getExp();
         onExperienceChange(onlineProfile, newAmount, false);
     }

--- a/src/main/java/org/betonquest/betonquest/objective/FishObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/FishObjective.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.util.BlockSelector;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
@@ -65,7 +64,7 @@ public class FishObjective extends CountingObjective implements Listener {
         if (event.getState() != State.CAUGHT_FISH) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile) || event.getCaught() == null || event.getCaught().getType() != EntityType.DROPPED_ITEM) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/JumpObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/JumpObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -23,7 +22,7 @@ public class JumpObjective extends CountingObjective implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerJump(final PlayerJumpEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             getCountingData(onlineProfile).progress();
             completeIfDoneOrNotify(onlineProfile);

--- a/src/main/java/org/betonquest/betonquest/objective/KillPlayerObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/KillPlayerObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -35,8 +34,8 @@ public class KillPlayerObjective extends CountingObjective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onKill(final PlayerDeathEvent event) {
         if (event.getEntity().getKiller() != null) {
-            final OnlineProfile victim = PlayerConverter.getID(event.getEntity());
-            final OnlineProfile killer = PlayerConverter.getID(event.getEntity().getKiller());
+            final OnlineProfile victim = BetonQuest.getInstance().getProfileProvider().getProfile(event.getEntity());
+            final OnlineProfile killer = BetonQuest.getInstance().getProfileProvider().getProfile(event.getEntity().getKiller());
 
             if (containsPlayer(killer)
                     && (name == null || event.getEntity().getName().equalsIgnoreCase(name))

--- a/src/main/java/org/betonquest/betonquest/objective/LoginObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/LoginObjective.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -27,7 +26,7 @@ public class LoginObjective extends Objective implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onJoin(final PlayerJoinEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             completeObjective(onlineProfile);
         }

--- a/src/main/java/org/betonquest/betonquest/objective/LogoutObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/LogoutObjective.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -26,7 +25,7 @@ public class LogoutObjective extends Objective implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onQuit(final PlayerQuitEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
             completeObjective(onlineProfile);
         }

--- a/src/main/java/org/betonquest/betonquest/objective/PasswordObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/PasswordObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -61,7 +60,7 @@ public class PasswordObjective extends Objective implements Listener {
 
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
     private boolean chatInput(final boolean fromCommand, final Player player, final String message) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(player);
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(player);
         if (!containsPlayer(onlineProfile)) {
             return false;
         }

--- a/src/main/java/org/betonquest/betonquest/objective/PickupObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/PickupObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.Item;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -30,7 +29,7 @@ public class PickupObjective extends CountingObjective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPickup(final EntityPickupItemEvent event) {
         if (isValidItem(event.getItem().getItemStack()) && event.getEntity() instanceof Player) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getEntity());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getEntity());
 
             if (containsPlayer(onlineProfile) && checkConditions(onlineProfile)) {
                 final ItemStack pickupItem = event.getItem().getItemStack();

--- a/src/main/java/org/betonquest/betonquest/objective/ResourcePackObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ResourcePackObjective.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.VariableString;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -54,7 +53,7 @@ public class ResourcePackObjective extends Objective implements Listener {
      */
     @EventHandler
     public void onResourcePackReceived(final PlayerResourcePackStatusEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         processObjective(onlineProfile, event.getStatus());
     }
 

--- a/src/main/java/org/betonquest/betonquest/objective/RideObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/RideObjective.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -50,7 +49,7 @@ public class RideObjective extends Objective implements Listener {
         if (!(event.getEntered() instanceof Player)) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getEntered());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getEntered());
         if (containsPlayer(onlineProfile) && (any || event.getVehicle().getType() == vehicle) && checkConditions(onlineProfile)) {
             completeObjective(onlineProfile);
         }

--- a/src/main/java/org/betonquest/betonquest/objective/ShearObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/ShearObjective.java
@@ -6,7 +6,6 @@ import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.EntityType;
@@ -47,7 +46,7 @@ public class ShearObjective extends CountingObjective implements Listener {
         if (event.getEntity().getType() != EntityType.SHEEP) {
             return;
         }
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
         if (containsPlayer(onlineProfile)
                 && (name == null || name.equals(event.getEntity().getCustomName()))
                 && (color == null || color.equals(((Sheep) event.getEntity()).getColor()))

--- a/src/main/java/org/betonquest/betonquest/objective/SmeltingObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/SmeltingObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
 import org.betonquest.betonquest.item.QuestItem;
 import org.betonquest.betonquest.util.InventoryUtils;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -37,7 +36,7 @@ public class SmeltingObjective extends CountingObjective implements Listener {
     public void onSmelting(final InventoryClickEvent event) {
         final InventoryType inventoryType = event.getInventory().getType();
         if (isSmeltingResultExtraction(event, inventoryType)) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getWhoClicked());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile((Player) event.getWhoClicked());
             if (containsPlayer(onlineProfile) && item.compare(event.getCurrentItem()) && checkConditions(onlineProfile)) {
                 final int taken = calculateTakeAmount(event);
                 getCountingData(onlineProfile).progress(taken);

--- a/src/main/java/org/betonquest/betonquest/objective/StepObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/StepObjective.java
@@ -9,7 +9,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.util.BlockSelector;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -70,7 +69,7 @@ public class StepObjective extends Objective implements Listener {
             return;
         }
         try {
-            final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+            final OnlineProfile onlineProfile = BetonQuest.getInstance().getProfileProvider().getProfile(event.getPlayer());
             final Block block = loc.getValue(onlineProfile).getBlock();
             if (!clickedBlock.equals(block)) {
                 return;

--- a/src/main/java/org/betonquest/betonquest/objective/TameObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/TameObjective.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.objective;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.instruction.argument.VariableArgument;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -38,10 +38,9 @@ public class TameObjective extends CountingObjective implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onTaming(final EntityTameEvent event) {
         if (event.getOwner() instanceof Player) {
-            final OnlineProfile onlineProfile = PlayerConverter.getID((Player) event.getOwner());
-            if (containsPlayer(onlineProfile)
-                    && type.equals(event.getEntity().getType())
-                    && checkConditions(onlineProfile)) {
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            final OnlineProfile onlineProfile = profileProvider.getProfile((Player) event.getOwner());
+            if (containsPlayer(onlineProfile) && type.equals(event.getEntity().getType()) && checkConditions(onlineProfile)) {
                 getCountingData(onlineProfile).progress();
                 completeIfDoneOrNotify(onlineProfile);
             }

--- a/src/main/java/org/betonquest/betonquest/objective/VariableObjective.java
+++ b/src/main/java/org/betonquest/betonquest/objective/VariableObjective.java
@@ -4,9 +4,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -57,7 +57,8 @@ public class VariableObjective extends Objective implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onChat(final AsyncPlayerChatEvent event) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(event.getPlayer());
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final OnlineProfile onlineProfile = profileProvider.getProfile(event.getPlayer());
         if (!containsPlayer(onlineProfile)) {
             return;
         }

--- a/src/main/java/org/betonquest/betonquest/playerhider/PlayerHider.java
+++ b/src/main/java/org/betonquest/betonquest/playerhider/PlayerHider.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.id.ConditionID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.scheduler.BukkitTask;
@@ -95,7 +94,7 @@ public class PlayerHider {
      * Trigger an update for the visibility.
      */
     public void updateVisibility() {
-        final Collection<? extends OnlineProfile> onlineProfiles = PlayerConverter.getOnlineProfiles();
+        final Collection<? extends OnlineProfile> onlineProfiles = BetonQuest.getInstance().getProfileProvider().getOnlineProfiles();
         final Map<OnlineProfile, List<OnlineProfile>> profilesToHide = getProfilesToHide(onlineProfiles);
         for (final OnlineProfile source : onlineProfiles) {
             updateVisibilityForProfiles(onlineProfiles, source, profilesToHide.get(source));

--- a/src/main/java/org/betonquest/betonquest/profile/UUIDProfileProvider.java
+++ b/src/main/java/org/betonquest/betonquest/profile/UUIDProfileProvider.java
@@ -1,7 +1,8 @@
-package org.betonquest.betonquest.util;
+package org.betonquest.betonquest.profile;
 
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -12,21 +13,17 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Converts the player to the Profile
+ * Default implementation for {@link ProfileProvider}.
  */
-@SuppressWarnings({"PMD.ClassNamingConventions", "PMD.CommentRequired"})
-public final class PlayerConverter {
-
-    private PlayerConverter() {
+public class UUIDProfileProvider implements ProfileProvider {
+    /**
+     * Default profile provider constructor.
+     */
+    public UUIDProfileProvider() {
     }
 
-    /**
-     * Returns the {@link Profile} of the passed {@link OfflinePlayer}.
-     *
-     * @param player - Player object to get the Profile from
-     * @return profile of the player
-     */
-    public static Profile getID(final OfflinePlayer player) {
+    @Override
+    public Profile getProfile(final OfflinePlayer player) {
         return new Profile() {
             @Override
             public OfflinePlayer getPlayer() {
@@ -50,7 +47,7 @@ public final class PlayerConverter {
                 if (onlinePlayer == null) {
                     return Optional.empty();
                 }
-                return Optional.of(getID(onlinePlayer));
+                return Optional.of(getProfile(onlinePlayer));
             }
 
             @Override
@@ -70,13 +67,8 @@ public final class PlayerConverter {
         };
     }
 
-    /**
-     * Returns the {@link OnlineProfile} of the passed {@link Player}.
-     *
-     * @param player - Player object to get the Profile from
-     * @return profile of the player
-     */
-    public static OnlineProfile getID(final Player player) {
+    @Override
+    public OnlineProfile getProfile(final Player player) {
         return new OnlineProfile() {
             @Override
             public Player getPlayer() {
@@ -118,12 +110,8 @@ public final class PlayerConverter {
         };
     }
 
-    /**
-     * Get all online {@link OnlineProfile}s.
-     *
-     * @return A list of {@link OnlineProfile}s
-     */
-    public static List<OnlineProfile> getOnlineProfiles() {
-        return Bukkit.getOnlinePlayers().stream().map(PlayerConverter::getID).toList();
+    @Override
+    public List<OnlineProfile> getOnlineProfiles() {
+        return Bukkit.getOnlinePlayers().stream().map(this::getProfile).toList();
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/condition/party/PartyCondition.java
+++ b/src/main/java/org/betonquest/betonquest/quest/condition/party/PartyCondition.java
@@ -1,14 +1,15 @@
 package org.betonquest.betonquest.quest.condition.party;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.api.quest.condition.nullable.NullableCondition;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Nullable;
@@ -81,7 +82,8 @@ public class PartyCondition implements NullableCondition {
 
     @Override
     public boolean check(@Nullable final Profile profile) throws QuestException {
-        final Set<OnlineProfile> partyMembers = Utils.getParty(questTypeAPI, PlayerConverter.getOnlineProfiles(),
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final Set<OnlineProfile> partyMembers = Utils.getParty(questTypeAPI, profileProvider.getOnlineProfiles(),
                 location.getValue(profile), range.getValue(profile).doubleValue(), conditions).keySet();
 
         final int pCount = count == null ? 0 : count.getValue(profile).intValue();

--- a/src/main/java/org/betonquest/betonquest/quest/event/drop/DropEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/drop/DropEventFactory.java
@@ -1,7 +1,9 @@
 package org.betonquest.betonquest.quest.event.drop;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.common.function.Selector;
 import org.betonquest.betonquest.api.common.function.Selectors;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.api.quest.event.EventFactory;
@@ -15,7 +17,6 @@ import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.event.OnlineProfileGroupStaticEventAdapter;
 import org.betonquest.betonquest.quest.event.PrimaryServerThreadEvent;
 import org.betonquest.betonquest.quest.event.PrimaryServerThreadStaticEvent;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -52,7 +53,8 @@ public class DropEventFactory implements EventFactory, StaticEventFactory {
     private StaticEvent createStaticDropEvent(final Instruction instruction) throws QuestException {
         final NullableEventAdapter dropEvent = createDropEvent(instruction);
         if (!instruction.hasArgument("location")) {
-            return new OnlineProfileGroupStaticEventAdapter(PlayerConverter::getOnlineProfiles, dropEvent);
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            return new OnlineProfileGroupStaticEventAdapter(profileProvider::getOnlineProfiles, dropEvent);
         }
         return dropEvent;
     }

--- a/src/main/java/org/betonquest/betonquest/quest/event/notify/NotifyAllEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/notify/NotifyAllEventFactory.java
@@ -1,6 +1,8 @@
 package org.betonquest.betonquest.quest.event.notify;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.api.quest.event.EventFactory;
@@ -11,7 +13,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.event.CallStaticEventAdapter;
 import org.betonquest.betonquest.quest.event.OnlineProfileGroupStaticEventAdapter;
-import org.betonquest.betonquest.util.PlayerConverter;
 
 /**
  * Factory for the notify all event.
@@ -37,6 +38,7 @@ public class NotifyAllEventFactory extends NotifyEventFactory implements EventFa
 
     @Override
     public StaticEvent parseStaticEvent(final Instruction instruction) throws QuestException {
-        return new OnlineProfileGroupStaticEventAdapter(PlayerConverter::getOnlineProfiles, super.parseEvent(instruction));
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        return new OnlineProfileGroupStaticEventAdapter(profileProvider::getOnlineProfiles, super.parseEvent(instruction));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/objective/ObjectiveEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/objective/ObjectiveEvent.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.Objective;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.api.quest.event.nullable.NullableEvent;
@@ -13,7 +14,6 @@ import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.database.UpdateType;
 import org.betonquest.betonquest.id.ObjectiveID;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Nullable;
 
@@ -106,7 +106,8 @@ public class ObjectiveEvent implements NullableEvent {
 
     private void handleStatic(final ObjectiveID objectiveID, final Objective objective) {
         if ("delete".equals(action) || "remove".equals(action)) {
-            PlayerConverter.getOnlineProfiles().forEach(onlineProfile -> cancelObjectiveForOnlinePlayer(onlineProfile, objectiveID, objective));
+            final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+            profileProvider.getOnlineProfiles().forEach(onlineProfile -> cancelObjectiveForOnlinePlayer(onlineProfile, objectiveID, objective));
             betonQuest.getSaver().add(new Saver.Record(UpdateType.REMOVE_ALL_OBJECTIVES, objectiveID.toString()));
         } else {
             log.warn(questPackage, "You tried to call an objective add / finish event in a static context! Only objective delete works here.");

--- a/src/main/java/org/betonquest/betonquest/quest/event/party/PartyEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/party/PartyEvent.java
@@ -1,13 +1,14 @@
 package org.betonquest.betonquest.quest.event.party;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.api.quest.event.online.OnlineEvent;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.instruction.variable.VariableNumber;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,7 +78,8 @@ public class PartyEvent implements OnlineEvent {
 
     private Set<OnlineProfile> getMemberList(final OnlineProfile profile) throws QuestException {
         final int toExecute = amount != null ? amount.getValue(profile).intValue() : -1;
-        final Map<OnlineProfile, Double> members = Utils.getParty(questTypeAPI, PlayerConverter.getOnlineProfiles(),
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        final Map<OnlineProfile, Double> members = Utils.getParty(questTypeAPI, profileProvider.getOnlineProfiles(),
                 profile.getPlayer().getLocation(), range.getValue(profile).doubleValue(), conditions);
 
         if (toExecute < 0) {

--- a/src/main/java/org/betonquest/betonquest/quest/event/point/DeletePointEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/point/DeletePointEventFactory.java
@@ -1,5 +1,7 @@
 package org.betonquest.betonquest.quest.event.point;
 
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.api.quest.event.EventFactory;
@@ -12,7 +14,6 @@ import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.quest.event.DatabaseSaverStaticEvent;
 import org.betonquest.betonquest.quest.event.OnlineProfileGroupStaticEventAdapter;
 import org.betonquest.betonquest.quest.event.SequentialStaticEvent;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 
 /**
@@ -49,13 +50,12 @@ public class DeletePointEventFactory implements EventFactory, StaticEventFactory
     @Override
     public StaticEvent parseStaticEvent(final Instruction instruction) throws QuestException {
         final String category = getCategory(instruction);
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
         return new SequentialStaticEvent(
                 new OnlineProfileGroupStaticEventAdapter(
-                        PlayerConverter::getOnlineProfiles,
-                        new DeletePointEvent(dataStorage::getOffline, category)
-                ),
-                new DatabaseSaverStaticEvent(saver, () -> new Saver.Record(UpdateType.REMOVE_ALL_POINTS, category))
-        );
+                        profileProvider::getOnlineProfiles,
+                        new DeletePointEvent(dataStorage::getOffline, category)),
+                new DatabaseSaverStaticEvent(saver, () -> new Saver.Record(UpdateType.REMOVE_ALL_POINTS, category)));
     }
 
     private String getCategory(final Instruction instruction) throws QuestException {

--- a/src/main/java/org/betonquest/betonquest/quest/event/run/RunForAllEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/run/RunForAllEventFactory.java
@@ -1,5 +1,7 @@
 package org.betonquest.betonquest.quest.event.run;
 
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.QuestTypeAPI;
 import org.betonquest.betonquest.api.quest.event.StaticEvent;
@@ -7,7 +9,6 @@ import org.betonquest.betonquest.api.quest.event.StaticEventFactory;
 import org.betonquest.betonquest.id.ConditionID;
 import org.betonquest.betonquest.id.EventID;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.util.PlayerConverter;
 
 import java.util.List;
 
@@ -34,6 +35,7 @@ public class RunForAllEventFactory implements StaticEventFactory {
     public StaticEvent parseStaticEvent(final Instruction instruction) throws QuestException {
         final List<EventID> events = instruction.getIDList(instruction.getOptional("events"), EventID::new);
         final List<ConditionID> conditions = instruction.getIDList(instruction.getOptional("where"), ConditionID::new);
-        return new RunForAllEvent(PlayerConverter::getOnlineProfiles, questTypeAPI, events, conditions);
+        final ProfileProvider profileProvider = BetonQuest.getInstance().getProfileProvider();
+        return new RunForAllEvent(profileProvider::getOnlineProfiles, questTypeAPI, events, conditions);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/event/tag/TagPlayerEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/tag/TagPlayerEventFactory.java
@@ -1,5 +1,6 @@
 package org.betonquest.betonquest.quest.event.tag;
 
+import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.api.quest.event.EventFactory;
@@ -13,7 +14,6 @@ import org.betonquest.betonquest.quest.event.DatabaseSaverStaticEvent;
 import org.betonquest.betonquest.quest.event.DoNothingStaticEvent;
 import org.betonquest.betonquest.quest.event.OnlineProfileGroupStaticEventAdapter;
 import org.betonquest.betonquest.quest.event.SequentialStaticEvent;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.betonquest.betonquest.util.Utils;
 
 import java.util.ArrayList;
@@ -90,7 +90,7 @@ public class TagPlayerEventFactory implements EventFactory, StaticEventFactory {
     private StaticEvent createStaticDeleteTagEvent(final String... tags) {
         final TagEvent deleteTagEvent = createDeleteTagEvent(tags);
         final List<StaticEvent> staticEvents = new ArrayList<>(tags.length + 1);
-        staticEvents.add(new OnlineProfileGroupStaticEventAdapter(PlayerConverter::getOnlineProfiles, deleteTagEvent));
+        staticEvents.add(new OnlineProfileGroupStaticEventAdapter(() -> BetonQuest.getInstance().getProfileProvider().getOnlineProfiles(), deleteTagEvent));
         for (final String tag : tags) {
             staticEvents.add(new DatabaseSaverStaticEvent(saver, () -> new Saver.Record(UpdateType.REMOVE_ALL_TAGS, tag)));
         }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
@@ -349,7 +349,7 @@ public class CoreQuestTypes {
         eventTypes.registerCombined("if", new IfElseEventFactory(questTypeAPI));
         eventTypes.register("itemdurability", new ItemDurabilityEventFactory(loggerFactory, data));
         eventTypes.registerCombined("journal", new JournalEventFactory(loggerFactory, pluginMessage, dataStorage,
-                InstantSource.system(), betonQuest.getSaver()));
+                InstantSource.system(), betonQuest.getSaver(), betonQuest.getProfileProvider()));
         eventTypes.register("kill", new KillEventFactory(loggerFactory, data));
         eventTypes.register("language", new LanguageEventFactory(dataStorage));
         eventTypes.registerCombined("lever", new LeverEventFactory(data));

--- a/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactoryIntegrationTest.java
+++ b/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventFactoryIntegrationTest.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.quest.event.journal;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.SingletonLoggerFactory;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.DefaultConfigAccessorFactory;
 import org.betonquest.betonquest.config.PluginMessage;
@@ -12,6 +13,7 @@ import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.id.NoID;
 import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.logger.util.BetonQuestLoggerService;
+import org.betonquest.betonquest.profile.UUIDProfileProvider;
 import org.betonquest.betonquest.quest.legacy.QuestEventFactoryAdapter;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.junit.jupiter.api.Test;
@@ -72,7 +74,8 @@ class JournalEventFactoryIntegrationTest {
     }
 
     private QuestEventFactoryAdapter createJournalEventFactory(final BetonQuestLogger logger) {
-        final JournalEventFactory journalEventFactory = new JournalEventFactory(new SingletonLoggerFactory(logger), mock(PluginMessage.class), dataStorage, InstantSource.fixed(now), saver);
+        final ProfileProvider profileProvider = new UUIDProfileProvider();
+        final JournalEventFactory journalEventFactory = new JournalEventFactory(new SingletonLoggerFactory(logger), mock(PluginMessage.class), dataStorage, InstantSource.fixed(now), saver, profileProvider);
         return new QuestEventFactoryAdapter(journalEventFactory, journalEventFactory);
     }
 

--- a/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventTest.java
+++ b/src/test/java/org/betonquest/betonquest/quest/event/journal/JournalEventTest.java
@@ -1,11 +1,11 @@
 package org.betonquest.betonquest.quest.event.journal;
 
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.ProfileProvider;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.feature.journal.Journal;
 import org.betonquest.betonquest.quest.event.NotificationSender;
-import org.betonquest.betonquest.util.PlayerConverter;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +25,8 @@ class JournalEventTest {
     void testJournalEventChangesUpdatesAndNotifiesInOrder(
             @Mock final PlayerDataStorage dataStorage, @Mock final PlayerData data, @Mock final Journal journal,
             @Mock final JournalChanger changer, @Mock final NotificationSender sender) {
-        final OnlineProfile onlineProfile = PlayerConverter.getID(mock(Player.class));
+        final ProfileProvider profileProvider = mock(ProfileProvider.class);
+        final OnlineProfile onlineProfile = profileProvider.getProfile(mock(Player.class));
         when(dataStorage.getOffline(onlineProfile)).thenReturn(data);
         when(data.getJournal()).thenReturn(journal);
 


### PR DESCRIPTION
This is a proposition to move the profile handling a `ProfileProvider` instance allowing the end-user to implement their own profile provider.

I created a `UUIDProfileProvider` which mimics the existing behaviour of `PlayerConverter`, which was responsible of providing profile information.

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
