### PR TITLE
Add the `betonquestanswer` command to not show the "unknown command" pop up in MC 1.21.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `brewery` null pointer exception when a brew has no recipe
 - `npcrange` objective did count player without it valid for `outside` action
 - `global objective` error on join when it was added with the command or the tag got removed
+- `tellraw` conversation IO showed pop-up for unknown command
 ### Security
 
 ## [2.2.1] - 2025-01-12

--- a/docs/Documentation/Configuration/Commands-and-Permissions.md
+++ b/docs/Documentation/Configuration/Commands-and-Permissions.md
@@ -43,6 +43,7 @@ Arguments referring to a package are prefixed in the format `package>` and marke
 * `/rpgmenu list` - Lists all currently loaded menus and allows opening them just by clicking on them.
 * `/rpgmenu open <menu(ID)> [player]` - Opens a menu for you or another player.
   [Open conditions](../Features/Menus/Menu.md#general-menu-settings) will be ignored when using this command.
+* `/betonquestanswer` - Selects an answer in a conversation, can not be used manually
 
 The filter only works on the list and will match all objectives/tags/points that start with the filter. 
 Please note, that the names are a composition of the package name and the name of the objective/tag/point.

--- a/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -498,6 +498,7 @@ public class BetonQuest extends JavaPlugin implements BetonQuestApi, LanguagePro
         final LangCommand langCommand = new LangCommand(loggerFactory.create(LangCommand.class), playerDataStorage, pluginMessage, profileProvider, this);
         getCommand("questlang").setExecutor(langCommand);
         getCommand("questlang").setTabCompleter(langCommand);
+        getCommand("betonquestanswer").setTabCompleter((sender, command, label, args) -> List.of());
     }
 
     private void migrate() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -70,6 +70,9 @@ commands:
     usage: /<command>
     permission: betonquest.admin
     aliases: [ q, bq, bquest, bquests, betonquests, quest, quests ]
+  betonquestanswer:
+    description: Selects an answer in a conversation
+    usage: No manual usage
 permissions:
   betonquest.admin:
     default: op


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #3481

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
