### PR TITLE
Load compasses, Canceler and Conversation Data in Processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- `quest compass` location now allows variables
 ### Changed
 - message.yml file was deleted and instead the lang folder now contains all translations
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - betonquest command without arguments did not work anymore
 - the Fabled hook not working properly
 - `compass` event did not work with variables in `compass` location
+- `quest canceler` did not resolve global variables
 ### Security
 
 ## [2.2.1] - 2025-01-12

--- a/src/main/java/org/betonquest/betonquest/api/feature/FeatureAPI.java
+++ b/src/main/java/org/betonquest/betonquest/api/feature/FeatureAPI.java
@@ -1,14 +1,15 @@
 package org.betonquest.betonquest.api.feature;
 
 import org.betonquest.betonquest.conversation.ConversationData;
-import org.betonquest.betonquest.feature.QuestCompass;
 import org.betonquest.betonquest.feature.QuestCanceler;
+import org.betonquest.betonquest.feature.QuestCompass;
 import org.betonquest.betonquest.id.CompassID;
 import org.betonquest.betonquest.id.ConversationID;
 import org.betonquest.betonquest.id.QuestCancelerID;
 import org.betonquest.betonquest.quest.registry.QuestRegistry;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,7 +42,7 @@ public final class FeatureAPI {
      */
     @Nullable
     public ConversationData getConversation(final ConversationID conversationID) {
-        return questRegistry.conversations().getConversation(conversationID);
+        return questRegistry.conversations().getValues().get(conversationID);
     }
 
     /**
@@ -50,7 +51,7 @@ public final class FeatureAPI {
      * @return quest cancellers in a new map
      */
     public Map<QuestCancelerID, QuestCanceler> getCanceler() {
-        return questRegistry.questCanceller().getCancelers();
+        return new HashMap<>(questRegistry.questCanceller().getValues());
     }
 
     /**
@@ -59,6 +60,6 @@ public final class FeatureAPI {
      * @return compasses in a new map
      */
     public Map<CompassID, QuestCompass> getCompasses() {
-        return questRegistry.compasses().getCompasses();
+        return new HashMap<>(questRegistry.compasses().getValues());
     }
 }

--- a/src/main/java/org/betonquest/betonquest/api/feature/FeatureAPI.java
+++ b/src/main/java/org/betonquest/betonquest/api/feature/FeatureAPI.java
@@ -1,7 +1,9 @@
 package org.betonquest.betonquest.api.feature;
 
 import org.betonquest.betonquest.conversation.ConversationData;
+import org.betonquest.betonquest.feature.QuestCompass;
 import org.betonquest.betonquest.feature.QuestCanceler;
+import org.betonquest.betonquest.id.CompassID;
 import org.betonquest.betonquest.id.ConversationID;
 import org.betonquest.betonquest.id.QuestCancelerID;
 import org.betonquest.betonquest.quest.registry.QuestRegistry;
