### PR TITLE
start and stop sound in the configuration for conversations were rem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Plugin Messages / Translations
 - `region` and `wand` conditions now supports variables
 - `JobsReborn`, `Quests`, `McMMO` now supports variables
+- notification categories `conversation_start` and `conversation_end`
 ### Changed
 - Spigot is no longer supported, paper is now required 
 - message.yml file was deleted and instead the lang folder now contains all translations
@@ -36,6 +37,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 - undocumented prefix feature in conversation
 - `citizens_npcs_by_name` config option, which is now part of the id
+- start and stop sound in the configuration for conversations were removed in favor of the notification system that now also has the two new build in categories `conversation_start` and `conversation_end`
 ### Fixed
 - Reloading plugin did not reload Menu config
 - potions generated not extended/upgraded since 2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `%quester%` variable is used instead of `%npc%` for the quester's name in conversations; `%npc` variable is used now for the new Npc system
 - `fish` objective use block selector instead of a QuestItem
 - everything that used `Citizens` NPC ids now uses the BQ NpcIDs
+- conversations now always print their start and stop conversation message
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
+++ b/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
@@ -17,6 +17,7 @@ Steps marked with :gear: are migrated automatically. Steps marked with :exclamat
 - [3.0.0-DEV-71 - Renamed Translation Keys](#300-dev-71-renamed-translation-keys) :gear:
 - [3.0.0-DEV-114 - Npc Rework](#300-dev-114-npc-rework) :exclamation:
 - [3.0.0-DEV-135 - Citizens Adaption to NpcID](#300-dev-135-citizens-adaption-to-npcid) :exclamation:
+- [3.0.0-DEV-142 - Conversation Sounds](#300-dev-142-conversation-sounds) :exclamation:
 
 ### 3.0.0-DEV-58 - Delete messages.yml :exclamation:
 
@@ -211,4 +212,29 @@ objectives:
 1. The `0` before the ':' is now the BetonQuest ID, where the `citizens 0` defines the Npc with id "0" from the 
 Citizens integration. 
 2. The `0` is here the BetonQuest NpcID but stays the same.
+</div>
+
+### 3.0.0-DEV-142 - Conversation Sounds :exclamation:
+
+The start and stop sound in the configuration for conversations were removed in favor of the notification system,
+that now also has the two new build in categories `conversation_start` and `conversation_end`.
+
+To get the previous sounds back, you need to configure it now like the following in any quest package:
+
+<div class="grid" markdown>
+
+```YAML title="Old Syntax (config.yml)"
+sounds:
+  start: ENTITY_VILLAGER_AMBIENT
+  end: ENTITY_VILLAGER_YES
+```
+
+```YAML title="New Syntax"
+notifications:
+  conversation_start:
+    sound: ENTITY_VILLAGER_AMBIENT
+  conversation_end:
+    sound: ENTITY_VILLAGER_YES
+```
+
 </div>

--- a/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
+++ b/docs/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md
@@ -247,16 +247,21 @@ notifications:
 | Inventory Full Backpack | inventory_full_backpack, inventory_full, *error* | 
 | Inventory Full Drop     | inventory_full_drop, inventory_full, *error*     | 
 | Language Changed        | language_changed, *info*                         | 
+| Quest Cancelled         | quest_cancelled, *info*                          | 
+| New Journal Entry       | new_journal_entry, *info*                        | 
+| Conversation start      | conversation_start, *info*                       |
+| Conversation end        | conversation_end, *info*                         |
+| Conversation blocked    | busy, *error*                                    | 
 | Money Given             | money_given, *info*                              | 
 | Money Taken             | money_taken, *info*                              | 
-| Quest Cancelled         | quest_cancelled, *info*                          | 
-| Items Given             | items_given, *info*                              | 
-| New Journal Entry       | new_journal_entry, *info*                        | 
-| Conversation blocked    | busy, *error*                                    | 
 
 
 | Notifications     | Categories               |
 |-------------------|--------------------------|
+| Items Given       | items_given, *info*      | 
+| Points given      | point_given, *info*      |
+| Points taken      | point_taken, *info*      |
+| Points multiplied | point_multiplied, *info* |
 | Animals to Breed  | animals_to_breed, *info* |
 | Blocks to Break   | blocks_to_break, *info*  |
 | Blocks to Place   | blocks_to_place, *info*  |
@@ -265,9 +270,6 @@ notifications:
 | Fish to catch     | fish_to_catch, *info*    |
 | Players to kill   | players_to_kill, *info*  |
 | Potions to brew   | potions_to_brew, *info*  |
-| Points given      | point_given, *info*      |
-| Points taken      | point_taken, *info*      |
-| Points multiplied | point_multiplied, *info* |
 | Sheep to shear    | sheep_to_shear, *info*   |
 
 </div>

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/conversation/MenuConvIO.java
@@ -686,14 +686,6 @@ public class MenuConvIO extends ChatConvIO {
         };
     }
 
-    /**
-     * @return if this conversationIO should send messages to the player when the conversation starts and ends
-     */
-    @Override
-    public boolean printMessages() {
-        return false;
-    }
-
     @SuppressWarnings("PMD.CollapsibleIfStatements")
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void playerInteractEvent(final PlayerInteractEvent event) {

--- a/src/main/java/org/betonquest/betonquest/config/Config.java
+++ b/src/main/java/org/betonquest/betonquest/config/Config.java
@@ -5,11 +5,7 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
-import org.betonquest.betonquest.api.profile.OnlineProfile;
-import org.bukkit.Sound;
-import org.bukkit.entity.Player;
 
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -65,23 +61,5 @@ public final class Config {
      */
     public static String getLanguage() {
         return lang;
-    }
-
-    /**
-     * Plays a sound specified in the plugin's config to the player.
-     *
-     * @param onlineProfile the {@link OnlineProfile} of the player
-     * @param soundName     the name of the sound to play to the player
-     */
-    public static void playSound(final OnlineProfile onlineProfile, final String soundName) {
-        final Player player = onlineProfile.getPlayer();
-        final String rawSound = plugin.getPluginConfig().getString("sounds." + soundName);
-        if (!"false".equalsIgnoreCase(rawSound)) {
-            try {
-                player.playSound(player.getLocation(), Sound.valueOf(rawSound), 1F, 1F);
-            } catch (final IllegalArgumentException e) {
-                player.playSound(player.getLocation(), rawSound.toLowerCase(Locale.ROOT), 1F, 1F);
-            }
-        }
     }
 }

--- a/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -436,10 +436,7 @@ public class Conversation implements Listener {
             for (final EventID event : data.getPublicData().finalEvents()) {
                 BetonQuest.getInstance().getQuestTypeAPI().event(onlineProfile, event);
             }
-            //only display status messages if conversationIO allows it
-            if (conv.inOut.printMessages()) {
-                endSender.sendNotification(onlineProfile, new PluginMessage.Replacement("npc", data.getPublicData().getQuester(log, onlineProfile)));
-            }
+            endSender.sendNotification(onlineProfile, new PluginMessage.Replacement("npc", data.getPublicData().getQuester(log, onlineProfile)));
 
             // End interceptor after a second
             if (interceptor != null) {
@@ -783,10 +780,7 @@ public class Conversation implements Listener {
                     // first select the option before sending message, so it
                     // knows which is used
                     selectOption(resolvedOptions, false);
-
-                    if (conv.inOut.printMessages()) {
-                        startSender.sendNotification(onlineProfile, new PluginMessage.Replacement("npc", data.getPublicData().getQuester(log, onlineProfile)));
-                    }
+                    startSender.sendNotification(onlineProfile, new PluginMessage.Replacement("npc", data.getPublicData().getQuester(log, onlineProfile)));
                 } else {
                     final List<ResolvedOption> resolvedOptions = resolveOptions(startingOptions);
                     selectOption(resolvedOptions, true);

--- a/src/main/java/org/betonquest/betonquest/conversation/ConversationIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/ConversationIO.java
@@ -43,13 +43,6 @@ public interface ConversationIO {
     void end();
 
     /**
-     * @return if this conversationIO should send messages to the player when the conversation starts and ends
-     */
-    default boolean printMessages() {
-        return true;
-    }
-
-    /**
      * Send message through ConversationIO
      *
      * @param message The message to send

--- a/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
@@ -403,11 +403,6 @@ public class InventoryConvIO implements Listener, ConversationIO {
         return inv != null && conv.nextNPCOption == null;
     }
 
-    @Override
-    public boolean printMessages() {
-        return printMessages;
-    }
-
     /**
      * Inventory GUI that also outputs the conversation to chat.
      */

--- a/src/main/resources/config.patch.yml
+++ b/src/main/resources/config.patch.yml
@@ -1,4 +1,9 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.0.0.4:
+  - type: DELETE
+    key: sounds.start
+  - type: DELETE
+    key: sounds.end
 3.0.0.3:
   - type: REMOVE
     key: citizens_npcs_by_name

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,9 +43,6 @@ quest_items_unbreakable: true
 player_hider_check_interval: 20
 npc_hider_check_interval: 100
 hologram_update_interval: 200
-sounds:
-  start: ENTITY_VILLAGER_AMBIENT
-  end: ENTITY_VILLAGER_YES
 cmd_blacklist:
   - spawn
 hook:


### PR DESCRIPTION
…oved in favor of the notification system that now also has the two new build in categories `conversation_start` and `conversation_end`

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/ConfigurationFiles/#updating-configurationfiles)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
