### PR TITLE
fix new message parser does not handle line breaks correctly

### DIFF
--- a/src/main/java/org/betonquest/betonquest/feature/CoreFeatureFactories.java
+++ b/src/main/java/org/betonquest/betonquest/feature/CoreFeatureFactories.java
@@ -118,7 +118,7 @@ public class CoreFeatureFactories {
         messageParserRegistry.register("minimessage", new MiniMessageParser(miniMessage));
         final MiniMessage legacyMiniMessage = MiniMessage.builder()
                 .preProcessor(input -> {
-                    final TextComponent deserialize = legacySerializer.deserialize(ChatColor.translateAlternateColorCodes('&', input));
+                    final TextComponent deserialize = legacySerializer.deserialize(ChatColor.translateAlternateColorCodes('&', input.replaceAll("\\\\n", "\n")));
                     final String serialize = miniMessage.serialize(deserialize);
                     return serialize.replaceAll("\\\\<", "<");
                 })

--- a/src/main/java/org/betonquest/betonquest/message/parser/LegacyParser.java
+++ b/src/main/java/org/betonquest/betonquest/message/parser/LegacyParser.java
@@ -29,6 +29,6 @@ public class LegacyParser implements MessageParser {
 
     @Override
     public Component parse(final String message) {
-        return serializer.deserialize(ChatColor.translateAlternateColorCodes('&', message));
+        return serializer.deserialize(ChatColor.translateAlternateColorCodes('&', message.replaceAll("\\\\n", "\n")));
     }
 }

--- a/src/main/java/org/betonquest/betonquest/message/parser/MineDownMessageParser.java
+++ b/src/main/java/org/betonquest/betonquest/message/parser/MineDownMessageParser.java
@@ -26,7 +26,7 @@ public class MineDownMessageParser implements MessageParser {
 
     @Override
     public Component parse(final String message) {
-        final MineDown mineDown = new MineDown(message);
+        final MineDown mineDown = new MineDown(message.replaceAll("\\\\n", "\n"));
         for (final Consumer<MineDown> consumer : mineDownOptions) {
             consumer.accept(mineDown);
         }


### PR DESCRIPTION
this could lead to issues in multiline text, and the title notify io which split title and subtitle at the linebreak

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
