### PR TITLE
Update .editorconfig for markdown - preserve trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,3 +36,7 @@ indent_size = 4
 [/{lib,venv,.venv}/**]
 indent_style = unset
 indent_size = unset
+
+[*.md]
+# In markdown, two trailing spaces are a line break
+trim_trailing_whitespace = false


### PR DESCRIPTION
Added configuration for markdown files to preserve trailing spaces. These represent a line break in Markdown and are easily lost during an editor config run.

This is not an issue (using IntelliJ) right now, as the default behaviour matches the required behaviour*. 
Other editors might have a different default setting though.
Since this setting is fundamental to the integrity of the markdown spec it should be explicity defined as a default setting.

*Actually, this might not be true, I just found this: https://betonquest.org/RELEASE/Participate/Setup-Project/#intellij-settings

---

### Related Issues


### Requirements
- [X] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... ~~increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?~~
- [ ]  ... ~~update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?~~
- [ ]  ... ~~update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?~~
- [ ]  ... ~~wrote a Migration?~~
- [X]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
