### PR TITLE
Move combat check after bound conversation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `menu` Conversation IO displaying and scroll behavior rework
 - `objectives` event listener are now registered on reload instead when the first player gets it active
 - `npcmove` event - remove strange code effecting the end of a navigation to may return to a previous location in some cases
+- `npc_conversations` show the combat message only if there is a bound conversation  
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/src/main/java/org/betonquest/betonquest/kernel/processor/quest/NpcProcessor.java
+++ b/src/main/java/org/betonquest/betonquest/kernel/processor/quest/NpcProcessor.java
@@ -202,11 +202,6 @@ public class NpcProcessor extends TypedQuestProcessor<NpcID, NpcWrapper<?>> {
         }
         npcInteractionLimiter.put(playerUUID, currentClick);
 
-        if (CombatTagger.isTagged(onlineProfile)) {
-            busySender.sendNotification(onlineProfile);
-            return false;
-        }
-
         return startConversation(onlineProfile, npcIds, npc, onlineProfile);
     }
 
@@ -226,13 +221,18 @@ public class NpcProcessor extends TypedQuestProcessor<NpcID, NpcWrapper<?>> {
             log.debug("Profile '" + clicker.getProfileName() + "' clicked Npc '" + identifier
                     + "' but there is no conversation assigned to it.");
             return false;
-        } else {
-            log.debug("Profile '" + clicker.getProfileName() + "' clicked Npc '" + selected
-                    + "' and started conversation '" + conversationID + "'.");
-            final Location center = npc.getLocation().orElseGet(() -> onlineProfile.getPlayer().getLocation());
-            new NpcConversation<>(loggerFactory.create(NpcConversation.class), pluginMessage, onlineProfile, conversationID, center, npc);
-            return true;
         }
+
+        if (CombatTagger.isTagged(onlineProfile)) {
+            busySender.sendNotification(onlineProfile);
+            return false;
+        }
+
+        log.debug("Profile '" + clicker.getProfileName() + "' clicked Npc '" + selected
+                + "' and started conversation '" + conversationID + "'.");
+        final Location center = npc.getLocation().orElseGet(() -> onlineProfile.getPlayer().getLocation());
+            new NpcConversation<>(loggerFactory.create(NpcConversation.class), pluginMessage, onlineProfile, conversationID, center, npc);
+        return true;
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your changes here. -->
 to start conversations from npc interaction to only show the combat message if there is actually a bound conversation.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
