### PR TITLE
Make MM mobs event/condition actually only for online player

### DIFF
--- a/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integration-List.md
@@ -727,7 +727,7 @@ Check whether the player is near a specific MythicMobs entity. The first argumen
 
 #### :material-skull: Spawn MythicMob: `mspawnmob`
 
-**persistent**, **static**
+**static**
 
 | Parameter  | Syntax                                               | Default Value          | Explanation                                                                                                                             |
 |------------|------------------------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobsIntegrator.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/MythicMobsIntegrator.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.compatibility.mythicmobs;
 import io.lumine.mythic.bukkit.BukkitAPIHelper;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.compatibility.HookException;
 import org.betonquest.betonquest.compatibility.Integrator;
@@ -55,12 +56,13 @@ public class MythicMobsIntegrator implements Integrator {
 
         final BukkitAPIHelper apiHelper = new BukkitAPIHelper();
 
+        final BetonQuestLoggerFactory loggerFactory = plugin.getLoggerFactory();
         final Server server = plugin.getServer();
         final PrimaryServerThreadData data = new PrimaryServerThreadData(server, server.getScheduler(), plugin);
         final QuestTypeRegistries questRegistries = plugin.getQuestRegistries();
-        questRegistries.condition().register("mythicmobdistance", new MythicMobDistanceConditionFactory(apiHelper, data));
+        questRegistries.condition().register("mythicmobdistance", new MythicMobDistanceConditionFactory(loggerFactory, apiHelper, data));
         questRegistries.objective().register("mmobkill", new MythicMobKillObjectiveFactory());
-        questRegistries.event().registerCombined("mspawnmob", new MythicSpawnMobEventFactory(apiHelper, data, compatibility));
+        questRegistries.event().registerCombined("mspawnmob", new MythicSpawnMobEventFactory(loggerFactory, apiHelper, data, compatibility));
         final NpcTypeRegistry npcTypes = plugin.getFeatureRegistries().npc();
         server.getPluginManager().registerEvents(new MythicMobsInteractCatcher(plugin.getProfileProvider(), npcTypes, apiHelper), plugin);
         npcTypes.register("mythicmobs", new MythicMobsNpcFactory(MythicBukkit.inst().getMobManager()));

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/condition/MythicMobDistanceCondition.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/condition/MythicMobDistanceCondition.java
@@ -2,15 +2,15 @@ package org.betonquest.betonquest.compatibility.mythicmobs.condition;
 
 import io.lumine.mythic.bukkit.BukkitAPIHelper;
 import org.betonquest.betonquest.api.instruction.variable.Variable;
-import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
-import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
 import org.bukkit.entity.Player;
 
 /**
  * Condition that checks if a player is within a certain distance of a specific MythicMob.
  */
-public class MythicMobDistanceCondition implements PlayerCondition {
+public class MythicMobDistanceCondition implements OnlineCondition {
     /**
      * The BukkitAPIHelper used to interact with MythicMobs.
      */
@@ -40,8 +40,8 @@ public class MythicMobDistanceCondition implements PlayerCondition {
     }
 
     @Override
-    public boolean check(final Profile profile) throws QuestException {
-        final Player player = profile.getOnlineProfile().get().getPlayer();
+    public boolean check(final OnlineProfile profile) throws QuestException {
+        final Player player = profile.getPlayer();
         final double dist = distance.getValue(profile).doubleValue();
 
         return player.getWorld().getNearbyEntities(player.getLocation(), dist, dist, dist)

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/condition/MythicMobDistanceConditionFactory.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/condition/MythicMobDistanceConditionFactory.java
@@ -4,9 +4,11 @@ import io.lumine.mythic.bukkit.BukkitAPIHelper;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.argument.Argument;
 import org.betonquest.betonquest.api.instruction.variable.Variable;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
 
@@ -14,6 +16,11 @@ import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondit
  * Factory to create {@link MythicMobDistanceCondition}s from {@link Instruction}s.
  */
 public class MythicMobDistanceConditionFactory implements PlayerConditionFactory {
+    /**
+     * Factory to create new class specific loggers.
+     */
+    private final BetonQuestLoggerFactory loggerFactory;
+
     /**
      * API Helper for getting MythicMobs.
      */
@@ -27,10 +34,12 @@ public class MythicMobDistanceConditionFactory implements PlayerConditionFactory
     /**
      * Create a new factory for {@link MythicMobDistanceCondition}s.
      *
-     * @param apiHelper the api helper used get MythicMobs
-     * @param data      the primary server thread data required for main thread checking
+     * @param loggerFactory the logger factory to create class specific logger
+     * @param apiHelper     the api helper used get MythicMobs
+     * @param data          the primary server thread data required for main thread checking
      */
-    public MythicMobDistanceConditionFactory(final BukkitAPIHelper apiHelper, final PrimaryServerThreadData data) {
+    public MythicMobDistanceConditionFactory(final BetonQuestLoggerFactory loggerFactory, final BukkitAPIHelper apiHelper, final PrimaryServerThreadData data) {
+        this.loggerFactory = loggerFactory;
         this.apiHelper = apiHelper;
         this.data = data;
     }
@@ -43,6 +52,10 @@ public class MythicMobDistanceConditionFactory implements PlayerConditionFactory
         }
 
         final Variable<Number> distance = instruction.get(Argument.NUMBER);
-        return new PrimaryServerThreadPlayerCondition(new MythicMobDistanceCondition(apiHelper, internalName, distance), data);
+        return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(
+                new MythicMobDistanceCondition(apiHelper, internalName, distance),
+                loggerFactory.create(MythicMobDistanceCondition.class),
+                instruction.getPackage()
+        ), data);
     }
 }

--- a/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/event/MythicSpawnMobEvent.java
+++ b/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/event/MythicSpawnMobEvent.java
@@ -5,10 +5,10 @@ import io.lumine.mythic.bukkit.BukkitAPIHelper;
 import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.core.mobs.ActiveMob;
 import org.betonquest.betonquest.api.instruction.variable.Variable;
-import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.QuestException;
-import org.betonquest.betonquest.api.quest.event.PlayerEvent;
 import org.betonquest.betonquest.api.quest.event.PlayerlessEvent;
+import org.betonquest.betonquest.api.quest.event.online.OnlineEvent;
 import org.betonquest.betonquest.compatibility.protocollib.hider.MythicHider;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Spawns MythicMobs mobs.
  */
-public class MythicSpawnMobEvent implements PlayerEvent, PlayerlessEvent {
+public class MythicSpawnMobEvent implements OnlineEvent, PlayerlessEvent {
     /**
      * The BukkitAPIHelper used to interact with MythicMobs.
      */
@@ -102,8 +102,8 @@ public class MythicSpawnMobEvent implements PlayerEvent, PlayerlessEvent {
     }
 
     @Override
-    public void execute(final Profile profile) throws QuestException {
-        final Player player = profile.getOnlineProfile().get().getPlayer();
+    public void execute(final OnlineProfile profile) throws QuestException {
+        final Player player = profile.getPlayer();
         final int pAmount = amount.getValue(profile).intValue();
         final int level = this.level.getValue(profile).intValue();
         final Location location = loc.getValue(profile);
@@ -117,7 +117,7 @@ public class MythicSpawnMobEvent implements PlayerEvent, PlayerlessEvent {
                     if (mythicHider == null) {
                         throw new QuestException("Can't hide MythicMob because the Hider is null!");
                     }
-                    Bukkit.getScheduler().runTaskLater(plugin, () -> mythicHider.applyVisibilityPrivate(profile.getOnlineProfile().get(), entity), 20L);
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> mythicHider.applyVisibilityPrivate(profile, entity), 20L);
                 }
                 if (targetPlayer) {
                     Bukkit.getScheduler().runTaskLater(plugin, () -> targetMob.setTarget(BukkitAdapter.adapt(player)), 20L);


### PR DESCRIPTION
<!-- Please describe your changes here. -->
to not just throw when the profile is offline

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
