### PR TITLE
added automatically renaming of npc events

### DIFF
--- a/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
+++ b/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
@@ -43,6 +43,7 @@ This guide explains how to migrate from the latest BetonQuest 2.X version to Bet
 - [3.0.0-DEV-274 - String List remove](#300-dev-274-string-list-remove) :sun:
 - [3.0.0-DEV-277 - Rename Constants](#300-dev-277-rename-constants) :white_sun_cloud:
 - [3.0.0-DEV-284 - Rename Constants](#300-dev-284-change-head-owner) :sun:
+- [3.0.0-DEV-299 - NPC events rename](#300-dev-299-npc-events-rename) :sun:
 
 ### 3.0.0-DEV-58 - Delete messages.yml :thunder_cloud_rain:
 
@@ -138,7 +139,8 @@ To support more Npc plugins than just Citizens the system got a rework.
 Npcs are now addressed with IDs and defined in the `npcs` section.
 Starting conversations with Npc interaction is moved inside the `npc_conversations` section.
 
-Also, the `teleportnpc` event got renamed to `npcteleport`.
+Also, the `teleportnpc` event got renamed to `npcteleport`. That change is automated, when updating to version
+3.0.0-DEV-299 or newer.
 
 In addition, the `npc` variable to get the quester name of the current conversation got changed to `quester`.
 That change is automated.
@@ -206,7 +208,9 @@ Citizens integration.
 ### 3.0.0-DEV-135 - Citizens Adaption to NpcID :thunder_cloud_rain:
 
 To streamline usage of Npcs the Citizens specific events and objective now also use the NpcID introduced in 3.0.0-DEV-114.
-Also, the `movenpc` and `stopnpc` events are renamed into `npcmove` and `npcstop`.
+
+Also, the `movenpc` and `stopnpc` events are renamed into `npcmove` and `npcstop`. These renames are automated, when 
+updating to version 3.0.0-DEV-299 or newer.
 
 As in the migration above stated you can either use a descriptive name as the id or use the numeric Citizens id of the Npc.
 
@@ -525,3 +529,12 @@ and if you only want sounds and no message, you use `sound` instead of `suppress
     ```
     
     </div>
+
+### 3.0.0-DEV-299 - NPC events rename  :sun:
+??? info "Automated Migration"
+    *The migration is automated. You shouldn't have to do anything.*
+    
+    -------------
+    
+    Some NPC events were renamed in the versions [3.0.0-DEV-114 - Npc Rework](#300-dev-114-npc-rework) and [3.0.
+    0-DEV-135 - Citizens Adaption to NpcID](#300-dev-135-citizens-adaption-to-npcid). These renames are automated now.

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
@@ -16,6 +16,7 @@ import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.Lang
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.ListNamesRenameToPlural;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.MoonPhaseRename;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.MoveMenuItems;
+import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.NpcEventsRename;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.NpcRename;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.PickRandomPercentage;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.RemoveStringList;
@@ -115,6 +116,7 @@ public class QuestMigrator {
         migrations.put(questVersion("3.0.0", 8), new RemoveStringList());
         migrations.put(questVersion("3.0.0", 9), new VariablesRename());
         migrations.put(questVersion("3.0.0", 10), new HeadOwnerMigrator());
+        migrations.put(questVersion("3.0.0", 11), new NpcEventsRename());
         this.fallbackVersion = questVersion(pluginDescription.getVersion(), 0);
     }
 

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/NpcEventsRename.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/NpcEventsRename.java
@@ -1,0 +1,26 @@
+package org.betonquest.betonquest.config.patcher.migration.migrator.from2to3;
+
+import org.betonquest.betonquest.api.bukkit.config.custom.multi.MultiConfiguration;
+import org.betonquest.betonquest.config.patcher.migration.QuestMigration;
+import org.betonquest.betonquest.config.quest.Quest;
+import org.bukkit.configuration.InvalidConfigurationException;
+
+/**
+ * Handles renaming of npc events.
+ */
+public class NpcEventsRename implements QuestMigration {
+
+    /**
+     * Creates a new NPC events migrator.
+     */
+    public NpcEventsRename() {
+    }
+
+    @Override
+    public void migrate(final Quest quest) throws InvalidConfigurationException {
+        final MultiConfiguration config = quest.getQuestConfig();
+        replaceStartValueInSection(config, "events", "teleportnpc", "npcteleport");
+        replaceStartValueInSection(config, "events", "movenpc", "npcmove");
+        replaceStartValueInSection(config, "events", "stopnpc", "npcstop");
+    }
+}

--- a/src/test/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/NpcEventsRenameTest.java
+++ b/src/test/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/NpcEventsRenameTest.java
@@ -1,0 +1,35 @@
+package org.betonquest.betonquest.config.patcher.migration.migrator.from2to3;
+
+import org.betonquest.betonquest.config.quest.Quest;
+import org.betonquest.betonquest.config.quest.QuestFixture;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Test for renaming npc events.
+ */
+class NpcEventsRenameTest extends QuestFixture {
+    @Test
+    void migrate() throws InvalidConfigurationException, IOException {
+        original.loadFromString("""
+                events:
+                  foo1: teleportnpc Bob 0;0;0;world
+                  foo2: movenpc Bob 0;0;0;world
+                  foo3: stopnpc Bob
+                """);
+        expected.loadFromString("""
+                events:
+                  foo1: npcteleport Bob 0;0;0;world
+                  foo2: npcmove Bob 0;0;0;world
+                  foo3: npcstop Bob
+                """);
+
+        final Quest quest = setupQuest("conv.yml");
+        new NpcEventsRename().migrate(quest);
+        quest.saveAll();
+
+        checkAssertion(quest, "conv.yml");
+    }
+}


### PR DESCRIPTION
Changes in 3.0.0-DEV-114 and DEV-135 caused a renaming of some npc events. This new migrator automates the process of renaming these manually to be able to get directly to the process of fixing the manual npc conflicts.

The docs are updated asuming this'll get dev build 299.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
