### PR TITLE
Fix DefaultEventServiceSubscriptionBuilder

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultEventServiceSubscriptionBuilder.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultEventServiceSubscriptionBuilder.java
@@ -198,9 +198,11 @@ public class DefaultEventServiceSubscriptionBuilder<T extends Event> implements 
         }
         if (onlineProfileHandler != null) {
             eventService.subscribe(logSource, eventClass, onlineProfileHandler, profileExtractor, eventPriority, ignoreCancelled);
+            return;
         }
         if (profileHandler != null) {
             eventService.subscribe(logSource, eventClass, profileHandler, profileExtractor, eventPriority, ignoreCancelled);
+            return;
         }
         throw new IllegalStateException("No valid handler specified!");
     }


### PR DESCRIPTION
Fix DefaultEventServiceSubscriptionBuilder throwing IllegalStateException even if a valid handler was defined

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
