### PR TITLE
Make Conversation Events async

### DIFF
--- a/src/main/java/org/betonquest/betonquest/api/bukkit/event/ConversationOptionEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/bukkit/event/ConversationOptionEvent.java
@@ -37,8 +37,9 @@ public class ConversationOptionEvent extends ProfileEvent {
      * @param selectedPlayerOption the option chosen by the player
      * @param nextNPCOption        the option which is NPC's response
      */
-    public ConversationOptionEvent(final Profile profile, final Conversation conv, final ResolvedOption selectedPlayerOption, final ResolvedOption nextNPCOption) {
-        super(profile);
+    public ConversationOptionEvent(final Profile profile, final Conversation conv,
+                                   final ResolvedOption selectedPlayerOption, final ResolvedOption nextNPCOption) {
+        super(profile, true);
         this.conv = conv;
         this.selectedOption = selectedPlayerOption;
         this.nextNPCOption = nextNPCOption;

--- a/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerConversationEndEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerConversationEndEvent.java
@@ -22,10 +22,11 @@ public class PlayerConversationEndEvent extends ProfileEvent {
      * Creates new conversation end event.
      *
      * @param who          the {@link Profile} who ended the conversation
+     * @param isAsync      whether the event is async
      * @param conversation conversation which has been ended
      */
-    public PlayerConversationEndEvent(final Profile who, final Conversation conversation) {
-        super(who);
+    public PlayerConversationEndEvent(final Profile who, final boolean isAsync, final Conversation conversation) {
+        super(who, isAsync);
         this.conversation = conversation;
     }
 

--- a/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerConversationStartEvent.java
+++ b/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerConversationStartEvent.java
@@ -31,7 +31,7 @@ public class PlayerConversationStartEvent extends ProfileEvent implements Cancel
      * @param conversation conversation which is about to start
      */
     public PlayerConversationStartEvent(final Profile who, final Conversation conversation) {
-        super(who);
+        super(who, true);
         this.conversation = conversation;
     }
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
When something wants to do stuff on the main thread with it, you can switch to it anyway when you are async and just halt the thread.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
