### PR TITLE
[DOCS] Use absolute path in snippets

### DIFF
--- a/docs/_snippets/events.yml
+++ b/docs/_snippets/events.yml
@@ -1,7 +1,7 @@
 cancel: |-
   ## Cancel a quest: `cancel`
 
-  This event works in the same way as a [quest canceler in the backpack](Documentation/Features/Quest-Cancelers.md).
+  This event works in the same way as a [quest canceler in the backpack](/Documentation/Features/Quest-Cancelers.md).
 
   Running this event is equal to the player canceling a quest using the backpack.
 
@@ -42,7 +42,7 @@ notify: |-
   ### Usage Examples
 
   Check out the notify IO specific options if you haven't yet. You must understand these two if you want to use the Notify system to it's full extend.
-  Advanced users may also use [Notify Categories](Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md#categories) to make their lives easier.
+  Advanced users may also use [Notify Categories](/Documentation/Visual-Effects/Notifications/Notification-IO's-&-Categories.md#categories) to make their lives easier.
   ```YAML
   #The simplest of all notify events. Just a chat message:
   customEvent: "notify Hello %player%!"  

--- a/docs/_snippets/integrations.yml
+++ b/docs/_snippets/integrations.yml
@@ -7,7 +7,7 @@ holograms: |-
       | DecentHolograms      | 2.7.5 or above   | [PlaceholderAPI](https://www.spigotmc.org/resources/6245/) for in-line variables.  |
       | Holographic Displays | 3.0.0 or above   | [ProtocolLib](https://www.spigotmc.org/resources/1997/) for conditioned holograms. |
   
-      If you have both plugins installed, you can use the [`hologram.default` option in the "_config.yml_"](Documentation/Configuration/Plugin-Config.md/#hologram-hologram-settings) to set which plugin should be used.
+      If you have both plugins installed, you can use the [`hologram.default` option in the "_config.yml_"](/Documentation/Configuration/Plugin-Config.md/#hologram-hologram-settings) to set which plugin should be used.
       !!! bug ""
           **When used by external plugins like BetonQuest, DecentHolograms does not support custom model data in items lines!**
   

--- a/docs/_snippets/tutorials.yml
+++ b/docs/_snippets/tutorials.yml
@@ -16,7 +16,7 @@ download-solution: |-
   ??? hint "Is the example not working?"
       Get the correct configs by running the following command.<br>
       :warning: _This will overwrite any changes (including NPC ID's and locations) you have made to the example.<br>_
-      Linking NPCs to conversations is explained in the [basics tutorial](Tutorials/Getting-Started/Basics/Conversations.md#1-linking-a-conversation-to-a-npc).
+      Linking NPCs to conversations is explained in the [basics tutorial](/Tutorials/Getting-Started/Basics/Conversations.md#1-linking-a-conversation-to-a-npc).
 
 download-this-part: |-
   ??? info "Download this part of the tutorial"
@@ -25,4 +25,3 @@ download-this-part: |-
 new-line-highlighting: |-
   !!! info "Highlighting"
       Every line/word that is highlighted in {==blue==} is new to the file! 
-


### PR DESCRIPTION
<!-- Please describe your changes here. -->
They are used in different places what prohibits relative pathing.
The "without leading `/`" gets interepreted locally as from root and works as expected in difference to the deployed website.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
