### PR TITLE
fix for Minecraft 1.21.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Menu`s throwing exception on reload when bound commands are used
 - `mmoitemcraft` objective NoSuchMethodError with MMOItems 6.10+
 - `menu` conversation IO exception in one edge case
+- 1.21.5 ProtocolLib support
 ### Security
 
 ## [2.2.1] - 2025-01-12

--- a/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/protocollib/hider/EntityHider.java
@@ -48,7 +48,6 @@ public class EntityHider implements Listener {
                 PacketType.Play.Server.ANIMATION,
                 PacketType.Play.Server.COLLECT,
                 PacketType.Play.Server.SPAWN_ENTITY,
-                PacketType.Play.Server.SPAWN_ENTITY_EXPERIENCE_ORB,
                 PacketType.Play.Server.ENTITY_VELOCITY,
                 PacketType.Play.Server.REL_ENTITY_MOVE,
                 PacketType.Play.Server.ENTITY_LOOK,
@@ -70,9 +69,14 @@ public class EntityHider implements Listener {
             entityPackets.add(PacketType.Play.Server.SPAWN_ENTITY_PAINTING);
         }
         // TODO version switch:
-        // Remove this code when only 1.20.2+ is supported
+        //  Remove this code when only 1.20.2+ is supported
         if (!PaperLib.isVersion(20, 2)) {
             entityPackets.add(PacketType.Play.Server.NAMED_ENTITY_SPAWN);
+        }
+        // TODO version switch:
+        //  Remove this code when only 1.21.4+ is supported
+        if (!PaperLib.isVersion(21, 4)) {
+            entityPackets.add(PacketType.Play.Server.SPAWN_ENTITY_EXPERIENCE_ORB);
         }
 
         ENTITY_PACKETS = entityPackets.toArray(PacketType[]::new);


### PR DESCRIPTION
ProtocolLib SPAWN_ENTITY_EXPERIENCE_ORB where removed and replaced with SPAWN_ENTITY

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
