### PR TITLE
`folder` event now use the `unit` argument to define the time unit fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `simple` quest items now resolve variables one time on reload to support `constant` variables
     - `owner:%player%` was changed to `owner:` to allow constant pre-parsing
 - `math` variable now gives a better exception message and does not return 0 instead
+- `folder` event now use the `unit` argument to define the time unit for ticks, seconds and minutes
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
+++ b/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
@@ -42,7 +42,7 @@ This guide explains how to migrate from the latest BetonQuest 2.X version to Bet
 - [3.0.0-DEV-267 - MoonPhases rename](#300-dev-267-moonphase-rename) :sun:
 - [3.0.0-DEV-274 - String List remove](#300-dev-274-string-list-remove) :sun:
 - [3.0.0-DEV-277 - Rename Constants](#300-dev-277-rename-constants) :white_sun_cloud:
-- [3.0.0-DEV-284 - Rename Constants](#300-dev-284-change-head-owner) :sun:
+- [3.0.0-DEV-284 - Change Head Owner](#300-dev-284-change-head-owner) :sun:
 - [3.0.0-DEV-299 - NPC events rename](#300-dev-299-npc-events-rename) :sun:
 - [3.0.0-DEV-306 - MMOItems Item Type](#300-dev-306-mmoitems-item-type) :thunder_cloud_rain:
 - [3.0.0-DEV-313 - Folder Time Unit](#300-dev-313-folder-time-unit) :white_sun_cloud:

--- a/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
+++ b/docs/Documentation/Configuration/Version-Changes/Migration-2-3.md
@@ -45,6 +45,7 @@ This guide explains how to migrate from the latest BetonQuest 2.X version to Bet
 - [3.0.0-DEV-284 - Rename Constants](#300-dev-284-change-head-owner) :sun:
 - [3.0.0-DEV-299 - NPC events rename](#300-dev-299-npc-events-rename) :sun:
 - [3.0.0-DEV-306 - MMOItems Item Type](#300-dev-306-mmoitems-item-type) :thunder_cloud_rain:
+- [3.0.0-DEV-313 - Folder Time Unit](#300-dev-313-folder-time-unit) :white_sun_cloud:
 
 ### 3.0.0-DEV-58 - Delete messages.yml :thunder_cloud_rain:
 
@@ -582,3 +583,25 @@ objectives:
 </div>
 
 The `mmoitemupgrade` and `mmoitemapplygem` objectives exist unchanged.
+
+### 3.0.0-DEV-313 - Folder Time Unit :white_sun_cloud:
+??? info "Automated Migration"
+    *The migration is automated. You shouldn't have to do anything.*
+    
+    -------------
+    
+    To allow variables for the time unit in the `folder` event, the time unit now needs a key `unit`.
+    
+    <div class="grid" markdown>
+    
+    ```YAML title="Old Syntax"
+    events:
+      setBlocks: folder block1,block2,block3 period:10 ticks
+    ```
+    
+    ```YAML title="New Syntax"
+    events:
+      setBlocks: folder block1,block2,block3 period:10 unit:ticks
+    ```
+    
+    </div>

--- a/docs/Documentation/Frequently-Asked-Questions.md
+++ b/docs/Documentation/Frequently-Asked-Questions.md
@@ -204,7 +204,7 @@ reached a certain value.
 === "events"
     ```YAML
     # 1. increase the global points 2. wait one tick for the change to process 3. attempt to run the completion events
-    gQuestProgress: folder gQuestIncrementCounter,gQuestCheckCompletion period:1 ticks
+    gQuestProgress: folder gQuestIncrementCounter,gQuestCheckCompletion period:1 unit:ticks
     # Adds 1 to the global points
     gQuestIncrementCounter: globalpoint gQuest 1
     # Runs completion events only when the condition is met (= the global points reached X points)

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -286,7 +286,7 @@ events:
   simpleFolder: "folder event1,event2,event3" # (1)!
   runEvents: "folder event1,event2,event3 delay:5 period:1" # (2)!
   troll: "folder killPlayer,banPlayer,kickPlayer delay:5 random:1" # (3)!
-  wait: "folder messagePlayer,giveReward delay:1 minutes" # (4)!
+  wait: "folder messagePlayer,giveReward delay:1 unit:minutes" # (4)!
 ```
 
 1. Runs all events after one tick with a delay of one tick between each event.

--- a/docs/Documentation/Scripting/Building-Blocks/Events-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Events-List.md
@@ -270,15 +270,15 @@ so those events should not be blocked by any conditions!
 You can use the `cancelOnLogout` argument to stop the folder executing any remaining events if the player disconnects.
 
 
-| Parameter          | Syntax                       | Default Value          | Explanation                                                                                     |
-|--------------------|------------------------------|------------------------|-------------------------------------------------------------------------------------------------|
-| _events to run_    | eventName1,event2            | :octicons-x-circle-16: | One or multiple events to run. Contains event names seperated by commas.                        |
-| _delay_            | Keyword                      | without delay          | The delay before the folder starts executing it's events.                                       |
-| _period_           | period:number                | without delay          | The time between each event of the folder.                                                      |
-| _time unit_        | Keyword                      | Seconds                | The unit of time to use for delay and period. Either `ticks` or `minutes`. Omit to use seconds. |
-| _random_           | random:number                | Disabled               | Enables "random mode". Will randomly pick the defined amount of events .                        |
-| _cancelOnLogout_   | Keyword                      | Disabled               | If enabled, the folder will stop executing events if the player disconnects.                    |
-| _cancelConditions_ | cancelConditions:cond1,cond2 | Disabled               | If enabled, the folder will stop executing events if the conditions are true.                   |
+| Parameter          | Syntax                       | Default Value          | Explanation                                                                           |
+|--------------------|------------------------------|------------------------|---------------------------------------------------------------------------------------|
+| _events to run_    | eventName1,event2            | :octicons-x-circle-16: | One or multiple events to run. Contains event names seperated by commas.              |
+| _delay_            | Keyword                      | without delay          | The delay before the folder starts executing it's events.                             |
+| _period_           | period:number                | without delay          | The time between each event of the folder.                                            |
+| _time unit_        | unit:unit                    | Seconds                | The unit of time to use for delay and period. Either `ticks`, `minutes` or `seconds`. |
+| _random_           | random:number                | Disabled               | Enables "random mode". Will randomly pick the defined amount of events .              |
+| _cancelOnLogout_   | Keyword                      | Disabled               | If enabled, the folder will stop executing events if the player disconnects.          |
+| _cancelConditions_ | cancelConditions:cond1,cond2 | Disabled               | If enabled, the folder will stop executing events if the conditions are true.         |
 
 
 ```YAML title="Examples" 

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/QuestMigrator.java
@@ -11,6 +11,7 @@ import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.Pack
 import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.RemoveEntity;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from1to2.RideUpdates;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.AddSimpleTypeToQuestItem;
+import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.FolderTimeUnit;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.HeadOwnerMigrator;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.LanguageRename;
 import org.betonquest.betonquest.config.patcher.migration.migrator.from2to3.ListNamesRenameToPlural;
@@ -117,6 +118,7 @@ public class QuestMigrator {
         migrations.put(questVersion("3.0.0", 9), new VariablesRename());
         migrations.put(questVersion("3.0.0", 10), new HeadOwnerMigrator());
         migrations.put(questVersion("3.0.0", 11), new NpcEventsRename());
+        migrations.put(questVersion("3.0.0", 12), new FolderTimeUnit());
         this.fallbackVersion = questVersion(pluginDescription.getVersion(), 0);
     }
 

--- a/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/FolderTimeUnit.java
+++ b/src/main/java/org/betonquest/betonquest/config/patcher/migration/migrator/from2to3/FolderTimeUnit.java
@@ -1,0 +1,25 @@
+package org.betonquest.betonquest.config.patcher.migration.migrator.from2to3;
+
+import org.betonquest.betonquest.api.bukkit.config.custom.multi.MultiConfiguration;
+import org.betonquest.betonquest.config.patcher.migration.QuestMigration;
+import org.betonquest.betonquest.config.quest.Quest;
+import org.bukkit.configuration.InvalidConfigurationException;
+
+/**
+ * Migrates the folder time unit to the new format "unit:TimeUnit".
+ */
+public class FolderTimeUnit implements QuestMigration {
+    /**
+     * Creates a new folder time unit migrator.
+     */
+    public FolderTimeUnit() {
+    }
+
+    @Override
+    public void migrate(final Quest quest) throws InvalidConfigurationException {
+        final MultiConfiguration config = quest.getQuestConfig();
+        replaceValueInSection(config, "events", "folder", " ticks", " unit:ticks");
+        replaceValueInSection(config, "events", "folder", " seconds", " unit:seconds");
+        replaceValueInSection(config, "events", "folder", " minutes", " unit:minutes");
+    }
+}

--- a/src/main/java/org/betonquest/betonquest/quest/event/folder/FolderEvent.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/folder/FolderEvent.java
@@ -80,7 +80,7 @@ public class FolderEvent implements NullableEvent {
     /**
      * The time unit to use for the delay and period.
      */
-    private final TimeUnit timeUnit;
+    private final Variable<TimeUnit> timeUnit;
 
     /**
      * Whether the event should be canceled on logout.
@@ -112,7 +112,7 @@ public class FolderEvent implements NullableEvent {
     public FolderEvent(final BetonQuest betonQuest, final BetonQuestLogger log, final PluginManager pluginManager,
                        final Variable<List<EventID>> events, final QuestTypeAPI questTypeAPI, final Random randomGenerator,
                        @Nullable final Variable<Number> delay, @Nullable final Variable<Number> period,
-                       @Nullable final Variable<Number> random, final TimeUnit timeUnit, final boolean cancelOnLogout,
+                       @Nullable final Variable<Number> random, final Variable<TimeUnit> timeUnit, final boolean cancelOnLogout,
                        final Variable<List<ConditionID>> cancelConditions) {
         this.betonQuest = betonQuest;
         this.log = log;
@@ -150,6 +150,7 @@ public class FolderEvent implements NullableEvent {
     @Override
     public void execute(@Nullable final Profile profile) throws QuestException {
         final Deque<EventID> chosenList = getEventOrder(profile);
+        final TimeUnit timeUnit = this.timeUnit.getValue(profile);
         final long delayTicks = delay == null ? 0 : timeUnit.getTicks(delay.getValue(profile).longValue());
         final long periodTicks = period == null ? 0 : timeUnit.getTicks(period.getValue(profile).longValue());
         if (delayTicks == 0 && periodTicks == 0) {

--- a/src/main/java/org/betonquest/betonquest/quest/event/folder/FolderEventFactory.java
+++ b/src/main/java/org/betonquest/betonquest/quest/event/folder/FolderEventFactory.java
@@ -17,6 +17,7 @@ import org.betonquest.betonquest.instruction.variable.Variable;
 import org.bukkit.plugin.PluginManager;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 /**
@@ -75,7 +76,7 @@ public class FolderEventFactory implements PlayerEventFactory, PlayerlessEventFa
         final Variable<Number> delay = instruction.getValue("delay", Argument.NUMBER);
         final Variable<Number> period = instruction.getValue("period", Argument.NUMBER);
         final Variable<Number> random = instruction.getValue("random", Argument.NUMBER);
-        final TimeUnit timeUnit = getTimeUnit(instruction);
+        final Variable<TimeUnit> timeUnit = instruction.getValue("unit", this::getTimeUnit, TimeUnit.SECONDS);
         final boolean cancelOnLogout = instruction.hasArgument("cancelOnLogout");
         final Variable<List<ConditionID>> cancelConditions = instruction.getValueList("cancelConditions", ConditionID::new);
         return new NullableEventAdapter(new FolderEvent(betonQuest, loggerFactory.create(FolderEvent.class), pluginManager,
@@ -83,13 +84,13 @@ public class FolderEventFactory implements PlayerEventFactory, PlayerlessEventFa
                 questTypeAPI, new Random(), delay, period, random, timeUnit, cancelOnLogout, cancelConditions));
     }
 
-    private TimeUnit getTimeUnit(final Instruction instruction) {
-        if (instruction.hasArgument("ticks")) {
-            return TimeUnit.TICKS;
-        } else if (instruction.hasArgument("minutes")) {
-            return TimeUnit.MINUTES;
-        } else {
-            return TimeUnit.SECONDS;
-        }
+    private TimeUnit getTimeUnit(final String input) throws QuestException {
+        return switch (input.toLowerCase(Locale.ROOT)) {
+            case "ticks" -> TimeUnit.TICKS;
+            case "seconds" -> TimeUnit.SECONDS;
+            case "minutes" -> TimeUnit.MINUTES;
+            default ->
+                    throw new QuestException("Invalid time unit: " + input + ". Valid units are: ticks, seconds, minutes.");
+        };
     }
 }


### PR DESCRIPTION
…r ticks, seconds and minutes

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
