### PR TITLE
fix issue where the chat of a menu conversation IO is empty, when for…

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/conversation/menu/MenuConvIO.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/conversation/menu/MenuConvIO.java
@@ -359,6 +359,9 @@ public class MenuConvIO extends ChatConvIO {
     }
 
     private void updateDisplay(final Scroll scroll) {
+        if (chatDisplay == null && scroll != Scroll.NONE) {
+            return;
+        }
         if (chatDisplay == null) {
             chatDisplay = new Display(settings, componentLineWrapper, npcName, npcText, new ArrayList<>(options.values()));
         }


### PR DESCRIPTION
…ward or backward key is pressed while confirming an answer

The issue happens because the chat display is updated with a scroll before the new text has been set, so the new dialog is empty.

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
