### PR TITLE
Add reload hint to item command

### DIFF
--- a/src/main/resources/messages-internal.yml
+++ b/src/main/resources/messages-internal.yml
@@ -18,7 +18,10 @@ specify_key: '@[legacy]&cSpecify valid key'
 package_created: '@[legacy]&2Package created'
 package_exists: '@[legacy]&cPackage already exists'
 config_set_error: '@[legacy]&cCould not set specified path.'
-item_created: '@[legacy]&2Item saved to configuration as {item}.'
+item_created: >-
+  @[minimessage]<dark_green>Item saved to configuration as {item}.</dark_green>
+  <yellow><click:suggest_command:'/bq reload'><hover:show_text:'<yellow>A <green>reload</green> is required to apply the change.</yellow> 
+  <newline>Click to suggest the <yellow>/bq reload</yellow> command.'>Reload BetonQuest
 value_set: '@[legacy]&aValue {value} set for key {key}.'
 key_remove: '@[legacy]&aRemoved key {key}.'
 player_variables: '@[legacy]&aPlayer''s variables in &b{objective}&a:'


### PR DESCRIPTION
<!-- Please describe your changes here. -->
The Processor for items "broke" (events using that item already did not update it) the adding without a reload.
Since I don't want to break my built structure nor the loaded state of quests a reload is required.
![grafik](https://github.com/user-attachments/assets/7b09b9fc-c46e-493c-adfa-ad397746acf6)
*Added a " BetonQuest" after the yellow Reload

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/Configuration-Files/#updating-configurations)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
