### PR TITLE
Holograms - Fixed Javadocs warnings and migrated variables to new api

### DIFF
--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/BetonHologram.java
@@ -5,45 +5,45 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * Interface class to wrap a hologram from another supported plugin
- * Instances of this class should only be created by {@link HologramIntegrator#createHologram(Location)}
+ * Interface class to wrap a hologram from another supported plugin.
+ * Instances of this class should only be created by {@link HologramIntegrator#createHologram(Location)}.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface BetonHologram {
 
     /**
-     * Add an item line to the bottom of this hologram
+     * Add an item line to the bottom of this hologram.
      *
-     * @param item The item to display and append
+     * @param item The item to display and append.
      */
     void appendLine(ItemStack item);
 
     /**
-     * Add a text line to the bottom of this hologram
+     * Add a text line to the bottom of this hologram.
      *
-     * @param text The text to append
+     * @param text The text to append.
      */
     void appendLine(String text);
 
     /**
-     * Replace a line at the index with a new item line. Will throw an exception if index is out of bounds
+     * Replace a line at the index with a new item line. Will throw an exception if index is out of bounds.
      *
-     * @param index The index at which the line is set
-     * @param item  The item to place at the line
+     * @param index The index at which the line is set.
+     * @param item  The item to place at the line.
      */
     void setLine(int index, ItemStack item);
 
     /**
-     * Replace a line at the index with a new text line. Will throw an exception if index is out of bounds
+     * Replace a line at the index with a new text line. Will throw an exception if index is out of bounds.
      *
-     * @param index The index at which the line is set
-     * @param text  The text to place at the line
+     * @param index The index at which the line is set.
+     * @param text  The text to place at the line.
      */
     void setLine(int index, String text);
 
     /**
-     * Creates multiple lines from the starting index and adding a specified amount of lines. If a line at an index
-     * already exists, then a line will not be created.
+     * Creates multiple lines from the starting index and adding a specified amount of lines.
+     * If a line at an index already exists, then a line will not be created.
      *
      * @param startingIndex  the starting index
      * @param linesToBeAdded the amount of lines to add
@@ -58,74 +58,74 @@ public interface BetonHologram {
     void removeLine(int index);
 
     /**
-     * Show this hologram to a player
+     * Show this hologram to a player.
      *
-     * @param player The player to show the hologram to
+     * @param player The player to show the hologram to.
      */
     void show(Player player);
 
     /**
-     * Hides this hologram from a player
+     * Hides this hologram from a player.
      *
-     * @param player The player to hide the hologram from
+     * @param player The player to hide the hologram from.
      */
     void hide(Player player);
 
     /**
-     * Moves this hologram to specified location
+     * Moves this hologram to specified location.
      *
-     * @param location The location to move this hologram to
+     * @param location The location to move this hologram to.
      */
     void move(Location location);
 
     /**
-     * Show this hologram to all players
+     * Show this hologram to all players.
      */
     void showAll();
 
     /**
-     * Hides this hologram to all players
+     * Hides this hologram to all players.
      */
     void hideAll();
 
     /**
-     * Destroys and deletes this hologram
+     * Destroys and deletes this hologram.
      */
     void delete();
 
     /**
-     * Whether the hologram is disabled or not
+     * Whether the hologram is disabled or not.
      *
-     * @return true if disabled, false otherwise
+     * @return true if disabled, false otherwise.
      */
     boolean isDisabled();
 
     /**
-     * Disables the hologram without deleting it
+     * Disables the hologram without deleting it.
      */
     void disable();
 
     /**
-     * Enables the hologram after it has been disabled
+     * Enables the hologram after it has been disabled.
      */
     void enable();
 
     /**
-     * Counts the amount of lines in this hologram when called
+     * Counts the amount of lines in this hologram when called.
      *
-     * @return the amount of lines
+     * @return the amount of lines.
      */
     int size();
 
     /**
      * Retrieves the location of the hologram.
      *
-     * @return the location of the hologram
+     * @return the location of the hologram.
      */
     Location getLocation();
 
     /**
-     * Clear all lines from this hologram
+     * Clear all lines from this hologram.
      */
     void clear();
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramIntegrator.java
@@ -52,10 +52,20 @@ public abstract class HologramIntegrator implements Integrator, Comparable<Holog
         this.qualifiers = qualifiers.clone();
     }
 
+    /**
+     * Get the name of the plugin.
+     *
+     * @return The name of the plugin.
+     */
     public String getPluginName() {
         return pluginName;
     }
 
+    /**
+     * Get the plugin.
+     *
+     * @return the {@link Plugin} object.
+     */
     @Nullable
     public Plugin getPlugin() {
         return plugin;
@@ -65,8 +75,8 @@ public abstract class HologramIntegrator implements Integrator, Comparable<Holog
      * Searches the BetonQuest config to get the priority of this HologramIntegrator as specified in the
      * `default_hologram` config option.
      *
-     * @return The priority of this integrator ranging from 1 to the amount of HologramIntegrators, or 0 if config option
-     * did not exist or if the plugin was not found in the `default_hologram` config option
+     * @return The priority of this integrator ranging from 1 to the amount of HologramIntegrators, or 0 if a config option
+     * did not exist or if the plugin was not found in the `default_hologram` config option.
      */
     public int getPriority() {
         final String defaultHolograms = BetonQuest.getInstance().getPluginConfig().getString("default_hologram");

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
@@ -130,6 +130,7 @@ public abstract class HologramLoop {
             hologram.hideAll();
         }
         final HologramWrapper hologramWrapper = new HologramWrapper(
+                loggerFactory.create(HologramWrapper.class),
                 checkInterval,
                 holograms,
                 isStaticHologram(cleanedLines),
@@ -171,7 +172,6 @@ public abstract class HologramLoop {
         return lines.stream().noneMatch(AbstractLine::isNotStaticText);
     }
 
-    @SuppressWarnings("PMD.LocalVariableCouldBeFinal")
     private ItemLine parseItemLine(final QuestPackage pack, final String line) throws QuestException {
         try {
             final String[] args = line.substring(5).split(":");

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
@@ -22,17 +22,17 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * Singleton class which provides Hologram
+ * Singleton class which provides Hologram.
  */
 @SuppressWarnings("PMD.AvoidSynchronizedStatement")
 public final class HologramProvider implements Integrator {
     /**
-     * Pattern to match an instruction variable in string
+     * Pattern to match an instruction variable in string.
      */
     public static final Pattern VARIABLE_VALIDATOR = Pattern.compile("%[^ %\\s]+%");
 
     /**
-     * HologramIntegrators when 'hooked' add themselves to this list
+     * HologramIntegrators when 'hooked' add themselves to this list.
      */
     private static final List<HologramIntegrator> ATTEMPTED_INTEGRATIONS = new ArrayList<>();
 
@@ -42,13 +42,13 @@ public final class HologramProvider implements Integrator {
     private static final BetonQuestLogger LOG = BetonQuest.getInstance().getLoggerFactory().create(HologramProvider.class);
 
     /**
-     * Singleton instance of this HologramProvider, only ever null if not initialised.
+     * Singleton instance of this HologramProvider, only ever null if not initialized.
      */
     @Nullable
     private static HologramProvider instance;
 
     /**
-     * The currently hooked integrator, this may change during runtime during a reload
+     * The currently hooked integrator, this may change during runtime during a reload.
      */
     private HologramIntegrator integrator;
 
@@ -65,18 +65,18 @@ public final class HologramProvider implements Integrator {
     private CitizensHologramLoop citizensHologramLoop;
 
     /**
-     * Creates a new HologramProvider object and assigns it to singleton instance if not already
+     * Creates a new HologramProvider object and assigns it to singleton instance if not already.
      *
-     * @param integrator The initial integrator to hook into
+     * @param integrator The initial integrator to hook into.
      */
     private HologramProvider(final HologramIntegrator integrator) {
         this.integrator = integrator;
     }
 
     /**
-     * Adds a possible integrator for this provider
+     * Adds a possible integrator for this provider.
      *
-     * @param integrator The integrator itself
+     * @param integrator The integrator itself.
      */
     public static void addIntegrator(final HologramIntegrator integrator) {
         ATTEMPTED_INTEGRATIONS.add(integrator);
@@ -105,8 +105,8 @@ public final class HologramProvider implements Integrator {
     /**
      * Get an instance of this HologramProvider.
      *
-     * @return An instance of Hologram Provider
-     * @throws IllegalStateException Thrown if this method has been used at the incorrect time
+     * @return An instance of Hologram Provider.
+     * @throws IllegalStateException Thrown if this method has been used at the incorrect time.
      */
     public static HologramProvider getInstance() {
         if (instance == null) {
@@ -116,9 +116,11 @@ public final class HologramProvider implements Integrator {
     }
 
     /**
-     * @param pluginName The name of the plugin to check
-     * @return True if plugin is currently hooked to this provider
-     * @throws IllegalStateException Thrown if this method has been used at the incorrect time
+     * Checks if a plugin is currently hooked to this provider.
+     *
+     * @param pluginName The name of the plugin to check.
+     * @return True if plugin is currently hooked to this provider.
+     * @throws IllegalStateException Thrown if this method has been used at the incorrect time.
      */
     public boolean isHooked(final String pluginName) {
         if (this.integrator == null) {
@@ -128,10 +130,10 @@ public final class HologramProvider implements Integrator {
     }
 
     /**
-     * Creates a wrapped hologram using a hooked hologram plugin
+     * Creates a wrapped hologram using a hooked hologram plugin.
      *
-     * @param location Location of where the hologram should be spawned
-     * @return The hologram
+     * @param location Location of where the hologram should be spawned.
+     * @return The hologram.
      */
     public BetonHologram createHologram(final Location location) {
         return integrator.createHologram(location);
@@ -139,11 +141,11 @@ public final class HologramProvider implements Integrator {
 
     /**
      * Parses a string containing an instruction variable and converts it to the appropriate format for the given
-     * plugin implementation
+     * plugin implementation.
      *
-     * @param pack The quest pack where the variable resides
-     * @param text The raw text
-     * @return The parsed and formatted full string
+     * @param pack The quest pack where the variable resides.
+     * @param text The raw text.
+     * @return The parsed and formatted full string.
      */
     public String parseVariable(final QuestPackage pack, final String text) {
         return integrator.parseVariable(pack, text);
@@ -193,20 +195,20 @@ public final class HologramProvider implements Integrator {
     }
 
     /**
-     * A listener class for bukkit events that are used by holograms
+     * A listener class for bukkit events that holograms use.
      */
     public static class HologramListener implements Listener {
         /**
-         * Creates and registers a new HologramListener
+         * Creates and registers a new HologramListener.
          */
         public HologramListener() {
             Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
         }
 
         /**
-         * Called when a player joins the server
+         * Called when a player joins the server.
          *
-         * @param event The event
+         * @param event The event.
          */
         @EventHandler
         public void onPlayerJoin(final PlayerJoinEvent event) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramRunner.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramRunner.java
@@ -51,7 +51,7 @@ public final class HologramRunner {
      * Adds a new HologramWrapper to the execution cycle. Decides whether to create a new runner or add the
      * Hologram to an existing runner that shares the same cycle in ticks.
      *
-     * @param hologram Hologram to be added
+     * @param hologram Hologram to be added.
      */
     static /* default */ void addHologram(final HologramWrapper hologram) {
         RUNNERS.computeIfAbsent(hologram.interval(),
@@ -63,9 +63,9 @@ public final class HologramRunner {
     }
 
     /**
-     * Refreshes all HologramRunners for a single player
+     * Refreshes all HologramRunners for a single player.
      *
-     * @param profile The online player's profile
+     * @param profile The online player's profile.
      */
     public static void refresh(final OnlineProfile profile) {
         for (final HologramRunner hologramRunner : RUNNERS.values()) {
@@ -86,16 +86,16 @@ public final class HologramRunner {
     /**
      * Adds a new hologram to the runner.
      *
-     * @param hologramWrapper The hologram to add
+     * @param hologramWrapper The hologram to add.
      */
     private void addRunnerHologram(final HologramWrapper hologramWrapper) {
         holograms.add(hologramWrapper);
     }
 
     /**
-     * Refreshes all HologramRunners for a single player
+     * Refreshes all HologramRunners for a single player.
      *
-     * @param profile The online player's profile
+     * @param profile The online player's profile.
      */
     private void refreshRunner(final OnlineProfile profile) {
         for (final HologramWrapper wrapper : holograms) {

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/decentholograms/DecentHologramsHologram.java
@@ -11,17 +11,17 @@ import org.bukkit.inventory.ItemStack;
 import java.util.List;
 
 /**
- * DecentHolograms specific implementation of BetonHologram
+ * DecentHolograms specific implementation of BetonHologram.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class DecentHologramsHologram implements BetonHologram {
     /**
-     * The hologram object from DecentHolograms
+     * The hologram object from DecentHolograms.
      */
     private final Hologram hologram;
 
     /**
-     * Create a BetonHologram to wrap the given DecentHolograms hologram
+     * Create a BetonHologram to wrap the given DecentHolograms hologram.
      *
      * @param hologram The hologram object to wrap
      */

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/holographicdisplays/HolographicDisplaysHologram.java
@@ -9,12 +9,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * HolographicDisplays specific implementation of BetonHologram
+ * HolographicDisplays specific implementation of BetonHologram.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class HolographicDisplaysHologram implements BetonHologram {
     /**
-     * The hologram object from HolographicDisplays
+     * The hologram object from HolographicDisplays.
      */
     private final Hologram hologram;
 
@@ -24,7 +24,7 @@ public class HolographicDisplaysHologram implements BetonHologram {
     private boolean disabled;
 
     /**
-     * Create a BetonHologram to wrap the given HolographicDisplays hologram
+     * Create a BetonHologram to wrap the given HolographicDisplays hologram.
      *
      * @param hologram The hologram object to wrap
      */

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/AbstractLine.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/AbstractLine.java
@@ -13,12 +13,12 @@ import org.betonquest.betonquest.compatibility.holograms.HologramLoop;
  */
 public abstract class AbstractLine {
     /**
-     * False if this line needs to be updated
+     * False if this line needs to be updated.
      */
     protected final boolean staticText;
 
     /**
-     * The amount of lines added by this line
+     * The amount of lines added by this line.
      */
     protected final int linesAdded;
 
@@ -52,7 +52,9 @@ public abstract class AbstractLine {
     }
 
     /**
-     * @return True if this line's content does not need to be updated, false if it does.
+     * Checks if this line's content does not need to be updated.
+     *
+     * @return {@code true} if this line's content does not need to be updated, {@code false} if it does.
      */
     public boolean isNotStaticText() {
         return !staticText;

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/ItemLine.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/ItemLine.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
  */
 public class ItemLine extends AbstractLine {
     /**
-     * The item to be displayed with all its metadata
+     * The item to be displayed with all its metadata.
      */
     private final ItemStack item;
 

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TextLine.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TextLine.java
@@ -3,7 +3,7 @@ package org.betonquest.betonquest.compatibility.holograms.lines;
 import org.betonquest.betonquest.compatibility.holograms.BetonHologram;
 
 /**
- * Displays a simple text line with optional color codes
+ * Displays a simple text line with optional color codes.
  */
 public class TextLine extends AbstractLine {
     /**

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TopXLine.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TopXLine.java
@@ -9,10 +9,10 @@ package org.betonquest.betonquest.compatibility.holograms.lines;
 public record TopXLine(String playerName, long count) {
 
     /**
-     * Creates a new instance of TopXLine
+     * Creates a new instance of TopXLine.
      *
-     * @param playerName Name of player
-     * @param count      Value of point
+     * @param playerName Name of player.
+     * @param count      Value of point.
      */
     public TopXLine {
     }

--- a/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TopXObject.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/holograms/lines/TopXObject.java
@@ -55,6 +55,11 @@ public class TopXObject {
         this.orderType = orderType;
     }
 
+    /**
+     * Returns the entries of the last database request.
+     *
+     * @return List of {@link TopXLine} entries.
+     */
     public List<TopXLine> getEntries() {
         return entries;
     }
@@ -113,10 +118,20 @@ public class TopXObject {
          */
         private final QueryType type;
 
+        /**
+         * Creates a new instance of OrderType.
+         *
+         * @param type The {@link QueryType} for descending or ascending order.
+         */
         OrderType(final QueryType type) {
             this.type = type;
         }
 
+        /**
+         * Returns the {@link QueryType}.
+         *
+         * @return The {@link QueryType} for descending or ascending order.
+         */
         public QueryType getType() {
             return type;
         }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
- Fixed severall javadocs
- changed the variables to new api

* Not quite shure but in HologramProvider#isHooked - can the integrator be null? Then we have to add the annotation, wasnt sure about this one.
* And I am not throwing one Exception the right way. This happens in HologramWrapper#getMaxRangeFromVariable. This isn't the fine way. I could get the logger here by using a BetonQuest.getInstance() call and creating it. But I do not like the idea to change the behaviour. the VariableNumber.getInt call returned a 0 in error states as far as I know so I adapted this.
---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
