### PR TITLE
fix `chest` conversation IO now actually ends when there is to npc op…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     - `item.backpack.cancel_button` and `item.backpack.compass_button` do not have a `DEFAULT` value anymore, instead you need to specify an item
 - LoadDataEvent is now called before and after the data is loaded with a new enum `LoadDataEvent.State` that indicates the state
 - menu conversation IO settings are now defined the config.yml file in the `conversation.io.menu` section
+- `chest` conversation IO now actually ends when there is to npc option left or the player closes the inventory
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/org/betonquest/betonquest/conversation/InventoryConvIO.java
@@ -89,6 +89,12 @@ public class InventoryConvIO implements Listener, ConversationIO {
     protected Location loc;
 
     /**
+     * Callback to be executed when the conversation ends.
+     */
+    @Nullable
+    protected Runnable endCallback;
+
+    /**
      * Creates a new InventoryConvIO instance.
      *
      * @param conv                 the conversation this IO is part of
@@ -118,6 +124,7 @@ public class InventoryConvIO implements Listener, ConversationIO {
         this.showNumber = showNumber;
         this.showNPCText = showNPCText;
         this.printMessages = printMessages;
+        this.endCallback = null;
 
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
     }
@@ -331,6 +338,10 @@ public class InventoryConvIO implements Listener, ConversationIO {
         // allow closing when the conversation has finished
         if (allowListenerUnregister) {
             HandlerList.unregisterAll(this);
+            if (endCallback != null) {
+                endCallback.run();
+                endCallback = null;
+            }
             return;
         }
         if (conv.isMovementBlock()) {
@@ -368,7 +379,7 @@ public class InventoryConvIO implements Listener, ConversationIO {
                 callback.run();
             });
         } else {
-            callback.run();
+            endCallback = callback;
         }
     }
 


### PR DESCRIPTION
…tion left or the player closes the inventory

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
