### PR TITLE
support math variable in VariablesRename migrator

### DIFF
--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRename.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRename.java
@@ -5,8 +5,11 @@ import org.betonquest.betonquest.config.patcher.migration.QuestMigration;
 import org.betonquest.betonquest.config.quest.Quest;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -73,26 +76,41 @@ public class VariablesRename implements QuestMigration {
         }
     }
 
-    private String replaceGlobalVariables(final String input) {
-        final Pattern pattern = Pattern.compile("(?<!\\\\)\\$(.*?)(?<!\\\\)\\$");
+    @VisibleForTesting
+    String replaceGlobalVariables(final String input) {
+        final String result1 = replaceRegex(input, "%math\\.(.*?)%",
+                math -> "%math." + replaceRegex(math, "(?<!\\\\)\\$(.*?)(?<!\\\\)\\$",
+                        variable -> "{" + migrateVariable(variable) + "}") + "%");
+        final String result2 = replaceRegex(result1, "(?<!\\\\)\\$(.*?)(?<!\\\\)\\$",
+                variable -> "%" + migrateVariable(variable) + "%");
+
+        return result2.replaceAll("\\\\\\$", "\\$");
+    }
+
+    @NotNull
+    private static String replaceRegex(final String input, final String regex, final Function<String, String> transformation) {
+        final Pattern pattern = Pattern.compile(regex);
         final Matcher matcher = pattern.matcher(input);
 
         final StringBuilder result = new StringBuilder();
         while (matcher.find()) {
             final String variable = matcher.group(1);
-            final String replacement;
-            if (variable.contains(".")) {
-                final int index = variable.indexOf('.');
-                final String pkg = variable.substring(0, index);
-                final String name = variable.substring(index + 1);
-                replacement = "%" + pkg + ".constant." + name + "%";
-            } else {
-                replacement = "%constant." + variable + "%";
-            }
+            final String replacement = transformation.apply(variable);
             matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(result);
+        return result.toString();
+    }
 
-        return result.toString().replaceAll("\\\\\\$", "\\$");
+    @NotNull
+    private static String migrateVariable(final String variable) {
+        if (!variable.contains(".")) {
+            return "constant." + variable;
+        }
+
+        final int index = variable.indexOf('.');
+        final String pkg = variable.substring(0, index);
+        final String name = variable.substring(index + 1);
+        return pkg + ".constant." + name;
     }
 }

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRename.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRename.java
@@ -5,7 +5,6 @@ import org.betonquest.betonquest.config.patcher.migration.QuestMigration;
 import org.betonquest.betonquest.config.quest.Quest;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.List;
@@ -87,7 +86,6 @@ public class VariablesRename implements QuestMigration {
         return result2.replaceAll("\\\\\\$", "\\$");
     }
 
-    @NotNull
     private static String replaceRegex(final String input, final String regex, final Function<String, String> transformation) {
         final Pattern pattern = Pattern.compile(regex);
         final Matcher matcher = pattern.matcher(input);
@@ -102,7 +100,6 @@ public class VariablesRename implements QuestMigration {
         return result.toString();
     }
 
-    @NotNull
     private static String migrateVariable(final String variable) {
         if (!variable.contains(".")) {
             return "constant." + variable;

--- a/src/test/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRenameTest.java
+++ b/src/test/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/VariablesRenameTest.java
@@ -1,0 +1,44 @@
+package org.betonquest.betonquest.config.patcher.migration.migrator.from2to3;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test renaming of variables to constants.
+ */
+class VariablesRenameTest {
+
+    private static Stream<Arguments> entriesToMigrate() {
+        return Stream.of(
+                Arguments.of("$foo$",
+                        "%constant.foo%"
+                ),
+                Arguments.of("$_-_-path-to.foo$",
+                        "%_-_-path-to.constant.foo%"
+                ),
+                Arguments.of("%math.calc:$foo$%",
+                        "%math.calc:{constant.foo}%"
+                ),
+                Arguments.of("%math.calc:$_-_-path-to.foo$%",
+                        "%math.calc:{_-_-path-to.constant.foo}%"
+                ),
+                Arguments.of("foo %math.calc:1+$bla$+2-$-a-b.c$% $bar$ $-a-b.c$ bar",
+                        "foo %math.calc:1+{constant.bla}+2-{-a-b.constant.c}% %constant.bar% %-a-b.constant.c% bar"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("entriesToMigrate")
+    void variable_rename(final String original, final String expected) {
+        final VariablesRename variablesRename = new VariablesRename();
+        final String actual = variablesRename.replaceGlobalVariables(original);
+
+        assertEquals(expected, actual, "Constant is not migrated correctly");
+    }
+}


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Updating the Variables Migrator for 3.0.0 to migrate variables inside `math.calc` variables without conflicts

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
