### PR TITLE
Allow (constant) variables in Simple QuestItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mooncycle` condition is now `moonphase` and uses a variable list of the phases instead of numbers
 - `item` command now requires the specification of serializer
 - `npcs` in the `npc_holograms` and `npcs`, `conditions` and `locations` in the `effectlib` section now use comma separated lists
-- in quest cancelers the events are now executed before the teleport 
+- in quest cancelers the events are now executed before the teleport
+- `simple` quest items now resolve variables one time on reload to support `constant` variables
+    - `owner:%player%` was changed to `owner:` to allow constant pre-parsing
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
+++ b/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
@@ -42,6 +42,7 @@ This guide explains how to migrate from the latest BetonQuest 2.X version to Bet
 - [3.0.0-DEV-267 - MoonPhases rename](#300-dev-267-moonphase-rename) :sun:
 - [3.0.0-DEV-274 - String List remove](#300-dev-274-string-list-remove) :sun:
 - [3.0.0-DEV-277 - Rename Constants](#300-dev-277-rename-constants) :white_sun_cloud:
+- [3.0.0-DEV-284 - Rename Constants](#300-dev-284-change-head-owner) :sun:
 
 ### 3.0.0-DEV-58 - Delete messages.yml :thunder_cloud_rain:
 
@@ -499,6 +500,28 @@ and if you only want sounds and no message, you use `sound` instead of `suppress
       MyCustomVariable: %constant.MyVariable% World
     events:
       sendNotify: notify %constant.MyCustomVariable%
+    ```
+    
+    </div>
+
+### 3.0.0-DEV-284 - Change Head Owner :sun:
+??? info "Automated Migration"
+    *The migration is automated. You shouldn't have to do anything.*
+    
+    -------------
+    
+    To allow pre-parsing of `constant` variables in `simple` Quest Items the `owner:%player%` has been replaced with `owner:`.
+    
+    <div class="grid" markdown>
+    
+    ```YAML title="Old Syntax"
+    items:
+      head: simple PLAYER_HEAD owner:%player%
+    ```
+    
+    ```YAML title="New Syntax"
+    items:
+      head: 'simple PLAYER_HEAD owner:'
     ```
     
     </div>

--- a/docs/Documentation/Features/Items.md
+++ b/docs/Documentation/Features/Items.md
@@ -14,7 +14,7 @@ item: simple BLOCK_SELECTOR other arguments...
 [BLOCK_SELECTOR](../Scripting/Data-Formats.md#block-selectors) is a type of the item. It doesn't have to be all in uppercase.
 Other arguments specify data like name of the item, lore, enchantments or potion effects.
 There are two categories of these arguments: the ones you can apply to every item and type specific arguments.
-Examples would be name (for every item type) and text (only in books).
+Examples would be `name` (for every item type) and `text` (only in books).
 
 Every argument is used in two ways: when creating an item and when checking if some existing item matches the instruction.
 The first case is pretty straightforward - BetonQuest takes all data you specified and creates an item, simple as that.
@@ -152,7 +152,7 @@ effects:none-weakness,invisibility:?:? effects-containing
 
 - `owner` - this is the name of the head owner. It will **not** use color codes nor replace underscores with spaces.
     If you want to check for heads without any owner, use `none` keyword.
-  - Use `%player%` to get the current players head.
+  - Use `owner:` to get the current players head. You need to quote the whole instruction when using that.
 
 ```YAML title="Examples"
 owner:Co0sh

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
@@ -11,6 +11,7 @@ import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.Pack
 import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.RemoveEntity;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.RideUpdates;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.AddSimpleTypeToQuestItem;
