### PR TITLE
added config option `conversation.interceptor.delay` to configure a d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `money` event now has a `multiply` argument instead of `*` in front of number
 - old maven artifact repository nexus `https://nexus.betonquest.org/repository/betonquest/` replaced with reposilite available at `https://repo.betonquest.org/betonquest/`
 - `menu` io based on packetevents renamed to `packetevents`
+- config option `conversation.interceptor.delay` to configure a delay between the end of a conversation and the moment the interceptor is ended
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/code/core/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/conversation/ConversationData.java
@@ -535,17 +535,19 @@ public class ConversationData {
     /**
      * The external used data.
      *
-     * @param conversationID The ID of the conversation.
-     * @param quester        A map of the quester's name in different languages.
-     * @param blockMovement  If true, the player will not be able to move during this conversation.
-     * @param finalEvents    All events that will be executed when the conversation ends.
-     * @param convIO         The conversation IO that should be used for this conversation.
-     * @param interceptor    The interceptor that should be used for this conversation.
-     * @param invincible     If true, the player will not be able to damage or be damaged by entities in conversation.
+     * @param conversationID   The ID of the conversation.
+     * @param quester          A map of the quester's name in different languages.
+     * @param blockMovement    If true, the player will not be able to move during this conversation.
+     * @param finalEvents      All events that will be executed when the conversation ends.
+     * @param convIO           The conversation IO that should be used for this conversation.
+     * @param interceptor      The interceptor that should be used for this conversation.
+     * @param interceptorDelay The delay before the interceptor is ended after the conversation ends.
+     * @param invincible       If true, the player will not be able to damage or be damaged by entities in conversation.
      */
     public record PublicData(ConversationID conversationID, Text quester, Variable<Boolean> blockMovement,
                              Variable<List<EventID>> finalEvents, Variable<ConversationIOFactory> convIO,
-                             Variable<InterceptorFactory> interceptor, boolean invincible) {
+                             Variable<InterceptorFactory> interceptor, Variable<Number> interceptorDelay,
+                             boolean invincible) {
 
         /**
          * Gets the quester's name in the specified language.

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ConversationProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ConversationProcessor.java
@@ -126,9 +126,10 @@ public class ConversationProcessor extends SectionProcessor<ConversationID, Conv
         final Variable<Boolean> blockMovement = new Variable<>(variables, pack, section.getString("stop", "false"), Argument.BOOLEAN);
         final Variable<ConversationIOFactory> convIO = helper.parseConvIO();
         final Variable<InterceptorFactory> interceptor = helper.parseInterceptor();
+        final Variable<Number> interceptorDelay = helper.parseInterceptorDelay();
         final Variable<List<EventID>> finalEvents = new VariableList<>(variables, pack, section.getString("final_events", ""), value -> new EventID(variables, packManager, pack, value));
         final boolean invincible = plugin.getConfig().getBoolean("conversation.damage.invincible");
-        final ConversationData.PublicData publicData = new ConversationData.PublicData(conversationID, quester, blockMovement, finalEvents, convIO, interceptor, invincible);
+        final ConversationData.PublicData publicData = new ConversationData.PublicData(conversationID, quester, blockMovement, finalEvents, convIO, interceptor, interceptorDelay, invincible);
 
         return new ConversationData(loggerFactory.create(ConversationData.class), packManager,
                 variables, plugin.getQuestTypeApi(), plugin.getFeatureApi().conversationApi(), textCreator, section, publicData);
@@ -216,7 +217,7 @@ public class ConversationProcessor extends SectionProcessor<ConversationID, Conv
         }
 
         private String defaulting(final String path, final String configPath, final String defaultConfig) {
-            if (section.isString(path)) {
+            if (section.isSet(path)) {
                 return Objects.requireNonNull(opt(path));
             }
             return plugin.getPluginConfig().getString(configPath, defaultConfig);
@@ -236,6 +237,11 @@ public class ConversationProcessor extends SectionProcessor<ConversationID, Conv
                 final List<String> interceptors = new VariableList<>(variables, pack, value, Argument.STRING).getValue(null);
                 return interceptorRegistry.getFactory(interceptors);
             });
+        }
+
+        private Variable<Number> parseInterceptorDelay() throws QuestException {
+            final String rawInterceptorDelay = defaulting("interceptor_delay", "conversation.interceptor.delay", "50");
+            return new Variable<>(variables, pack, rawInterceptorDelay, Argument.NUMBER_NOT_LESS_THAN_ZERO);
         }
     }
 }

--- a/code/core/src/main/resources/config.patch.yml
+++ b/code/core/src/main/resources/config.patch.yml
@@ -1,4 +1,8 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.0.0.22:
+  - type: SET
+    key: conversation.interceptor.delay
+    value: 50
 3.0.0.21:
   - type: VALUE_RENAME
     key: conversation.default_io

--- a/code/core/src/main/resources/config.yml
+++ b/code/core/src/main/resources/config.yml
@@ -31,6 +31,7 @@ conversation:
   interceptor:
     default: redischat,packetevents,simple
     display_history: true
+    delay: 50
   damage:
     combat_delay: 10
     invincible: true

--- a/docs/Documentation/Configuration/Plugin-Config.md
+++ b/docs/Documentation/Configuration/Plugin-Config.md
@@ -123,6 +123,8 @@ All conversation related settings.
     * `display_history` - If set to `true`, the interceptor will display all previous messages in the chat after
       the conversation ends, like there was no conversation. This is only supported by some interceptors.  
       **This option needs a server restart to take effect when changed!**
+    * `delay` - The delay (in ticks) after the conversation ends and before the interceptor is displayed.
+      This is to let the player some time to read the last conversation message.
 * `damage`  
   All damage related settings.
     * `combat_delay` - A delay (in seconds) the player must wait before starting a conversation after the last combat.  

--- a/docs/Documentation/Features/Conversations.md
+++ b/docs/Documentation/Features/Conversations.md
@@ -20,19 +20,21 @@ conversations: #(1)!
     first: "welcome,blacksmithReminder" #(4)!
     stop: "true"  #(5)!
     final_events: "setCityState" #(6)!
-    interceptor: "simple" #(7)!
-    NPC_options: #(8)!
+    conversationIO: "menu" #(7)!
+    interceptor: "simple" #(8)!
+    interceptor_delay: 70 #(9)!
+    NPC_options: #(10)!
       welcome:
-        text: "Good day, dear %player%! Welcome back to my town." #(10)!
+        text: "Good day, dear %player%! Welcome back to my town." #(11)!
         events: "playSound,giveMoney" #(12)!
-        conditions: "firstVisit,!criminal" #(11)!
-        pointers: "friendly,hostile" #(13)!
+        conditions: "firstVisit,!criminal" #(13)!
+        pointers: "friendly,hostile" #(14)!
       blacksmithReminder:
         text: "Please visit the blacksmith, he has a task for you."
         conditions: "!criminal"
       howDareYou:
         text: "How dare you to talk to me like that?! Get out of my sight!"
-    player_options: #(9)!
+    player_options: #(15)!
       friendly:
         text: "Thank you your honor, I'm happy to be here."
         events: "givePresent"
@@ -47,21 +49,34 @@ conversations: #(1)!
 1. All conversation must be defined in a `conversations` section.
 2. `mayorHans` is the name of the conversation, which is used to reference the conversation. 
 3. `Hans` is the visual name of NPC that is displayed during the conversation.
-4. `first` are pointers to options the NPC will use at the beginning of the conversation. He will choose the first one that meets all conditions. You 
+4. `first` are pointers to options the NPC will use at the beginning of the conversation. He will choose the first 
+    one that meets all conditions. You 
     define these options in `npc_options` branch.
-5. `stop` determines if player can move away from an NPC while in this conversation (false) or if he's stopped every time
-    he tries to (true). If enabled, it will also suspend the conversation when the player quits, and resume it after he 
-    joins back in. This way he will have to finish his conversation no matter what. You can modify
-    the distance at which the conversation is automatically stopped / player is teleported back with `max_conversation_distance` option in "_config.yml_".
-6. `final_events` are events that will fire when the conversation ends, no matter how it ends (so you can create e.g. guards attacking
-    the player if he tries to run). You can leave this option out if you don't need any final events.
-7. `interceptor` optionally set a chat interceptor for this conversation. Multiple interceptors can be provided in a comma-separated list with the first valid one used. It's better to set this as a global config setting in "_config.yml_".
-8. `NPC_options` is a branch with texts said by the NPC.
-9. `player_options` is a branch with options the player can choose from.
-10. `text` defines what will display on screen. If you don't want to set any events/conditions/pointers to the option, just skip them. Only `text` is always required.
-11. `conditions` are names of conditions which must be met for this option to display, separated by commas.
-12. `events` is a list of event names that will fire when an option is chosen (either by NPC or a player), defined similar to conditions.
-13. `pointer` is list of pointers to the opposite branch (from NPC branch it will point to options player can choose from when answering, and from player branch it will point to different NPC reactions).
+5. `stop` determines if player can move away from an NPC while in this conversation (false) or if he's stopped 
+    every time he tries to (true). If enabled, it will also suspend the conversation when the player quits, and 
+    resume it after he joins back in. This way he will have to finish his conversation no matter what. You can modify
+    the distance at which the conversation is automatically stopped / player is teleported back with 
+    `max_conversation_distance` option in "_config.yml_".
+6. `final_events` are events that will fire when the conversation ends, no matter how it ends (so you can create 
+    e.g. guards attacking the player if he tries to run). You can leave this option out if you don't need any final 
+    events.
+7. `conversationIO` optionally set the conversation style for this conversation. Multiple styles can be provided in 
+    acomma-separated list with the first valid one used. It's better to set this as a global config setting in
+    "_config.yml_".
+8. `interceptor` optionally set a chat interceptor for this conversation. Multiple interceptors can be provided in a 
+    comma-separated list with the first valid one used. It's better to set this as a global config setting in
+    "_config.yml_".
+9. `interceptor_delay` optionally set a delay (in ticks) after the conversation ends and before the interceptor is 
+    displayed. This can also be set globally in "_config.yml_".
+10. `NPC_options` is a branch with texts said by the NPC.
+11. `text` defines what will display on screen. If you don't want to set any events/conditions/pointers to the 
+    option, just skip them. Only `text` is always required.
+12. `events` is a list of event names that will fire when an option is chosen (either by NPC or a player), defined 
+    similar to conditions.
+13. `conditions` are names of conditions which must be met for this option to display, separated by commas.
+14. `pointers` is list of pointers to the opposite branch (from NPC branch it will point to options player can 
+    choose from when answering, and from player branch it will point to different NPC reactions).
+15. `player_options` is a branch with options the player can choose from.
 
 When an NPC wants to say something he will check conditions for the first option (in this case `welcome`). If they are met,
 he will choose it. Otherwise, he will skip to next option (note: conversation ends when there are no options left to choose).


### PR DESCRIPTION
…elay between the end of a conversation and the moment the interceptor is ended

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
