### PR TITLE
Add some package-info.java with javadocs

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/config/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/config/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains classes for accessing configuration files.
+ */
+package org.betonquest.betonquest.api.config;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/identifier/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/identifier/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains classes related to identifiers.
+ */
+package org.betonquest.betonquest.api.identifier;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/argument/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/argument/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This instruction subpackage contains classes for parsing instruction arguments.
+ */
+package org.betonquest.betonquest.api.instruction.argument;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This instruction subpackage contains classes for instruction chains.
+ */
+package org.betonquest.betonquest.api.instruction.chain;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/package-info.java
@@ -1,4 +1,4 @@
 /**
- * The package contains classes for parsing instructions.
+ * This package contains classes for parsing instructions.
  */
 package org.betonquest.betonquest.api.instruction;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/type/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This instruction subpackage contains classes for special instruction types.
+ */
+package org.betonquest.betonquest.api.instruction.type;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/logger/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/logger/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The Logging API package. This package contains classes for creating loggers and logging messages in general.
+ */
+package org.betonquest.betonquest.api.logger;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The root package of the API containing classes that are used across the API
+ * and are not easy to associate with a single subpackage.
+ */
+package org.betonquest.betonquest.api;

--- a/code/api/src/main/java/org/betonquest/betonquest/api/profile/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/profile/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains classes related to profiles.
+ */
+package org.betonquest.betonquest.api.profile;


### PR DESCRIPTION
Add package-info.java with javadocs to packages that most-likely won't be changed or renamed in near future

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
