### PR TITLE
fix ComponentPatternSplitter does not handle non TextComponents corre…

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/api/common/component/ComponentPatternSplitter.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/common/component/ComponentPatternSplitter.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -50,6 +51,8 @@ public final class ComponentPatternSplitter {
         if (component instanceof final TextComponent textComponent) {
             final LinkedList<String> parts = split(splitter, textComponent.content());
             parts.forEach(part -> result.add(Component.text(part).style(component.style())));
+        } else {
+            result.add(component.children(Collections.emptyList()));
         }
         final TextComponent parentComponent = Component.empty().style(component.style());
         for (final Component child : component.children()) {

--- a/code/core/src/test/java/org/betonquest/betonquest/api/common/component/ComponentPatternSplitterTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/common/component/ComponentPatternSplitterTest.java
@@ -85,7 +85,11 @@ class ComponentPatternSplitterTest extends ComponentFixture {
                                     Component.empty().color(NamedTextColor.RED)
                                             .append(Component.text(" to").color(NamedTextColor.YELLOW))
                                             .append(Component.text(" assertWrap")))
-                    )
+                    ),
+                    Arguments.of("Press <key:key.jump> to Jump!",
+                            List.of(Component.text("Press ")
+                                    .append(Component.keybind("key.jump")
+                                            .append(Component.text(" to Jump!")))))
             );
         }
 


### PR DESCRIPTION
…ctly

This is an issue with a keybild and is probably also an issue with other component types that is now fixed. Now only the width of other than TextComponents still not work

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
