### PR TITLE
just parse the whole instruction as variable to allow using constants with spaces

### DIFF
--- a/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
+++ b/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
@@ -20,7 +20,6 @@ import org.betonquest.betonquest.kernel.registry.TypeFactory;
 import org.betonquest.betonquest.util.BlockSelector;
 import org.betonquest.betonquest.util.Utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -79,11 +78,16 @@ public class SimpleQuestItemFactory implements TypeFactory<QuestItem> {
     }
 
     @Override
-    public QuestItem parseInstruction(final Instruction instruction) throws QuestException {
-        final String material = instruction.get(Argument.STRING).getValue(null);
-        final List<String> arguments = new ArrayList<>(instruction.size() - 1);
-        while (instruction.hasNext()) {
-            arguments.add(instruction.get(Argument.STRING).getValue(null));
+    public QuestItem parseInstruction(final Instruction rawInstruction) throws QuestException {
+        final String instructionString = rawInstruction.get(rawInstruction.toString(), Argument.STRING).getValue(null);
+        final Instruction instruction = new Instruction(rawInstruction.getPackage(), rawInstruction.getID(), instructionString);
+        final String material = instruction.next();
+        final List<String> arguments;
+        if (instruction.hasNext()) {
+            final List<String> valueParts = instruction.getValueParts();
+            arguments = valueParts.subList(1, valueParts.size());
+        } else {
+            arguments = List.of();
         }
         return parseInstruction(material, arguments);
     }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
… for more than one part and keeping quoting
There is no eval equivalent and there won't be one.
Tested with
```yaml
constants:
  paper: 'PAPER custom-model-data:100'
  paper2: '"lore:I bin ei Bärliner" name:Amerika'
items:
  PaperITem: simple %constant.paper% %constant.paper2%
```

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... adjust the [ConfigPatcher](https://betonquest.org/DEV/API/Configuration-Files/#updating-configurations)?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
