### PR TITLE
bump version of minedown to 1.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
     <dependency>
       <groupId>de.themoep</groupId>
       <artifactId>minedown-adventure</artifactId>
-      <version>1.7.3-SNAPSHOT</version>
+      <version>1.7.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
This updates `minedown-adventure` version [from 1.7.3 to 1.7.4](https://github.com/Phoenix616/MineDown/compare/3d0ac7c845e3b05c8f1277083138057d74aadf81..f98f77b415669e312b4f1e505808519fea3657f8) to support translation texts as described [in their docs](https://wiki.phoenix616.dev/library/minedown/syntax#advanced-syntax:~:text=Translatable):
> [fallback](translate=translation.key with={value1, value2})


Minedown already has a version [1.7.5](https://github.com/Phoenix616/MineDown/compare/322eb79ffe3099ee26d95aa3ef8660ea9882ff8a..e2125596d8475b3d5b29e2c45872890220c2e638), however, this version was not built and is not available [in the repo](https://repo.minebench.de/de/themoep/minedown-adventure/).

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