+import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.HeadOwnerMigrator;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.LanguageRename;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.ListNamesRenameToPlural;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.MoonPhaseRename;
@@ -113,6 +114,7 @@ public class QuestMigrator {
         migrations.put(questVersion("3.0.0", 7), new MoonPhaseRename());
         migrations.put(questVersion("3.0.0", 8), new RemoveStringList());
         migrations.put(questVersion("3.0.0", 9), new VariablesRename());
+        migrations.put(questVersion("3.0.0", 10), new HeadOwnerMigrator());
         this.fallbackVersion = questVersion(pluginDescription.getVersion(), 0);
     }
 

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/HeadOwnerMigrator.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/HeadOwnerMigrator.java
@@ -1,0 +1,21 @@
+package org.betonquest.betonquest.config.patcher.migration.migrator.from2to3;
+
+import org.betonquest.betonquest.config.patcher.migration.QuestMigration;
+import org.betonquest.betonquest.config.quest.Quest;
+import org.bukkit.configuration.InvalidConfigurationException;
+
+/**
+ * Changes the %player% to empty string.
+ */
+public class HeadOwnerMigrator implements QuestMigration {
+    /**
+     * Create a new HeadOwner Migrator.
+     */
+    public HeadOwnerMigrator() {
+    }
+
+    @Override
+    public void migrate(final Quest quest) throws InvalidConfigurationException {
+        replaceValueInSection(quest.getQuestConfig(), "items", "simple", "owner:%player%", "owner:");
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
+++ b/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.item;
 
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.instruction.Instruction;
+import org.betonquest.betonquest.instruction.argument.Argument;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.CustomModelDataHandler;
@@ -19,6 +20,7 @@ import org.betonquest.betonquest.kernel.registry.TypeFactory;
 import org.betonquest.betonquest.util.BlockSelector;
 import org.betonquest.betonquest.util.Utils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -78,13 +80,10 @@ public class SimpleQuestItemFactory implements TypeFactory<QuestItem> {
 
     @Override
     public QuestItem parseInstruction(final Instruction instruction) throws QuestException {
-        final String material = instruction.next();
-        final List<String> arguments;
-        if (instruction.hasNext()) {
-            final List<String> valueParts = instruction.getValueParts();
-            arguments = valueParts.subList(1, valueParts.size());
-        } else {
-            arguments = List.of();
+        final String material = instruction.get(Argument.STRING).getValue(null);
+        final List<String> arguments = new ArrayList<>(instruction.size() - 1);
+        while (instruction.hasNext()) {
+            arguments.add(instruction.get(Argument.STRING).getValue(null));
         }
         return parseInstruction(material, arguments);
     }

--- a/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
+++ b/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
@@ -43,7 +43,7 @@ public class SimpleQuestItemFactory implements TypeFactory<QuestItem> {
      * @throws QuestException when an error occurs while parsing
      */
     public QuestItem parseInstruction(final String string) throws QuestException {
-        final String[] split = string.split(",");
+        final String[] split = string.split(" ");
         final String material = split[0];
         final List<String> arguments = split.length > 1 ? List.of(split).subList(1, split.length) : List.of();
         return parseInstruction(material, arguments);

--- a/src/main/java/org/betonquest/betonquest/item/typehandler/HeadHandler.java
+++ b/src/main/java/org/betonquest/betonquest/item/typehandler/HeadHandler.java
@@ -38,11 +38,6 @@ public class HeadHandler implements ItemMetaHandler<SkullMeta> {
     public static final String META_TEXTURE = "texture";
 
     /**
-     * Variable placeholder literal for player name.
-     */
-    private static final String VARIABLE_PLAYER_NAME = "%player%";
-
-    /**
      * Existence of the player UUID.
      */
     private Existence playerIdE = Existence.WHATEVER;
@@ -202,7 +197,7 @@ public class HeadHandler implements ItemMetaHandler<SkullMeta> {
      */
     @Nullable
     public Profile getOwner(@Nullable final Profile profile) {
-        if (profile != null && VARIABLE_PLAYER_NAME.equals(owner)) {
+        if (profile != null && owner != null && owner.isEmpty()) {
             return profile;
         }
         if (owner != null) {


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Currently there is no variable support at all but the `constants` require it at least at reload.
- [x] Fix the issue with `owner:%player%` throwing errors on "pre"-resolving

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/Configuration-Files/#updating-configurations)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