@@ -49,5 +51,14 @@ public final class FeatureAPI {
      */
     public Map<QuestCancelerID, QuestCanceler> getCanceler() {
         return questRegistry.questCanceller().getCancelers();
+    }
+
+    /**
+     * Get the loaded Compasses.
+     *
+     * @return compasses in a new map
+     */
+    public Map<CompassID, QuestCompass> getCompasses() {
+        return questRegistry.compasses().getCompasses();
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/QuestCompass.java
+++ b/src/main/java/org/betonquest/betonquest/feature/QuestCompass.java
@@ -1,0 +1,17 @@
+package org.betonquest.betonquest.feature;
+
+import org.betonquest.betonquest.id.ItemID;
+import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * A Quest Compass targeting a location.
+ *
+ * @param names    the display names by their language
+ * @param location the compass location
+ * @param itemID   possible item id, when it should be displayed in the backpack
+ */
+public record QuestCompass(Map<String, String> names, VariableLocation location, @Nullable ItemID itemID) {
+}

--- a/src/main/java/org/betonquest/betonquest/feature/registry/CompassProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/CompassProcessor.java
@@ -1,0 +1,86 @@
+package org.betonquest.betonquest.feature.registry;
+
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.quest.QuestException;
+import org.betonquest.betonquest.config.Config;
+import org.betonquest.betonquest.feature.QuestCompass;
+import org.betonquest.betonquest.id.CompassID;
+import org.betonquest.betonquest.id.ItemID;
+import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
+import org.betonquest.betonquest.quest.registry.processor.QuestProcessor;
+import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
+import org.betonquest.betonquest.variables.GlobalVariableResolver;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loads and stores {@link QuestCompass}es.
+ */
+public class CompassProcessor extends QuestProcessor<CompassID, QuestCompass> {
+
+    /**
+     * Variable to create new variables.
+     */
+    private final VariableProcessor variableProcessor;
+
+    /**
+     * Create a new QuestProcessor to store {@link QuestCompass}es.
+     *
+     * @param log               the custom logger for this class
+     * @param variableProcessor the variable to create new variables
+     */
+    public CompassProcessor(final BetonQuestLogger log, final VariableProcessor variableProcessor) {
+        super(log);
+        this.variableProcessor = variableProcessor;
+    }
+
+    @Override
+    public void load(final QuestPackage pack) {
+        final ConfigurationSection section = pack.getConfig().getConfigurationSection("compass");
+        if (section == null) {
+            return;
+        }
+        for (final String key : section.getKeys(false)) {
+            try {
+                values.put(new CompassID(pack, key), loadCompass(pack, section.getConfigurationSection(key)));
+            } catch (final QuestException e) {
+                log.warn("Could not load compass '" + key + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private QuestCompass loadCompass(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
+        final Map<String, String> names = new HashMap<>();
+        if (section.isConfigurationSection("name")) {
+            final ConfigurationSection nameSection = section.getConfigurationSection("name");
+            for (final String key : section.getKeys(false)) {
+                names.put(key, nameSection.getString(GlobalVariableResolver.resolve(pack, key)));
+            }
+        } else {
+            names.put(Config.getLanguage(), GlobalVariableResolver.resolve(pack, section.getString("name")));
+        }
+        if (names.isEmpty()) {
+            throw new QuestException("Name not defined");
+        }
+        final String location = section.getString("location");
+        if (location == null) {
+            throw new QuestException("Location not defined");
+        }
+        final VariableLocation loc = new VariableLocation(variableProcessor, pack, GlobalVariableResolver.resolve(pack, location));
+        final String itemName = section.getString("item");
+        final ItemID itemID = itemName == null ? null : new ItemID(pack, itemName);
+        return new QuestCompass(names, loc, itemID);
+    }
+
+    /**
+     * Get the loaded Quest Canceler.
+     *
+     * @return quest cancelers in a new map
+     */
+    public Map<CompassID, QuestCompass> getCompasses() {
+        return new HashMap<>(values);
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/feature/registry/CompassProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/CompassProcessor.java
@@ -3,23 +3,21 @@ package org.betonquest.betonquest.feature.registry;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.quest.QuestException;
-import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.feature.QuestCompass;
+import org.betonquest.betonquest.feature.registry.processor.SectionProcessor;
 import org.betonquest.betonquest.id.CompassID;
 import org.betonquest.betonquest.id.ItemID;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
-import org.betonquest.betonquest.quest.registry.processor.QuestProcessor;
 import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
 import org.betonquest.betonquest.variables.GlobalVariableResolver;
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Loads and stores {@link QuestCompass}es.
  */
-public class CompassProcessor extends QuestProcessor<CompassID, QuestCompass> {
+public class CompassProcessor extends SectionProcessor<CompassID, QuestCompass> {
 
     /**
      * Variable to create new variables.
@@ -33,35 +31,13 @@ public class CompassProcessor extends QuestProcessor<CompassID, QuestCompass> {
      * @param variableProcessor the variable to create new variables
      */
     public CompassProcessor(final BetonQuestLogger log, final VariableProcessor variableProcessor) {
-        super(log);
+        super(log, "Compass", "compass");
         this.variableProcessor = variableProcessor;
     }
 
     @Override
-    public void load(final QuestPackage pack) {
-        final ConfigurationSection section = pack.getConfig().getConfigurationSection("compass");
-        if (section == null) {
-            return;
-        }
-        for (final String key : section.getKeys(false)) {
-            try {
-                values.put(new CompassID(pack, key), loadCompass(pack, section.getConfigurationSection(key)));
-            } catch (final QuestException e) {
-                log.warn("Could not load compass '" + key + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
-            }
-        }
-    }
-
-    private QuestCompass loadCompass(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
-        final Map<String, String> names = new HashMap<>();
-        if (section.isConfigurationSection("name")) {
-            final ConfigurationSection nameSection = section.getConfigurationSection("name");
-            for (final String key : section.getKeys(false)) {
-                names.put(key, nameSection.getString(GlobalVariableResolver.resolve(pack, key)));
-            }
-        } else {
-            names.put(Config.getLanguage(), GlobalVariableResolver.resolve(pack, section.getString("name")));
-        }
+    protected QuestCompass loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
+        final Map<String, String> names = parseWithLanguage(pack, section, "name");
         if (names.isEmpty()) {
             throw new QuestException("Name not defined");
         }
@@ -75,12 +51,8 @@ public class CompassProcessor extends QuestProcessor<CompassID, QuestCompass> {
         return new QuestCompass(names, loc, itemID);
     }
 
-    /**
-     * Get the loaded Quest Canceler.
-     *
-     * @return quest cancelers in a new map
-     */
-    public Map<CompassID, QuestCompass> getCompasses() {
-        return new HashMap<>(values);
+    @Override
+    protected CompassID getIdentifier(final QuestPackage pack, final String identifier) throws QuestException {
+        return new CompassID(pack, identifier);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/CancellerProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/CancellerProcessor.java
@@ -2,39 +2,115 @@ package org.betonquest.betonquest.feature.registry.processor;
 
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.feature.QuestCanceler;
+import org.betonquest.betonquest.id.ConditionID;
+import org.betonquest.betonquest.id.EventID;
+import org.betonquest.betonquest.id.ID;
+import org.betonquest.betonquest.id.ItemID;
+import org.betonquest.betonquest.id.ObjectiveID;
 import org.betonquest.betonquest.id.QuestCancelerID;
+import org.betonquest.betonquest.instruction.argument.IDArgument;
+import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
+import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
+import org.betonquest.betonquest.variables.GlobalVariableResolver;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Array;
+import java.util.Map;
 
 /**
  * Stores Quest Canceller.
  */
 public class CancellerProcessor extends SectionProcessor<QuestCancelerID, QuestCanceler> {
+
+    /**
+     * Logger factory to create new class specific logger.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
     /**
      * The {@link PluginMessage} instance.
      */
     private final PluginMessage pluginMessage;
 
     /**
+     * Variable processor to create new variables.
+     */
+    private final VariableProcessor variableProcessor;
+
+    /**
      * Create a new Quest Canceler Processor to store them.
      *
-     * @param log           the custom logger for this class
-     * @param pluginMessage the {@link PluginMessage} instance
+     * @param log               the custom logger for this class
+     * @param loggerFactory     the logger factory to create new class specific logger
+     * @param pluginMessage     the {@link PluginMessage} instance
+     * @param variableProcessor the variable processor to create new variables
      */
-    public CancellerProcessor(final BetonQuestLogger log, final PluginMessage pluginMessage) {
+    public CancellerProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
+                              final PluginMessage pluginMessage, final VariableProcessor variableProcessor) {
         super(log, "Quest Canceler", "cancel");
+        this.loggerFactory = loggerFactory;
         this.pluginMessage = pluginMessage;
+        this.variableProcessor = variableProcessor;
     }
 
     @Override
     protected QuestCanceler loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
-        return new QuestCanceler(pluginMessage, pack, section.getName());
+        final Map<String, String> names = parseWithLanguage(pack, section, "name");
+        final String itemString = section.getString("item");
+        final String rawItem = itemString == null ? pack.getConfig().getString("items.cancel_button") : itemString;
+        final ItemID item = rawItem == null ? null : new ItemID(pack, rawItem);
+        final CreationHelper helper = new CreationHelper(pack, section);
+        final EventID[] events = helper.parseID("events", EventID::new);
+        final ConditionID[] conditions = helper.parseID("conditions", ConditionID::new);
+        final ObjectiveID[] objectives = helper.parseID("objectives", ObjectiveID::new);
+        final String[] tags = helper.split("tags");
+        final String[] points = helper.split("points");
+        final String[] journal = helper.split("journal");
+        final String rawLoc = GlobalVariableResolver.resolve(pack, section.getString("loc"));
+        final VariableLocation location = rawLoc == null ? null : new VariableLocation(variableProcessor, pack, rawLoc);
+        final QuestCanceler.CancelData cancelData = new QuestCanceler.CancelData(conditions, location, events, objectives, tags, points, journal);
+        final BetonQuestLogger logger = loggerFactory.create(getClass());
+        return new QuestCanceler(logger, section.getName(), pluginMessage, names, item, pack, cancelData);
     }
 
     @Override
     protected QuestCancelerID getIdentifier(final QuestPackage pack, final String identifier) throws QuestException {
         return new QuestCancelerID(pack, identifier);
+    }
+
+    /**
+     * Class to bundle objects required to create a QuestCanceler.
+     *
+     * @param pack    The canceler pack.
+     * @param section The canceler specific section.
+     */
+    private record CreationHelper(QuestPackage pack, ConfigurationSection section) {
+
+        @Nullable
+        private String[] split(final String path) {
+            final String raw = section.getString(path);
+            return raw == null ? null : GlobalVariableResolver.resolve(pack, raw).split(",");
+        }
+
+        @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
+        @Nullable
+        private <T extends ID> T[] parseID(final String path, final IDArgument<T> argument) throws QuestException {
+            final String[] rawObjectives = split(path);
+            if (rawObjectives == null || rawObjectives.length == 0) {
+                return null;
+            }
+            final T first = argument.convert(pack, rawObjectives[0]);
+            @SuppressWarnings("unchecked") final T[] converted = (T[]) Array.newInstance(first.getClass(), rawObjectives.length);
+            converted[0] = first;
+            for (int i = 1; i < rawObjectives.length; i++) {
+                converted[i] = argument.convert(pack, rawObjectives[i]);
+            }
+            return converted;
+        }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/CancellerProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/CancellerProcessor.java
@@ -6,16 +6,12 @@ import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.betonquest.betonquest.feature.QuestCanceler;
 import org.betonquest.betonquest.id.QuestCancelerID;
-import org.betonquest.betonquest.quest.registry.processor.QuestProcessor;
 import org.bukkit.configuration.ConfigurationSection;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Stores Quest Canceller.
  */
-public class CancellerProcessor extends QuestProcessor<QuestCancelerID, QuestCanceler> {
+public class CancellerProcessor extends SectionProcessor<QuestCancelerID, QuestCanceler> {
     /**
      * The {@link PluginMessage} instance.
      */
@@ -28,30 +24,17 @@ public class CancellerProcessor extends QuestProcessor<QuestCancelerID, QuestCan
      * @param pluginMessage the {@link PluginMessage} instance
      */
     public CancellerProcessor(final BetonQuestLogger log, final PluginMessage pluginMessage) {
-        super(log);
+        super(log, "Quest Canceler", "cancel");
         this.pluginMessage = pluginMessage;
     }
 
     @Override
-    public void load(final QuestPackage pack) {
-        final ConfigurationSection cancelSection = pack.getConfig().getConfigurationSection("cancel");
-        if (cancelSection != null) {
-            for (final String key : cancelSection.getKeys(false)) {
-                try {
-                    values.put(new QuestCancelerID(pack, key), new QuestCanceler(pluginMessage, pack, key));
-                } catch (final QuestException e) {
-                    log.warn(pack, "Could not load '" + pack.getQuestPath() + "." + key + "' quest canceler: " + e.getMessage(), e);
-                }
-            }
-        }
+    protected QuestCanceler loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
+        return new QuestCanceler(pluginMessage, pack, section.getName());
     }
 
-    /**
-     * Get the loaded Quest Canceler.
-     *
-     * @return quest cancelers in a new map
-     */
-    public Map<QuestCancelerID, QuestCanceler> getCancelers() {
-        return new HashMap<>(values);
+    @Override
+    protected QuestCancelerID getIdentifier(final QuestPackage pack, final String identifier) throws QuestException {
+        return new QuestCancelerID(pack, identifier);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/CompassProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/CompassProcessor.java
@@ -1,10 +1,9 @@
-package org.betonquest.betonquest.feature.registry;
+package org.betonquest.betonquest.feature.registry.processor;
 
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.feature.QuestCompass;
-import org.betonquest.betonquest.feature.registry.processor.SectionProcessor;
 import org.betonquest.betonquest.id.CompassID;
 import org.betonquest.betonquest.id.ItemID;
 import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
@@ -20,7 +19,7 @@ import java.util.Map;
 public class CompassProcessor extends SectionProcessor<CompassID, QuestCompass> {
 
     /**
-     * Variable to create new variables.
+     * Variable processor to create new variables.
      */
     private final VariableProcessor variableProcessor;
 
@@ -28,7 +27,7 @@ public class CompassProcessor extends SectionProcessor<CompassID, QuestCompass> 
      * Create a new QuestProcessor to store {@link QuestCompass}es.
      *
      * @param log               the custom logger for this class
-     * @param variableProcessor the variable to create new variables
+     * @param variableProcessor the variable processor to create new variables
      */
     public CompassProcessor(final BetonQuestLogger log, final VariableProcessor variableProcessor) {
         super(log, "Compass", "compass");
@@ -38,9 +37,6 @@ public class CompassProcessor extends SectionProcessor<CompassID, QuestCompass> 
     @Override
     protected QuestCompass loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
         final Map<String, String> names = parseWithLanguage(pack, section, "name");
-        if (names.isEmpty()) {
-            throw new QuestException("Name not defined");
-        }
         final String location = section.getString("location");
         if (location == null) {
             throw new QuestException("Location not defined");

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/ConversationProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/ConversationProcessor.java
@@ -3,34 +3,87 @@ package org.betonquest.betonquest.feature.registry.processor;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.conversation.ConversationData;
+import org.betonquest.betonquest.feature.registry.ConversationIORegistry;
+import org.betonquest.betonquest.feature.registry.InterceptorRegistry;
 import org.betonquest.betonquest.id.ConversationID;
+import org.betonquest.betonquest.id.EventID;
+import org.betonquest.betonquest.quest.registry.processor.VariableProcessor;
+import org.betonquest.betonquest.variables.GlobalVariableResolver;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Stores Conversation Data and validates it.
  */
 public class ConversationProcessor extends SectionProcessor<ConversationID, ConversationData> {
     /**
+     * Factory to create class specific logger.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    /**
      * Plugin instance used for new Conversation Data.
      */
     private final BetonQuest plugin;
 
     /**
+     * Processor to create new variables.
+     */
+    private final VariableProcessor variableProcessor;
+
+    /**
+     * Registry for available ConversationIOs.
+     */
+    private final ConversationIORegistry convIORegistry;
+
+    /**
+     * Registry for available Interceptors.
+     */
+    private final InterceptorRegistry interceptorRegistry;
+
+    /**
      * Create a new Conversation Data Processor to load and process conversation data.
      *
-     * @param log    the custom logger for this class
-     * @param plugin the plugin instance used for new conversation data
+     * @param log                 the custom logger for this class
+     * @param loggerFactory       the logger factory to create new class specific logger
+     * @param plugin              the plugin instance used for new conversation data
+     * @param variableProcessor   the processor to create new variables
+     * @param convIORegistry      the registry for available ConversationIOs
+     * @param interceptorRegistry the registry for available Interceptors
      */
-    public ConversationProcessor(final BetonQuestLogger log, final BetonQuest plugin) {
+    public ConversationProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory, final BetonQuest plugin,
+                                 final VariableProcessor variableProcessor, final ConversationIORegistry convIORegistry, final InterceptorRegistry interceptorRegistry) {
         super(log, "Conversation", "conversations");
+        this.loggerFactory = loggerFactory;
         this.plugin = plugin;
+        this.variableProcessor = variableProcessor;
+        this.convIORegistry = convIORegistry;
+        this.interceptorRegistry = interceptorRegistry;
     }
 
     @Override
     protected ConversationData loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
-        return new ConversationData(plugin, new ConversationID(pack, section.getName()), section);
+        final String convName = section.getName();
+        log.debug(pack, String.format("Loading conversation '%s'.", convName));
+
+        final Map<String, String> quester = parseWithLanguage(pack, section, "quester");
+        final CreationHelper helper = new CreationHelper(pack, section);
+        final boolean blockMovement = Boolean.parseBoolean(helper.opt("stop"));
+        final String convIO = helper.parseConvIO();
+        final String interceptor = helper.parseInterceptor();
+        final List<EventID> finalEvents = helper.parseFinalEvents();
+        final ConversationData.PublicData publicData = new ConversationData.PublicData(convName, quester, blockMovement, finalEvents, convIO, interceptor);
+
+        return new ConversationData(loggerFactory.create(ConversationData.class), plugin.getQuestTypeAPI(), plugin.getFeatureAPI(),
+                variableProcessor, pack, section, publicData);
     }
 
     @Override
@@ -52,10 +105,83 @@ public class ConversationProcessor extends SectionProcessor<ConversationID, Conv
                 convData.checkExternalPointers();
             } catch (final QuestException e) {
                 log.warn(convData.getPack(), "Error in '" + convData.getPack().getQuestPath() + "."
-                        + convData.getName() + "' conversation: " + e.getMessage(), e);
+                        + convData.getPublicData().convName() + "' conversation: " + e.getMessage(), e);
                 return true;
             }
             return false;
         });
+    }
+
+    /**
+     * Class to bundle objects required to create a ConversationData.
+     */
+    private final class CreationHelper {
+        /**
+         * The conversation pack.
+         */
+        private final QuestPackage pack;
+
+        /**
+         * The conversation specific section.
+         */
+        private final ConfigurationSection section;
+
+        private CreationHelper(final QuestPackage pack, final ConfigurationSection section) {
+            this.pack = pack;
+            this.section = section;
+        }
+
+        @Nullable
+        private String opt(final String path) {
+            return GlobalVariableResolver.resolve(pack, section.getString(path));
+        }
+
+        private String defaulting(final String path, final String configPath, final String defaultConfig) {
+            if (section.isString(path)) {
+                return Objects.requireNonNull(opt(path));
+            }
+            return plugin.getPluginConfig().getString(configPath, defaultConfig);
+        }
+
+        private String parseConvIO() throws QuestException {
+            final String rawConvIOs = defaulting("conversationIO", "default_conversation_IO", "menu,tellraw");
+            for (final String rawConvIOPart : rawConvIOs.split(",")) {
+                final String rawConvIO = rawConvIOPart.trim();
+                if (convIORegistry.getFactory(rawConvIO) != null) {
+                    return rawConvIO;
+                } else {
+                    log.debug(pack, "Conversation IO '" + rawConvIO + "' not found. Trying next one...");
+                }
+            }
+            throw new QuestException("No registered conversation IO found: " + rawConvIOs);
+        }
+
+        private String parseInterceptor() throws QuestException {
+            final String rawInterceptor = defaulting("interceptor", "default_interceptor", "simple");
+            for (final String s : rawInterceptor.split(",")) {
+                final String trimmed = s.trim();
+                if (interceptorRegistry.getFactory(trimmed) != null) {
+                    return trimmed;
+                }
+            }
+            throw new QuestException("No registered interceptor found: " + rawInterceptor);
+        }
+
+        private List<EventID> parseFinalEvents() throws QuestException {
+            final String rawFinalEvents = opt("final_events");
+            if (rawFinalEvents == null || rawFinalEvents.isEmpty()) {
+                return new ArrayList<>(0);
+            }
+            final String[] array = rawFinalEvents.split(",");
+            final List<EventID> finalEvents = new ArrayList<>(array.length);
+            for (final String identifier : array) {
+                try {
+                    finalEvents.add(new EventID(pack, identifier));
+                } catch (final QuestException e) {
+                    throw new QuestException("Error while loading final events: " + e.getMessage(), e);
+                }
+            }
+            return finalEvents;
+        }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/ConversationProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/ConversationProcessor.java
@@ -6,14 +6,12 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.conversation.ConversationData;
 import org.betonquest.betonquest.id.ConversationID;
-import org.betonquest.betonquest.quest.registry.processor.QuestProcessor;
 import org.bukkit.configuration.ConfigurationSection;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Stores Conversation Data and validates it.
  */
-public class ConversationProcessor extends QuestProcessor<ConversationID, ConversationData> {
+public class ConversationProcessor extends SectionProcessor<ConversationID, ConversationData> {
     /**
      * Plugin instance used for new Conversation Data.
      */
@@ -26,29 +24,18 @@ public class ConversationProcessor extends QuestProcessor<ConversationID, Conver
      * @param plugin the plugin instance used for new conversation data
      */
     public ConversationProcessor(final BetonQuestLogger log, final BetonQuest plugin) {
-        super(log);
+        super(log, "Conversation", "conversations");
         this.plugin = plugin;
     }
 
     @Override
-    public void load(final QuestPackage pack) {
-        final ConfigurationSection conversationsConfig = pack.getConfig().getConfigurationSection("conversations");
-        if (conversationsConfig != null) {
-            final String packName = pack.getQuestPath();
-            for (final String convName : conversationsConfig.getKeys(false)) {
-                try {
-                    final ConfigurationSection convSection = conversationsConfig.getConfigurationSection(convName);
-                    if (convSection == null) {
-                        log.warn(pack, "No configuration section for '" + packName + "." + convName + "' conversation!");
-                        continue;
-                    }
-                    final ConversationID convID = new ConversationID(pack, convName);
-                    values.put(convID, new ConversationData(plugin, convID, convSection));
-                } catch (final QuestException e) {
-                    log.warn(pack, "Error in '" + packName + "." + convName + "' conversation: " + e.getMessage(), e);
-                }
-            }
-        }
+    protected ConversationData loadSection(final QuestPackage pack, final ConfigurationSection section) throws QuestException {
+        return new ConversationData(plugin, new ConversationID(pack, section.getName()), section);
+    }
+
+    @Override
+    protected ConversationID getIdentifier(final QuestPackage pack, final String identifier) throws QuestException {
+        return new ConversationID(pack, identifier);
     }
 
     /**
@@ -70,18 +57,5 @@ public class ConversationProcessor extends QuestProcessor<ConversationID, Conver
             }
             return false;
         });
-    }
-
-    /**
-     * Gets stored Conversation Data.
-     * <p>
-     * The conversation data can be null if there was an error loading it.
-     *
-     * @param conversationID package name, dot and name of the conversation
-     * @return ConversationData object for this conversation or null if it does not exist
-     */
-    @Nullable
-    public ConversationData getConversation(final ConversationID conversationID) {
-        return values.get(conversationID);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/SectionProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/SectionProcessor.java
@@ -1,0 +1,105 @@
+package org.betonquest.betonquest.feature.registry.processor;
+
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.quest.QuestException;
+import org.betonquest.betonquest.config.Config;
+import org.betonquest.betonquest.id.ID;
+import org.betonquest.betonquest.quest.registry.processor.QuestProcessor;
+import org.betonquest.betonquest.variables.GlobalVariableResolver;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Does the load logic around {@link T} from a configuration section.
+ *
+ * @param <I> the {@link ID} identifying the type
+ * @param <T> the type
+ */
+public abstract class SectionProcessor<I extends ID, T> extends QuestProcessor<I, T> {
+
+    /**
+     * Create a new QuestProcessor to store and execute type logic.
+     *
+     * @param log      the custom logger for this class
+     * @param readable the type name used for logging, with the first letter in upper case
+     * @param internal the section name and/or bstats topic identifier
+     */
+    public SectionProcessor(final BetonQuestLogger log, final String readable, final String internal) {
+        super(log, readable, internal);
+    }
+
+    @Override
+    public void load(final QuestPackage pack) {
+        final ConfigurationSection section = pack.getConfig().getConfigurationSection(internal);
+        if (section == null) {
+            return;
+        }
+        for (final String key : section.getKeys(false)) {
+            try {
+                final ConfigurationSection featureSection = section.getConfigurationSection(key);
+                final I identifier = getIdentifier(pack, key);
+                if (featureSection == null) {
+                    log.warn(pack, "No configuration section for '" + identifier.getFullID() + "' " + readable + "!");
+                    continue;
+                }
+                values.put(identifier, loadSection(pack, featureSection));
+            } catch (final QuestException e) {
+                log.warn("Could not load " + readable + " '" + key + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Load all {@link T} from the QuestPackage.
+     * <p>
+     * Any errors will be logged.
+     *
+     * @param pack    to load the {@link T} from
+     * @param section the section to load
+     * @return the loaded {@link T}
+     * @throws QuestException if the loading fails
+     */
+    protected abstract T loadSection(QuestPackage pack, ConfigurationSection section) throws QuestException;
+
+    /**
+     * Loads value(s) from a key in a section, potentially identified by a language key.
+     * When there is no section the value will be identified by the default language.
+     *
+     * @param pack    the pack to resolve variables
+     * @param section the section to load from
+     * @param name    the key to load the values
+     * @return the values identified by the language key
+     * @throws QuestException if there is no value
+     */
+    protected Map<String, String> parseWithLanguage(final QuestPackage pack, final ConfigurationSection section, final String name)
+            throws QuestException {
+        final Map<String, String> map = new HashMap<>();
+        if (section.isConfigurationSection(name)) {
+            final ConfigurationSection subSection = section.getConfigurationSection(name);
+            if (subSection == null) {
+                throw new QuestException("No configuration section for '" + name + "'!");
+            }
+            for (final String key : subSection.getKeys(false)) {
+                map.put(key, GlobalVariableResolver.resolve(pack, subSection.getString(key)));
+            }
+        } else {
+            map.put(Config.getLanguage(), GlobalVariableResolver.resolve(pack, section.getString(name)));
+        }
+        if (map.isEmpty()) {
+            throw new QuestException("No values in " + name);
+        }
+        return map;
+    }
+
+    /**
+     * Get the loaded {@link T} by their ID.
+     *
+     * @return loaded values map, reflecting changes
+     */
+    public Map<I, T> getValues() {
+        return values;
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/feature/registry/processor/SectionProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/feature/registry/processor/SectionProcessor.java
@@ -70,26 +70,28 @@ public abstract class SectionProcessor<I extends ID, T> extends QuestProcessor<I
      *
      * @param pack    the pack to resolve variables
      * @param section the section to load from
-     * @param name    the key to load the values
+     * @param path    where the value(s) are stored
      * @return the values identified by the language key
      * @throws QuestException if there is no value
      */
-    protected Map<String, String> parseWithLanguage(final QuestPackage pack, final ConfigurationSection section, final String name)
+    protected Map<String, String> parseWithLanguage(final QuestPackage pack, final ConfigurationSection section, final String path)
             throws QuestException {
         final Map<String, String> map = new HashMap<>();
-        if (section.isConfigurationSection(name)) {
-            final ConfigurationSection subSection = section.getConfigurationSection(name);
+        if (section.isConfigurationSection(path)) {
+            final ConfigurationSection subSection = section.getConfigurationSection(path);
             if (subSection == null) {
-                throw new QuestException("No configuration section for '" + name + "'!");
+                throw new QuestException("No configuration section for '" + path + "'!");
             }
             for (final String key : subSection.getKeys(false)) {
                 map.put(key, GlobalVariableResolver.resolve(pack, subSection.getString(key)));
             }
+        } else if (section.isString(path)) {
+            map.put(Config.getLanguage(), GlobalVariableResolver.resolve(pack, section.getString(path)));
         } else {
-            map.put(Config.getLanguage(), GlobalVariableResolver.resolve(pack, section.getString(name)));
+            throw new QuestException("The '" + path + "' is missing!");
         }
         if (map.isEmpty()) {
-            throw new QuestException("No values in " + name);
+            throw new QuestException("No values defined for '" + path + "'!");
         }
         return map;
     }

--- a/src/main/java/org/betonquest/betonquest/id/CompassID.java
+++ b/src/main/java/org/betonquest/betonquest/id/CompassID.java
@@ -1,0 +1,32 @@
+package org.betonquest.betonquest.id;
+
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.quest.QuestException;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a quest compass ID.
+ */
+public class CompassID extends ID {
+
+    /**
+     * Creates new QuestCompassID instance.
+     *
+     * @param pack       the package where the identifier was used in
+     * @param identifier the identifier of the quest compass
+     * @throws QuestException if the instruction could not be created or
+     *                        when the quest compass could not be resolved with the given identifier
+     */
+    public CompassID(@Nullable final QuestPackage pack, final String identifier) throws QuestException {
+        super(pack, identifier, "compass", "Compass");
+    }
+
+    /**
+     * Get the full path of the tag to indicate a quest compass should be shown.
+     *
+     * @return the compass tag
+     */
+    public String getCompassTag() {
+        return getPackage().getQuestPath() + ".compass-" + getBaseID();
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/id/ID.java
+++ b/src/main/java/org/betonquest/betonquest/id/ID.java
@@ -27,7 +27,7 @@ public abstract class ID {
      * A list of all objects that can be addressed via this ID.
      */
     public static final List<String> PATHS = List.of("events", "conditions", "objectives", "variables",
-            "conversations", "cancel", "items");
+            "conversations", "cancel", "items", "compass");
 
     /**
      * The package the object is in.

--- a/src/main/java/org/betonquest/betonquest/quest/event/compass/CompassEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/compass/CompassEventFactory.java
@@ -1,21 +1,14 @@
 package org.betonquest.betonquest.quest.event.compass;
 
-import org.betonquest.betonquest.BetonQuest;
-import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.feature.FeatureAPI;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.event.Event;
 import org.betonquest.betonquest.api.quest.event.EventFactory;
-import org.betonquest.betonquest.config.Config;
 import org.betonquest.betonquest.data.PlayerDataStorage;
+import org.betonquest.betonquest.id.CompassID;
 import org.betonquest.betonquest.instruction.Instruction;
-import org.betonquest.betonquest.instruction.variable.location.VariableLocation;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.event.PrimaryServerThreadEvent;
-import org.betonquest.betonquest.util.Utils;
-import org.betonquest.betonquest.variables.GlobalVariableResolver;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.PluginManager;
 
 /**
@@ -23,9 +16,9 @@ import org.bukkit.plugin.PluginManager;
  */
 public class CompassEventFactory implements EventFactory {
     /**
-     * Custom {@link BetonQuestLogger} instance for this class.
+     * Feature API.
      */
-    private final BetonQuestLogger log;
+    private final FeatureAPI featureAPI;
 
     /**
      * Storage to get the offline player data.
@@ -45,14 +38,14 @@ public class CompassEventFactory implements EventFactory {
     /**
      * Create the compass event factory.
      *
-     * @param loggerFactory logger factory to use
+     * @param featureAPI    the Feature API
      * @param dataStorage   the storage for used player data
      * @param pluginManager plugin manager to use
      * @param data          the data for primary server thread access
      */
-    public CompassEventFactory(final BetonQuestLoggerFactory loggerFactory, final PlayerDataStorage dataStorage,
+    public CompassEventFactory(final FeatureAPI featureAPI, final PlayerDataStorage dataStorage,
                                final PluginManager pluginManager, final PrimaryServerThreadData data) {
-        this.log = loggerFactory.create(CompassEvent.class);
+        this.featureAPI = featureAPI;
         this.dataStorage = dataStorage;
         this.pluginManager = pluginManager;
         this.data = data;
@@ -61,25 +54,9 @@ public class CompassEventFactory implements EventFactory {
     @Override
     public Event parseEvent(final Instruction instruction) throws QuestException {
         final CompassTargetAction action = instruction.getEnum(CompassTargetAction.class);
-        final String compass = Utils.addPackage(instruction.getPackage(), instruction.next());
-        final VariableLocation compassLocation = getCompassLocation(compass);
+        final CompassID compassId = instruction.getID(CompassID::new);
         return new PrimaryServerThreadEvent(
-                new CompassEvent(log, dataStorage, pluginManager, action, compass, compassLocation, instruction.getPackage()),
+                new CompassEvent(featureAPI, dataStorage, pluginManager, action, compassId),
                 data);
-    }
-
-    private VariableLocation getCompassLocation(final String compass) throws QuestException {
-        final String[] split = compass.split("\\.", 2);
-        final QuestPackage targetPack = Config.getPackages().get(split[0]);
-        if (targetPack == null) {
-            throw new QuestException("QuestPackage '" + split[0] + "' not found");
-        }
-        final ConfigurationSection section = targetPack.getConfig().getConfigurationSection("compass." + split[1]);
-        if (section == null) {
-            throw new QuestException("The compass '" + compass + "' does not exist");
-        }
-        final String location = GlobalVariableResolver.resolve(targetPack, section.getString("location"));
-        return new VariableLocation(BetonQuest.getInstance().getVariableProcessor(), targetPack,
-                Utils.getNN(location, "Missing location in compass section"));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/CoreQuestTypes.java
@@ -327,7 +327,7 @@ public class CoreQuestTypes {
         eventTypes.registerCombined("chestclear", new ChestClearEventFactory(data));
         eventTypes.registerCombined("chestgive", new ChestGiveEventFactory(data));
         eventTypes.registerCombined("chesttake", new ChestTakeEventFactory(data));
-        eventTypes.register("compass", new CompassEventFactory(loggerFactory, dataStorage, server.getPluginManager(), data));
+        eventTypes.register("compass", new CompassEventFactory(betonQuest.getFeatureAPI(), dataStorage, server.getPluginManager(), data));
         eventTypes.registerCombined("command", new CommandEventFactory(loggerFactory, data));
         eventTypes.register("conversation", new ConversationEventFactory(loggerFactory, data, pluginMessage));
         eventTypes.register("damage", new DamageEventFactory(loggerFactory, data));

--- a/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
@@ -6,6 +6,7 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.bstats.InstructionMetricsSupplier;
 import org.betonquest.betonquest.config.PluginMessage;
+import org.betonquest.betonquest.feature.registry.CompassProcessor;
 import org.betonquest.betonquest.feature.registry.FeatureRegistries;
 import org.betonquest.betonquest.feature.registry.processor.CancellerProcessor;
 import org.betonquest.betonquest.feature.registry.processor.ConversationProcessor;
@@ -64,6 +65,11 @@ public class QuestRegistry {
     private final ConversationProcessor conversationProcessor;
 
     /**
+     * Compasses.
+     */
+    private final CompassProcessor compassProcessor;
+
+    /**
      * Create a new Registry for storing and using Conditions, Events, Objectives, Variables,
      * Conversations and Quest canceller.
      *
@@ -84,6 +90,7 @@ public class QuestRegistry {
         this.variableProcessor = new VariableProcessor(loggerFactory.create(VariableProcessor.class), questTypeRegistries.variable());
         this.cancellerProcessor = new CancellerProcessor(loggerFactory.create(CancellerProcessor.class), pluginMessage);
         this.conversationProcessor = new ConversationProcessor(loggerFactory.create(ConversationProcessor.class), plugin);
+        this.compassProcessor = new CompassProcessor(loggerFactory.create(CompassProcessor.class), variableProcessor);
     }
 
     /**
@@ -101,6 +108,7 @@ public class QuestRegistry {
         variableProcessor.clear();
         cancellerProcessor.clear();
         conversationProcessor.clear();
+        compassProcessor.clear();
 
         for (final QuestPackage pack : packages) {
             final String packName = pack.getQuestPath();
@@ -111,6 +119,7 @@ public class QuestRegistry {
             objectiveProcessor.load(pack);
             conversationProcessor.load(pack);
             eventScheduling.loadData(pack);
+            compassProcessor.load(pack);
 
             log.debug(pack, "Everything in package " + packName + " loaded");
         }
@@ -197,5 +206,14 @@ public class QuestRegistry {
      */
     public ConversationProcessor conversations() {
         return conversationProcessor;
+    }
+
+    /**
+     * Gets the class processing compass logic.
+     *
+     * @return compass logic
+     */
+    public CompassProcessor compasses() {
+        return compassProcessor;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
@@ -89,7 +89,8 @@ public class QuestRegistry {
         this.objectiveProcessor = new ObjectiveProcessor(loggerFactory.create(ObjectiveProcessor.class), questTypeRegistries.objective());
         this.variableProcessor = new VariableProcessor(loggerFactory.create(VariableProcessor.class), questTypeRegistries.variable());
         this.cancellerProcessor = new CancellerProcessor(loggerFactory.create(CancellerProcessor.class), loggerFactory, pluginMessage, variableProcessor);
-        this.conversationProcessor = new ConversationProcessor(loggerFactory.create(ConversationProcessor.class), plugin);
+        this.conversationProcessor = new ConversationProcessor(loggerFactory.create(ConversationProcessor.class), loggerFactory, plugin, variableProcessor,
+                otherRegistries.conversationIO(), otherRegistries.interceptor());
         this.compassProcessor = new CompassProcessor(loggerFactory.create(CompassProcessor.class), variableProcessor);
     }
 

--- a/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/QuestRegistry.java
@@ -6,9 +6,9 @@ import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.bstats.InstructionMetricsSupplier;
 import org.betonquest.betonquest.config.PluginMessage;
-import org.betonquest.betonquest.feature.registry.CompassProcessor;
 import org.betonquest.betonquest.feature.registry.FeatureRegistries;
 import org.betonquest.betonquest.feature.registry.processor.CancellerProcessor;
+import org.betonquest.betonquest.feature.registry.processor.CompassProcessor;
 import org.betonquest.betonquest.feature.registry.processor.ConversationProcessor;
 import org.betonquest.betonquest.id.ID;
 import org.betonquest.betonquest.quest.registry.processor.ConditionProcessor;
@@ -88,7 +88,7 @@ public class QuestRegistry {
         this.eventProcessor = new EventProcessor(loggerFactory.create(EventProcessor.class), questTypeRegistries.event());
         this.objectiveProcessor = new ObjectiveProcessor(loggerFactory.create(ObjectiveProcessor.class), questTypeRegistries.objective());
         this.variableProcessor = new VariableProcessor(loggerFactory.create(VariableProcessor.class), questTypeRegistries.variable());
-        this.cancellerProcessor = new CancellerProcessor(loggerFactory.create(CancellerProcessor.class), pluginMessage);
+        this.cancellerProcessor = new CancellerProcessor(loggerFactory.create(CancellerProcessor.class), loggerFactory, pluginMessage, variableProcessor);
         this.conversationProcessor = new ConversationProcessor(loggerFactory.create(ConversationProcessor.class), plugin);
         this.compassProcessor = new CompassProcessor(loggerFactory.create(CompassProcessor.class), variableProcessor);
     }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/processor/QuestProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/processor/QuestProcessor.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.quest.registry.processor;
 
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.id.ID;
 
 import java.util.HashMap;
@@ -25,13 +26,27 @@ public abstract class QuestProcessor<I extends ID, T> {
     protected final Map<I, T> values;
 
     /**
+     * Type name used for logging.
+     */
+    protected final String readable;
+
+    /**
+     * Section name.
+     */
+    protected final String internal;
+
+    /**
      * Create a new QuestProcessor to store and execute {@link T} logic.
      *
-     * @param log the custom logger for this class
+     * @param log      the custom logger for this class
+     * @param readable the type name used for logging, with the first letter in upper case
+     * @param internal the section name and/or bstats topic identifier
      */
-    public QuestProcessor(final BetonQuestLogger log) {
+    public QuestProcessor(final BetonQuestLogger log, final String readable, final String internal) {
         this.log = log;
         this.values = new HashMap<>();
+        this.readable = readable;
+        this.internal = internal;
     }
 
     /**
@@ -58,4 +73,15 @@ public abstract class QuestProcessor<I extends ID, T> {
      * @param pack to load the {@link T} from
      */
     public abstract void load(QuestPackage pack);
+
+    /**
+     * Creates a new type ID to store the created {@link T} with it.
+     *
+     * @param pack       the package the ID is in
+     * @param identifier the id instruction string
+     * @return the new typed ID
+     * @throws QuestException if the instruction of the identifier could not be created or
+     *                        if the ID could not be parsed
+     */
+    protected abstract I getIdentifier(QuestPackage pack, String identifier) throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/quest/registry/processor/TypedQuestProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/quest/registry/processor/TypedQuestProcessor.java
@@ -25,16 +25,6 @@ public abstract class TypedQuestProcessor<I extends ID, T> extends QuestProcesso
     protected final FactoryRegistry<TypeFactory<T>> types;
 
     /**
-     * Type name used for logging.
-     */
-    private final String readable;
-
-    /**
-     * Section name and/or BStats topic identifier.
-     */
-    private final String internal;
-
-    /**
      * Create a new QuestProcessor to store and execute type logic.
      *
      * @param log      the custom logger for this class
@@ -44,10 +34,8 @@ public abstract class TypedQuestProcessor<I extends ID, T> extends QuestProcesso
      */
     public TypedQuestProcessor(final BetonQuestLogger log, final FactoryRegistry<TypeFactory<T>> types,
                                final String readable, final String internal) {
-        super(log);
+        super(log, readable, internal);
         this.types = types;
-        this.readable = readable;
-        this.internal = internal;
     }
 
     /**
@@ -105,15 +93,4 @@ public abstract class TypedQuestProcessor<I extends ID, T> extends QuestProcesso
             log.warn(pack, "Error in '" + identifier + "' " + readable + " (" + type + "): " + e.getMessage(), e);
         }
     }
-
-    /**
-     * Creates a new type ID to store the created {@link T} with it.
-     *
-     * @param pack       the package the ID is in
-     * @param identifier the id instruction string
-     * @return the new typed ID
-     * @throws QuestException if the instruction of the identifier could not be created or
-     *                        if the ID could not be parsed
-     */
-    protected abstract I getIdentifier(QuestPackage pack, String identifier) throws QuestException;
 }

--- a/src/main/java/org/betonquest/betonquest/quest/variable/name/NpcNameVariable.java
+++ b/src/main/java/org/betonquest/betonquest/quest/variable/name/NpcNameVariable.java
@@ -30,6 +30,6 @@ public class NpcNameVariable implements PlayerVariable {
         if (conv == null) {
             return "";
         }
-        return conv.getData().getQuester(dataStorage.get(profile).getLanguage());
+        return conv.getData().getPublicData().getQuester(dataStorage.get(profile).getLanguage());
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Create new Quest Compass, move Canceler creation into Processor and move public values from ConversationData into it.
In whole a cleanup of responsibilites.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
