### PR TITLE
Further extraction of functionality from DefaultObjective

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/bukkit/event/BukkitEventService.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/bukkit/event/BukkitEventService.java
@@ -57,4 +57,9 @@ public interface BukkitEventService {
                                                                   final EventServiceSubscriber<T> subscriber) throws QuestException {
         return subscribe(event, priority, true, subscriber);
     }
+
+    /**
+     * Unsubscribes all subscribers from all events.
+     */
+    void unsubscribeAll();
 }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjective.java
@@ -5,9 +5,9 @@ import com.gamingmesh.jobs.container.Job;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Objective that tracks the join of a player to a specific job.
@@ -22,12 +22,12 @@ public class JoinJobObjective extends DefaultObjective {
     /**
      * Constructor for the JoinJobObjective.
      *
-     * @param instruction the instruction of the objective
-     * @param job         the job to join
+     * @param service the objective factory service
+     * @param job     the job to join
      * @throws QuestException if the instruction is invalid
      */
-    public JoinJobObjective(final Instruction instruction, final Argument<Job> job) throws QuestException {
-        super(instruction);
+    public JoinJobObjective(final ObjectiveFactoryService service, final Argument<Job> job) throws QuestException {
+        super(service);
         this.job = job;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjectiveFactory.java
@@ -24,7 +24,7 @@ public class JoinJobObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Job> job = instruction.parse(JobParser.JOB).get();
-        final JoinJobObjective objective = new JoinJobObjective(instruction, job);
+        final JoinJobObjective objective = new JoinJobObjective(service, job);
         service.request(JobsJoinEvent.class).onlineHandler(objective::onJobsJoinEvent)
                 .player(event -> event.getPlayer().getPlayer()).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjective.java
@@ -5,9 +5,9 @@ import com.gamingmesh.jobs.container.Job;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Objective that tracks the leave of a player from a specific job.
@@ -22,12 +22,12 @@ public class LeaveJobObjective extends DefaultObjective {
     /**
      * Constructor for the LeaveJobObjective.
      *
-     * @param instruction the instruction of the objective
-     * @param job         the job to leave
+     * @param service the objective factory service
+     * @param job     the job to leave
      * @throws QuestException if the instruction is invalid
      */
-    public LeaveJobObjective(final Instruction instruction, final Argument<Job> job) throws QuestException {
-        super(instruction);
+    public LeaveJobObjective(final ObjectiveFactoryService service, final Argument<Job> job) throws QuestException {
+        super(service);
         this.job = job;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjectiveFactory.java
@@ -24,7 +24,7 @@ public class LeaveJobObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Job> job = instruction.parse(JobParser.JOB).get();
-        final LeaveJobObjective objective = new LeaveJobObjective(instruction, job);
+        final LeaveJobObjective objective = new LeaveJobObjective(service, job);
         service.request(JobsLeaveEvent.class).onlineHandler(objective::onJobsLeaveEvent)
                 .player(event -> event.getPlayer().getPlayer()).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjective.java
@@ -5,9 +5,9 @@ import com.gamingmesh.jobs.container.Job;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Objective that tracks the level up of a player in a specific job.
@@ -22,12 +22,12 @@ public class LevelUpObjective extends DefaultObjective {
     /**
      * Constructor for the LevelUpObjective.
      *
-     * @param instruction the instruction of the objective
-     * @param job         the job to level up
+     * @param service the objective factory service
+     * @param job     the job to level up
      * @throws QuestException if the instruction is invalid
      */
-    public LevelUpObjective(final Instruction instruction, final Argument<Job> job) throws QuestException {
-        super(instruction);
+    public LevelUpObjective(final ObjectiveFactoryService service, final Argument<Job> job) throws QuestException {
+        super(service);
         this.job = job;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjectiveFactory.java
@@ -24,7 +24,7 @@ public class LevelUpObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Job> job = instruction.parse(JobParser.JOB).get();
-        final LevelUpObjective objective = new LevelUpObjective(instruction, job);
+        final LevelUpObjective objective = new LevelUpObjective(service, job);
         service.request(JobsLevelUpEvent.class).onlineHandler(objective::onJobsLevelUpEvent)
                 .player(event -> event.getPlayer().getPlayer()).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/PaymentObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/PaymentObjectiveFactory.java
@@ -46,7 +46,7 @@ public class PaymentObjectiveFactory implements ObjectiveFactory {
         final IngameNotificationSender paymentSender = new IngameNotificationSender(log,
                 pluginMessage, instruction.getPackage(), instruction.getID().getFull(),
                 NotificationLevel.INFO, "payment_to_receive");
-        final PaymentObjective objective = new PaymentObjective(instruction, targetAmount, paymentSender);
+        final PaymentObjective objective = new PaymentObjective(service, targetAmount, paymentSender);
         service.request(JobsPaymentEvent.class).handler(objective::onJobsPaymentEvent)
                 .offlinePlayer(JobsPaymentEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreBreakCustomBlockObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreBreakCustomBlockObjective.java
@@ -8,8 +8,8 @@ import net.Indyuce.mmoitems.comp.mmocore.load.MMOItemsBlockType;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -25,13 +25,13 @@ public class MMOCoreBreakCustomBlockObjective extends CountingObjective {
     /**
      * Constructor for the MMOCoreBreakCustomBlockObjective.
      *
-     * @param instruction    the instruction object representing the objective
+     * @param service        the objective factory service
      * @param targetAmount   the target amount of blocks to break
      * @param desiredBlockId the ID of the block to be broken
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public MMOCoreBreakCustomBlockObjective(final Instruction instruction, final Argument<Number> targetAmount, final Argument<String> desiredBlockId) throws QuestException {
-        super(instruction, targetAmount, "blocks_to_break");
+    public MMOCoreBreakCustomBlockObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final Argument<String> desiredBlockId) throws QuestException {
+        super(service, targetAmount, "blocks_to_break");
         this.desiredBlockId = desiredBlockId;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreBreakCustomBlockObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreBreakCustomBlockObjectiveFactory.java
@@ -26,7 +26,7 @@ public class MMOCoreBreakCustomBlockObjectiveFactory implements ObjectiveFactory
             throw new QuestException("Missing required argument: block");
         }
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final MMOCoreBreakCustomBlockObjective objective = new MMOCoreBreakCustomBlockObjective(instruction, targetAmount, desiredBlockId);
+        final MMOCoreBreakCustomBlockObjective objective = new MMOCoreBreakCustomBlockObjective(service, targetAmount, desiredBlockId);
         service.request(CustomBlockMineEvent.class).onlineHandler(objective::onBlockBreak)
                 .player(CustomBlockMineEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjective.java
@@ -4,9 +4,9 @@ import net.Indyuce.mmocore.api.event.PlayerChangeClassEvent;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -23,12 +23,12 @@ public class MMOCoreChangeClassObjective extends DefaultObjective {
     /**
      * Constructor for the MMOCoreChangeClassObjective.
      *
-     * @param instruction     Instruction object representing the objective;
+     * @param service         the objective factory service
      * @param targetClassName the name of the class to be changed to
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public MMOCoreChangeClassObjective(final Instruction instruction, @Nullable final Argument<String> targetClassName) throws QuestException {
-        super(instruction);
+    public MMOCoreChangeClassObjective(final ObjectiveFactoryService service, @Nullable final Argument<String> targetClassName) throws QuestException {
+        super(service);
         this.targetClassName = targetClassName;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjectiveFactory.java
@@ -22,7 +22,7 @@ public class MMOCoreChangeClassObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> targetClassName = instruction.string().get("class").orElse(null);
-        final MMOCoreChangeClassObjective objective = new MMOCoreChangeClassObjective(instruction, targetClassName);
+        final MMOCoreChangeClassObjective objective = new MMOCoreChangeClassObjective(service, targetClassName);
         service.request(PlayerChangeClassEvent.class).onlineHandler(objective::onClassChange)
                 .player(PlayerChangeClassEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjective.java
@@ -5,9 +5,9 @@ import net.Indyuce.mmocore.experience.Profession;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * An objective that listens for the player leveling up in their MMOCore profession.
@@ -27,14 +27,14 @@ public class MMOCoreProfessionObjective extends DefaultObjective {
     /**
      * Constructor for the MMOCoreProfessionObjective.
      *
-     * @param instruction    the instruction object representing the objective
+     * @param service        the objective factory service
      * @param professionName the name of the profession to be leveled up, 'main' for class
      * @param targetLevel    the target level to be reached
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public MMOCoreProfessionObjective(final Instruction instruction, final Argument<String> professionName,
+    public MMOCoreProfessionObjective(final ObjectiveFactoryService service, final Argument<String> professionName,
                                       final Argument<Number> targetLevel) throws QuestException {
-        super(instruction);
+        super(service);
         this.professionName = professionName;
         this.targetLevel = targetLevel;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjectiveFactory.java
@@ -23,7 +23,7 @@ public class MMOCoreProfessionObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> professionName = instruction.string().get();
         final Argument<Number> targetLevel = instruction.number().get();
-        final MMOCoreProfessionObjective objective = new MMOCoreProfessionObjective(instruction, professionName, targetLevel);
+        final MMOCoreProfessionObjective objective = new MMOCoreProfessionObjective(service, professionName, targetLevel);
         service.request(PlayerLevelUpEvent.class).onlineHandler(objective::onLevelUp)
                 .player(PlayerLevelUpEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjective.java
@@ -5,9 +5,9 @@ import net.Indyuce.mmoitems.api.item.mmoitem.MMOItem;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * An objective that listens for the player applying a gem to their MMOItems item.
@@ -32,14 +32,14 @@ public class MMOItemsApplyGemObjective extends DefaultObjective {
     /**
      * Constructor for the MMOItemsApplyGemObjective.
      *
-     * @param instruction the instruction object representing the objective
-     * @param itemID      the ID of the item to be upgraded
-     * @param itemType    the type of the item to be upgraded
-     * @param gemID       the ID of the gem to be applied
+     * @param service  the objective factory service
+     * @param itemID   the ID of the item to be upgraded
+     * @param itemType the type of the item to be upgraded
+     * @param gemID    the ID of the gem to be applied
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public MMOItemsApplyGemObjective(final Instruction instruction, final Argument<String> itemID, final Argument<String> itemType, final Argument<String> gemID) throws QuestException {
-        super(instruction);
+    public MMOItemsApplyGemObjective(final ObjectiveFactoryService service, final Argument<String> itemID, final Argument<String> itemType, final Argument<String> gemID) throws QuestException {
+        super(service);
         this.itemID = itemID;
         this.itemType = itemType;
         this.gemID = gemID;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjectiveFactory.java
@@ -24,7 +24,7 @@ public class MMOItemsApplyGemObjectiveFactory implements ObjectiveFactory {
         final Argument<String> itemType = instruction.string().get();
         final Argument<String> itemID = instruction.string().get();
         final Argument<String> gemID = instruction.string().get();
-        final MMOItemsApplyGemObjective objective = new MMOItemsApplyGemObjective(instruction, itemType, itemID, gemID);
+        final MMOItemsApplyGemObjective objective = new MMOItemsApplyGemObjective(service, itemType, itemID, gemID);
         service.request(ApplyGemStoneEvent.class).onlineHandler(objective::onApplyGem)
                 .player(ApplyGemStoneEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjective.java
@@ -5,9 +5,9 @@ import net.Indyuce.mmoitems.api.item.mmoitem.MMOItem;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * An objective that listens for the player upgrading their MMOItems item.
@@ -27,13 +27,13 @@ public class MMOItemsUpgradeObjective extends DefaultObjective {
     /**
      * Constructor for the MMOItemsUpgradeObjective.
      *
-     * @param instruction the instruction object representing the objective
-     * @param itemID      the ID of the item to be upgraded
-     * @param itemType    the type of the item to be upgraded
+     * @param service  the objective factory service
+     * @param itemID   the ID of the item to be upgraded
+     * @param itemType the type of the item to be upgraded
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public MMOItemsUpgradeObjective(final Instruction instruction, final Argument<String> itemID, final Argument<String> itemType) throws QuestException {
-        super(instruction);
+    public MMOItemsUpgradeObjective(final ObjectiveFactoryService service, final Argument<String> itemID, final Argument<String> itemType) throws QuestException {
+        super(service);
         this.itemID = itemID;
         this.itemType = itemType;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjectiveFactory.java
@@ -23,7 +23,7 @@ public class MMOItemsUpgradeObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> itemType = instruction.string().get();
         final Argument<String> itemID = instruction.string().get();
-        final MMOItemsUpgradeObjective objective = new MMOItemsUpgradeObjective(instruction, itemType, itemID);
+        final MMOItemsUpgradeObjective objective = new MMOItemsUpgradeObjective(service, itemType, itemID);
         service.request(UpgradeItemEvent.class).onlineHandler(objective::onUpgradeItem)
                 .player(UpgradeItemEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
@@ -5,9 +5,9 @@ import io.lumine.mythic.lib.skill.trigger.TriggerType;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 import java.util.List;
 
@@ -30,13 +30,13 @@ public class MythicLibSkillObjective extends DefaultObjective {
     /**
      * Parses the instruction and creates a new objective.
      *
-     * @param instruction  the user-provided instruction
+     * @param service      the objective factory service
      * @param skillId      the skill ID to activate
      * @param triggerTypes the trigger types that will activate the skill
      * @throws QuestException if the instruction is invalid
      */
-    public MythicLibSkillObjective(final Instruction instruction, final Argument<String> skillId, final List<TriggerType> triggerTypes) throws QuestException {
-        super(instruction);
+    public MythicLibSkillObjective(final ObjectiveFactoryService service, final Argument<String> skillId, final List<TriggerType> triggerTypes) throws QuestException {
+        super(service);
         this.skillId = skillId;
         this.triggerTypes = triggerTypes;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjectiveFactory.java
@@ -29,7 +29,7 @@ public class MythicLibSkillObjectiveFactory implements ObjectiveFactory {
         final List<TriggerType> triggerTypes = instruction
                 .parse(id -> TriggerType.valueOf(id.toUpperCase(Locale.ROOT)))
                 .list().get().getValue(null);
-        final MythicLibSkillObjective objective = new MythicLibSkillObjective(instruction, skillId, triggerTypes);
+        final MythicLibSkillObjective objective = new MythicLibSkillObjective(service, skillId, triggerTypes);
         service.request(SkillCastEvent.class).onlineHandler(objective::onSkillCast)
                 .player(SkillCastEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/objective/MythicMobKillObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/objective/MythicMobKillObjective.java
@@ -7,9 +7,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -72,7 +72,7 @@ public class MythicMobKillObjective extends CountingObjective {
     /**
      * Creates a new MythicMobKillObjective.
      *
-     * @param instruction                  the user-provided instruction
+     * @param service                      the objective factory service
      * @param targetAmount                 the target amount of kills
      * @param identifiers                  the identifiers of all mobs that this objective should count
      * @param mode                         the mode to choose the identifier from a mob
@@ -84,11 +84,11 @@ public class MythicMobKillObjective extends CountingObjective {
      * @throws QuestException if the instruction is invalid
      */
     public MythicMobKillObjective(
-            final Instruction instruction, final Argument<Number> targetAmount, final Argument<List<String>> identifiers,
+            final ObjectiveFactoryService service, final Argument<Number> targetAmount, final Argument<List<String>> identifiers,
             final Argument<IdentifierMode> mode, final Argument<Number> minMobLevel, final Argument<Number> maxMobLevel,
             final Argument<Number> deathRadiusAllPlayers, final Argument<Number> neutralDeathRadiusAllPlayers,
             @Nullable final Argument<String> marked) throws QuestException {
-        super(instruction, targetAmount, "mobs_to_kill");
+        super(service, targetAmount, "mobs_to_kill");
         this.identifiers = identifiers;
         this.mode = mode;
         this.minMobLevel = minMobLevel;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/objective/MythicMobKillObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/objective/MythicMobKillObjectiveFactory.java
@@ -33,7 +33,7 @@ public class MythicMobKillObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> minMobLevel = instruction.number().get("minLevel", Double.NEGATIVE_INFINITY);
         final Argument<Number> maxMobLevel = instruction.number().get("maxLevel", Double.POSITIVE_INFINITY);
         final Argument<String> marked = instruction.packageIdentifier().get("marked").orElse(null);
-        final MythicMobKillObjective objective = new MythicMobKillObjective(instruction, targetAmount, names, mode, minMobLevel, maxMobLevel, deathRadiusAllPlayers, neutralDeathRadiusAllPlayers, marked);
+        final MythicMobKillObjective objective = new MythicMobKillObjective(service, targetAmount, names, mode, minMobLevel, maxMobLevel, deathRadiusAllPlayers, neutralDeathRadiusAllPlayers, marked);
         service.request(MythicMobDeathEvent.class).handler(objective::onKill).subscribe(true);
         return objective;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/objective/NPCKillObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/objective/NPCKillObjective.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.npc.NpcID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Player has to kill an NPC.
@@ -28,15 +29,15 @@ public class NPCKillObjective extends CountingObjective {
     /**
      * Create a new Citizens NPC kill objective.
      *
-     * @param instruction  the user-provided instruction
+     * @param service      the objective factory service
      * @param registry     the registry of NPCs to use
      * @param targetAmount the amount of NPCs to kill
      * @param npcID        the npc id
      * @throws QuestException when the instruction cannot be parsed or is invalid
      */
-    public NPCKillObjective(final Instruction instruction, final NPCRegistry registry, final Argument<Number> targetAmount,
+    public NPCKillObjective(final ObjectiveFactoryService service, final NPCRegistry registry, final Argument<Number> targetAmount,
                             final Argument<NpcID> npcID) throws QuestException {
-        super(instruction, targetAmount, "mobs_to_kill");
+        super(service, targetAmount, "mobs_to_kill");
         this.registry = registry;
         this.npcID = npcID;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/objective/NPCKillObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/objective/NPCKillObjectiveFactory.java
@@ -34,7 +34,7 @@ public class NPCKillObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<NpcID> npcID = instruction.parse(CitizensArgument.CITIZENS_ID).get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get("amount", 1);
-        final NPCKillObjective objective = new NPCKillObjective(instruction, registry, targetAmount, npcID);
+        final NPCKillObjective objective = new NPCKillObjective(service, registry, targetAmount, npcID);
         service.request(MobKilledEvent.class).handler(objective::onNpcKill)
                 .profile(MobKilledEvent::getProfile).subscribe(true);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
@@ -4,9 +4,9 @@ import com.bergerkiller.bukkit.tc.events.seat.MemberSeatExitEvent;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.compatibility.traincarts.TrainCartsUtils;
 
 /**
@@ -22,12 +22,12 @@ public class TrainCartsExitObjective extends DefaultObjective {
     /**
      * The constructor takes an Instruction object as a parameter and throws an QuestException.
      *
-     * @param instruction the Instruction object to be used in the constructor
-     * @param name        the name of the train, maybe empty
+     * @param service the ObjectiveFactoryService to be used in the constructor
+     * @param name    the name of the train, maybe empty
      * @throws QuestException if there is an error while parsing the instruction
      */
-    public TrainCartsExitObjective(final Instruction instruction, final Argument<String> name) throws QuestException {
-        super(instruction);
+    public TrainCartsExitObjective(final ObjectiveFactoryService service, final Argument<String> name) throws QuestException {
+        super(service);
         this.name = name;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjectiveFactory.java
@@ -22,7 +22,7 @@ public class TrainCartsExitObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> name = instruction.string().get("name", "");
-        final TrainCartsExitObjective objective = new TrainCartsExitObjective(instruction, name);
+        final TrainCartsExitObjective objective = new TrainCartsExitObjective(service, name);
         service.request(MemberSeatExitEvent.class).onlineHandler(objective::onMemberSeatExit)
                 .entity(MemberSeatExitEvent::getEntity).subscribe(false);
         return objective;

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjective.java
@@ -2,9 +2,9 @@ package org.betonquest.betonquest.compatibility.traincarts.objectives;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.compatibility.traincarts.TrainCartsUtils;
 import org.betonquest.betonquest.quest.objective.location.AbstractLocationObjective;
 import org.bukkit.Location;
@@ -27,13 +27,13 @@ public class TrainCartsLocationObjective extends AbstractLocationObjective {
     /**
      * Creates a new {@link TrainCartsLocationObjective}.
      *
-     * @param instruction the Instruction object to be used in the constructor
-     * @param loc         the location the player has to be inside
-     * @param range       the range around the location
+     * @param service the objective factory service
+     * @param loc     the location the player has to be inside
+     * @param range   the range around the location
      * @throws QuestException if there is an error while parsing the instruction
      */
-    public TrainCartsLocationObjective(final Instruction instruction, final Argument<Location> loc, final Argument<Number> range) throws QuestException {
-        super(instruction);
+    public TrainCartsLocationObjective(final ObjectiveFactoryService service, final Argument<Location> loc, final Argument<Number> range) throws QuestException {
+        super(service);
         this.loc = loc;
         this.range = range;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjectiveFactory.java
@@ -23,7 +23,7 @@ public class TrainCartsLocationObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Location> loc = instruction.location().get();
         final Argument<Number> range = instruction.number().atLeast(1).get("range", 1);
-        final TrainCartsLocationObjective objective = new TrainCartsLocationObjective(instruction, loc, range);
+        final TrainCartsLocationObjective objective = new TrainCartsLocationObjective(service, loc, range);
         objective.registerLocationEvents(service);
         return objective;
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsRideObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsRideObjectiveFactory.java
@@ -4,6 +4,7 @@ import com.bergerkiller.bukkit.tc.events.seat.MemberSeatEnterEvent;
 import com.bergerkiller.bukkit.tc.events.seat.MemberSeatExitEvent;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.bukkit.event.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveFactory;
@@ -26,13 +27,15 @@ public class TrainCartsRideObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> name = instruction.string().get("name", "");
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get("amount", 1);
-        final TrainCartsRideObjective objective = new TrainCartsRideObjective(instruction, targetAmount, name);
+        final TrainCartsRideObjective objective = new TrainCartsRideObjective(service, targetAmount, name);
         service.request(MemberSeatEnterEvent.class).onlineHandler(objective::onMemberSeatEnter)
                 .entity(MemberSeatEnterEvent::getEntity).subscribe(false);
         service.request(MemberSeatExitEvent.class).onlineHandler(objective::onMemberSeatExit)
                 .entity(MemberSeatExitEvent::getEntity).subscribe(false);
         service.request(PlayerQuitEvent.class).priority(EventPriority.LOWEST).onlineHandler(objective::onQuit)
                 .player(PlayerQuitEvent::getPlayer).subscribe(true);
+        service.request(PlayerObjectiveChangeEvent.class).handler(objective::onStop)
+                .profile(PlayerObjectiveChangeEvent::getProfile).subscribe(false);
         return objective;
     }
 }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
@@ -2,9 +2,9 @@ package org.betonquest.betonquest.compatibility.worldguard;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.quest.objective.location.AbstractLocationObjective;
 import org.bukkit.Location;
 
@@ -21,12 +21,12 @@ public class RegionObjective extends AbstractLocationObjective {
     /**
      * The constructor takes an Instruction object as a parameter and throws an QuestException.
      *
-     * @param instruction the Instruction object to be used in the constructor
-     * @param name        the name of the region
+     * @param service the ObjectiveFactoryService to be used in the constructor
+     * @param name    the name of the region
      * @throws QuestException if there is an error while parsing the instruction
      */
-    public RegionObjective(final Instruction instruction, final Argument<String> name) throws QuestException {
-        super(instruction);
+    public RegionObjective(final ObjectiveFactoryService service, final Argument<String> name) throws QuestException {
+        super(service);
         this.name = name;
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjectiveFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjectiveFactory.java
@@ -21,7 +21,7 @@ public class RegionObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<String> name = instruction.string().get();
-        final RegionObjective objective = new RegionObjective(instruction, name);
+        final RegionObjective objective = new RegionObjective(service, name);
         objective.registerLocationEvents(service);
         return objective;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerObjectiveChangeEvent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/bukkit/event/PlayerObjectiveChangeEvent.java
@@ -1,8 +1,8 @@
 package org.betonquest.betonquest.api.bukkit.event;
 
-import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.identifier.Identifier;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.Objective;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveState;
 import org.bukkit.event.HandlerList;
 
@@ -19,7 +19,7 @@ public class PlayerObjectiveChangeEvent extends ProfileEvent {
     /**
      * Objective which will change of this event.
      */
-    private final DefaultObjective objective;
+    private final Objective objective;
 
     /**
      * ID of the changed objective.
@@ -46,7 +46,7 @@ public class PlayerObjectiveChangeEvent extends ProfileEvent {
      * @param state         future state of this objective
      * @param previousState previous state of this objective
      */
-    public PlayerObjectiveChangeEvent(final Profile who, final boolean isAsync, final DefaultObjective objective, final Identifier objectiveID,
+    public PlayerObjectiveChangeEvent(final Profile who, final boolean isAsync, final Objective objective, final Identifier objectiveID,
                                       final ObjectiveState state, final ObjectiveState previousState) {
         super(who, isAsync);
         this.objective = objective;
@@ -69,7 +69,7 @@ public class PlayerObjectiveChangeEvent extends ProfileEvent {
      *
      * @return the objective
      */
-    public DefaultObjective getObjective() {
+    public Objective getObjective() {
         return objective;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/Objective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/Objective.java
@@ -1,0 +1,36 @@
+package org.betonquest.betonquest.api.quest.objective;
+
+import org.betonquest.betonquest.api.PropertyHolder;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
+
+/**
+ * Any objective should implement this interface.
+ */
+public interface Objective extends PropertyHolder {
+
+    /**
+     * Should return the {@link ObjectiveFactoryService} for this objective.
+     *
+     * @return the objective service
+     */
+    ObjectiveFactoryService getService();
+
+    /**
+     * Should return the objective ID.
+     *
+     * @return the objective ID
+     */
+    default ObjectiveID getObjectiveID() {
+        return getService().getObjectiveID();
+    }
+
+    /**
+     * Should return the package of this objective.
+     *
+     * @return the package
+     */
+    default QuestPackage getPackage() {
+        return getObjectiveID().getPackage();
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultObjectiveFactoryService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultObjectiveFactoryService.java
@@ -1,7 +1,20 @@
 package org.betonquest.betonquest.api.quest.objective.event;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.action.ActionID;
+import org.betonquest.betonquest.api.quest.condition.ConditionID;
+import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
+import org.betonquest.betonquest.kernel.processor.quest.ActionProcessor;
+import org.betonquest.betonquest.kernel.processor.quest.ConditionProcessor;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Default implementation of the {@link ObjectiveFactoryService}.
@@ -9,28 +22,90 @@ import org.bukkit.event.Event;
 public class DefaultObjectiveFactoryService implements ObjectiveFactoryService {
 
     /**
-     * The instruction that created this service.
+     * The objective service data.
      */
-    private final QuestPackage questPackage;
+    private final ObjectiveServiceData objectiveServiceData;
 
     /**
-     * The event service to request events from.
+     * The objective service.
      */
-    private final ObjectiveService eventService;
+    private final ObjectiveService objectiveService;
+
+    /**
+     * The processors to process actions.
+     */
+    private final ActionProcessor actionProcessor;
+
+    /**
+     * The processors to process conditions.
+     */
+    private final ConditionProcessor conditionProcessor;
+
+    /**
+     * The objective related to this service.
+     */
+    private ObjectiveID objectiveID;
 
     /**
      * Creates a new objective service.
      *
-     * @param questPackage the instruction that created this service
-     * @param eventService the event service to request events from
+     * @param objectiveID        the objective related to this service
+     * @param actionProcessor    the event processor to use
+     * @param conditionProcessor the condition processor to use
+     * @param objectiveService   the event service to request events from
+     * @throws QuestException if the objective service data of the instruction could not be parsed
      */
-    public DefaultObjectiveFactoryService(final QuestPackage questPackage, final ObjectiveService eventService) {
-        this.questPackage = questPackage;
-        this.eventService = eventService;
+    public DefaultObjectiveFactoryService(final ObjectiveID objectiveID, final ActionProcessor actionProcessor,
+                                          final ConditionProcessor conditionProcessor, final ObjectiveService objectiveService) throws QuestException {
+        this.objectiveID = objectiveID;
+        this.objectiveService = objectiveService;
+        this.actionProcessor = actionProcessor;
+        this.conditionProcessor = conditionProcessor;
+        this.objectiveServiceData = parseObjectiveData(objectiveID.getInstruction());
+    }
+
+    private static ObjectiveServiceData parseObjectiveData(final Instruction instruction) throws QuestException {
+        final FlagArgument<Boolean> persistent = instruction.bool().getFlag("persistent", true);
+        final Optional<Argument<List<ActionID>>> actions = instruction.parse(ActionID::new).list().get("actions");
+        final Optional<Argument<List<ConditionID>>> conditions = instruction.parse(ConditionID::new).list().get("conditions");
+        final FlagArgument<Number> notify = instruction.number().atLeast(0).getFlag("notify", 1);
+        return new ObjectiveServiceData(conditions, actions, persistent, notify);
     }
 
     @Override
     public <T extends Event> EventServiceSubscriptionBuilder<T> request(final Class<T> eventClass) {
-        return eventService.request(eventClass).source(questPackage);
+        return objectiveService.request(eventClass).source(objectiveID.getPackage());
+    }
+
+    @Override
+    public void renameObjective(final ObjectiveID newObjectiveID) {
+        this.objectiveID = newObjectiveID;
+    }
+
+    @Override
+    public ObjectiveID getObjectiveID() {
+        return objectiveID;
+    }
+
+    @Override
+    public ObjectiveServiceDataProvider getServiceDataProvider() {
+        return objectiveServiceData;
+    }
+
+    @Override
+    public boolean checkConditions(@Nullable final Profile profile) throws QuestException {
+        final ObjectiveServiceDataProvider provider = getServiceDataProvider();
+        final List<ConditionID> conditions = provider.getConditions(profile);
+        return conditions.isEmpty() || conditionProcessor.checks(profile, conditions, true);
+    }
+
+    @Override
+    public void callActions(@Nullable final Profile profile) throws QuestException {
+        final ObjectiveServiceDataProvider provider = getServiceDataProvider();
+        final List<ActionID> events = provider.getActions(profile);
+        if (events.isEmpty()) {
+            return;
+        }
+        actionProcessor.executes(profile, events);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveFactoryService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveFactoryService.java
@@ -1,13 +1,16 @@
 package org.betonquest.betonquest.api.quest.objective.event;
 
+import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.logger.LogSource;
+import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveFactory;
+import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Provides services for objective creation and event subscriptions.
  */
-@FunctionalInterface
 public interface ObjectiveFactoryService {
 
     /**
@@ -25,4 +28,44 @@ public interface ObjectiveFactoryService {
      * @return a new {@link EventServiceSubscriptionBuilder} for the requested event
      */
     <T extends Event> EventServiceSubscriptionBuilder<T> request(Class<T> eventClass);
+
+    /**
+     * Do not use this method directly. It is used for internal logic.
+     * <br>
+     * Renames the objective.
+     *
+     * @param newObjectiveID the new objective ID
+     */
+    void renameObjective(ObjectiveID newObjectiveID);
+
+    /**
+     * Retrieves the objective ID.
+     *
+     * @return the objective ID
+     */
+    ObjectiveID getObjectiveID();
+
+    /**
+     * Retrieves the service data provider containing all additional information about the objective.
+     *
+     * @return the service data provider
+     */
+    ObjectiveServiceDataProvider getServiceDataProvider();
+
+    /**
+     * Checks if the objective conditions are met.
+     *
+     * @param profile the profile to check conditions for
+     * @return if the conditions are met
+     * @throws QuestException if argument resolving for the profile fails
+     */
+    boolean checkConditions(@Nullable Profile profile) throws QuestException;
+
+    /**
+     * Executes all objective actions for the given profile.
+     *
+     * @param profile the profile to execute actions for
+     * @throws QuestException if argument resolving for the profile fails
+     */
+    void callActions(@Nullable Profile profile) throws QuestException;
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveService.java
@@ -17,12 +17,19 @@ import java.util.Optional;
 public interface ObjectiveService {
 
     /**
+     * Resets the entire service.
+     * Use with caution!
+     */
+    void clear();
+
+    /**
      * Creates a new {@link ObjectiveFactoryService} for the given objectiveId.
      *
      * @param objectiveID the objective to create a subscription service for
      * @return a new {@link ObjectiveFactoryService} for the given objectiveId
+     * @throws QuestException if the objective causes issues with creating a factory service
      */
-    ObjectiveFactoryService getSubscriptionService(ObjectiveID objectiveID);
+    ObjectiveFactoryService getFactoryService(ObjectiveID objectiveID) throws QuestException;
 
     /**
      * Requests a new event subscription using an {@link EventServiceSubscriptionBuilder}.

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveServiceData.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveServiceData.java
@@ -1,0 +1,53 @@
+package org.betonquest.betonquest.api.quest.objective.event;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.action.ActionID;
+import org.betonquest.betonquest.api.quest.condition.ConditionID;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents the arguments defined per objective that may be parsed independently of their implementation.
+ *
+ * @param conditions     the optional conditions that must be met to receive forwarded bukkit actions
+ * @param actions        the optional actions that will be called after completing the objective
+ * @param persistent     the boolean flag to decide if the objective will be reapplied after completing
+ * @param notifyInterval the number flag to determine how often the objective should inform about progression
+ */
+public record ObjectiveServiceData(Optional<Argument<List<ConditionID>>> conditions,
+                                   Optional<Argument<List<ActionID>>> actions,
+                                   FlagArgument<Boolean> persistent, FlagArgument<Number> notifyInterval)
+        implements ObjectiveServiceDataProvider {
+
+    @Override
+    public boolean isPersistent(@Nullable final Profile profile) throws QuestException {
+        return persistent.getValue(profile).orElse(false);
+    }
+
+    @Override
+    public List<ActionID> getActions(@Nullable final Profile profile) throws QuestException {
+        if (actions.isPresent()) {
+            return actions.get().getValue(profile);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ConditionID> getConditions(@Nullable final Profile profile) throws QuestException {
+        if (conditions.isPresent()) {
+            return conditions.get().getValue(profile);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getNotificationInterval(@Nullable final Profile profile) throws QuestException {
+        return notifyInterval.getValue(profile).orElse(0).intValue();
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveServiceDataProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveServiceDataProvider.java
@@ -1,0 +1,54 @@
+package org.betonquest.betonquest.api.quest.objective.event;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.action.ActionID;
+import org.betonquest.betonquest.api.quest.condition.ConditionID;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Defines additional information accessible per objective.
+ */
+public interface ObjectiveServiceDataProvider {
+
+    /**
+     * If the objective is persistent.
+     * <br>
+     * A persistent objective will be reapplied after completion.
+     *
+     * @param profile the profile to check for
+     * @return if the objective is persistent
+     * @throws QuestException if argument resolving failed
+     */
+    boolean isPersistent(@Nullable Profile profile) throws QuestException;
+
+    /**
+     * Retrieves a list of actionIds for actions to call after completing the objective.
+     *
+     * @param profile the profile to get the actions for
+     * @return a list of actionIds
+     * @throws QuestException if argument resolving failed
+     */
+    List<ActionID> getActions(@Nullable Profile profile) throws QuestException;
+
+    /**
+     * Retrieves a list of conditionIds for conditions to check before each bukkit event for the objective.
+     *
+     * @param profile the profile to get the conditions for
+     * @return a list of conditionIds
+     * @throws QuestException if argument resolving failed
+     */
+    List<ConditionID> getConditions(@Nullable Profile profile) throws QuestException;
+
+    /**
+     * Retrieves the notification interval for the objective.
+     * An interval of 0 disables notifications.
+     *
+     * @param profile the profile to get the interval for
+     * @return the notification interval
+     * @throws QuestException if argument resolving failed
+     */
+    int getNotificationInterval(@Nullable Profile profile) throws QuestException;
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/CoreQuestRegistry.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/CoreQuestRegistry.java
@@ -36,11 +36,12 @@ import java.util.Map;
  * @param objectives   Objective logic.
  * @param placeholders Placeholder logic.
  */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public record CoreQuestRegistry(
         ConditionProcessor conditions,
         ActionProcessor actions,
-        ObjectiveProcessor objectives,
-        PlaceholderProcessor placeholders
+        PlaceholderProcessor placeholders,
+        ObjectiveProcessor objectives
 ) implements QuestTypeApi {
 
     /**
@@ -60,14 +61,15 @@ public record CoreQuestRegistry(
                                            final BukkitScheduler scheduler, final ProfileProvider profileProvider, final Plugin plugin) {
         final PlaceholderProcessor placeholderProcessor = new PlaceholderProcessor(loggerFactory.create(PlaceholderProcessor.class),
                 packManager, questTypeRegistries.placeholder(), scheduler, plugin);
-        final DefaultObjectiveService objectiveService = new DefaultObjectiveService(plugin, loggerFactory, profileProvider);
-        return new CoreQuestRegistry(
-                new ConditionProcessor(loggerFactory.create(ConditionProcessor.class), placeholderProcessor, packManager,
-                        questTypeRegistries.condition(), scheduler, plugin),
-                new ActionProcessor(loggerFactory.create(ActionProcessor.class), placeholderProcessor, packManager,
-                        questTypeRegistries.action(), scheduler, plugin),
+        final ActionProcessor actionProcessor = new ActionProcessor(loggerFactory.create(ActionProcessor.class),
+                placeholderProcessor, packManager, questTypeRegistries.action(), scheduler, plugin);
+        final ConditionProcessor conditionProcessor = new ConditionProcessor(loggerFactory.create(ConditionProcessor.class),
+                placeholderProcessor, packManager, questTypeRegistries.condition(), scheduler, plugin);
+        final DefaultObjectiveService objectiveService = new DefaultObjectiveService(plugin, conditionProcessor,
+                actionProcessor, loggerFactory, profileProvider);
+        return new CoreQuestRegistry(conditionProcessor, actionProcessor, placeholderProcessor,
                 new ObjectiveProcessor(loggerFactory.create(ObjectiveProcessor.class), placeholderProcessor, packManager,
-                        questTypeRegistries.objective(), pluginManager, objectiveService, plugin), placeholderProcessor);
+                        questTypeRegistries.objective(), pluginManager, objectiveService, plugin));
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
@@ -4,9 +4,9 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.menu.Menu;
 import org.betonquest.betonquest.menu.MenuID;
 import org.betonquest.betonquest.menu.RPGMenu;
@@ -40,14 +40,14 @@ public class MenuObjective extends DefaultObjective {
     /**
      * Construct a new Menu Objective from Instruction.
      *
-     * @param instruction the instruction to get the id from
-     * @param log         the logger for this objective
-     * @param rpgMenu     the RPGMenu instance
-     * @param menuID      the menu id to open
+     * @param service the objective factory service
+     * @param log     the logger for this objective
+     * @param rpgMenu the RPGMenu instance
+     * @param menuID  the menu id to open
      * @throws QuestException if the menu id does not exist
      */
-    public MenuObjective(final Instruction instruction, final BetonQuestLogger log, final RPGMenu rpgMenu, final Argument<MenuID> menuID) throws QuestException {
-        super(instruction);
+    public MenuObjective(final ObjectiveFactoryService service, final BetonQuestLogger log, final RPGMenu rpgMenu, final Argument<MenuID> menuID) throws QuestException {
+        super(service);
         this.log = log;
         this.rpgMenu = rpgMenu;
         this.menuID = menuID;
@@ -68,7 +68,7 @@ public class MenuObjective extends DefaultObjective {
                 return;
             }
         } catch (final QuestException e) {
-            log.debug(instruction.getPackage(), "Could not get menu placeholder value in '" + instruction.getID() + "' objective:"
+            log.debug(getPackage(), "Could not get menu placeholder value in '" + getPackage() + "' objective:"
                     + e.getMessage(), e);
             return;
         }
@@ -90,19 +90,19 @@ public class MenuObjective extends DefaultObjective {
             try {
                 menuData = rpgMenu.getMenu(menuID.getValue(profile));
             } catch (final QuestException e) {
-                log.warn(instruction.getPackage(), "Error while getting menu property in '" + instruction.getID() + "' objective: "
+                log.warn(getPackage(), "Error while getting menu property in '" + getObjectiveID() + "' objective: "
                         + e.getMessage(), e);
                 return "";
             }
             if (menuData == null) {
-                log.debug(instruction.getPackage(), "Error while getting menu property in '" + instruction.getID() + "' objective: "
+                log.debug(getPackage(), "Error while getting menu property in '" + getObjectiveID() + "' objective: "
                         + "menu with id " + menuID + " isn't loaded");
                 return "";
             }
             try {
                 return LegacyComponentSerializer.legacySection().serialize(menuData.getTitle(profile));
             } catch (final QuestException e) {
-                log.debug(instruction.getPackage(), "Error while getting menu property in '" + instruction.getID() + "' objective: "
+                log.debug(getPackage(), "Error while getting menu property in '" + getObjectiveID() + "' objective: "
                         + e.getMessage(), e);
             }
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjectiveFactory.java
@@ -45,7 +45,7 @@ public class MenuObjectiveFactory implements ObjectiveFactory {
                 (placeholders, packManager, pack, string)
                         -> new MenuID(packManager, pack, string)).get();
         final BetonQuestLogger log = loggerFactory.create(MenuObjective.class);
-        final MenuObjective objective = new MenuObjective(instruction, log, rpgMenu, menuID);
+        final MenuObjective objective = new MenuObjective(service, log, rpgMenu, menuID);
         service.request(MenuOpenEvent.class).priority(EventPriority.MONITOR).handler(objective::onMenuOpen)
                 .profile(MenuOpenEvent::getProfile).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjective.java
@@ -4,10 +4,10 @@ import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.BlockSelector;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -69,21 +69,21 @@ public class ActionObjective extends DefaultObjective {
     /**
      * Creates a new instance of the ActionObjective.
      *
-     * @param instruction the instruction
-     * @param action      the action to check for
-     * @param selector    the selector to check for the block
-     * @param exactMatch  if the block should be checked for exact match
-     * @param loc         the location where the player has to click
-     * @param range       the range of the location
-     * @param cancel      if the event should be canceled
-     * @param slot        the equipment slot to check for the action
+     * @param service    the objective factory service
+     * @param action     the action to check for
+     * @param selector   the selector to check for the block
+     * @param exactMatch if the block should be checked for exact match
+     * @param loc        the location where the player has to click
+     * @param range      the range of the location
+     * @param cancel     if the event should be canceled
+     * @param slot       the equipment slot to check for the action
      * @throws QuestException if an error occurs while creating the objective
      */
-    public ActionObjective(final Instruction instruction, final Argument<Click> action,
+    public ActionObjective(final ObjectiveFactoryService service, final Argument<Click> action,
                            final Argument<Optional<BlockSelector>> selector, final FlagArgument<Boolean> exactMatch,
                            @Nullable final Argument<Location> loc, final Argument<Number> range,
                            final FlagArgument<Boolean> cancel, @Nullable final EquipmentSlot slot) throws QuestException {
-        super(instruction);
+        super(service);
         this.action = action;
         this.selector = selector;
         this.exactMatch = exactMatch;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjectiveFactory.java
@@ -45,7 +45,7 @@ public class ActionObjectiveFactory implements ObjectiveFactory {
                 .prefilterOptional(ANY, null)
                 .get("hand").orElse(null);
         final EquipmentSlot slot = hand == null ? null : hand.getValue(null).orElse(null);
-        final ActionObjective objective = new ActionObjective(instruction, action, selector, exactMatch, loc, range, cancel, slot);
+        final ActionObjective objective = new ActionObjective(service, action, selector, exactMatch, loc, range, cancel, slot);
         service.request(PlayerInteractEvent.class).priority(EventPriority.LOWEST).onlineHandler(objective::onInteract)
                 .player(PlayerInteractEvent::getPlayer).subscribe(false);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjective.java
@@ -4,9 +4,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Projectile;
@@ -31,13 +31,13 @@ public class ArrowShootObjective extends DefaultObjective {
     /**
      * Constructor for the ArrowShootObjective.
      *
-     * @param instruction the instruction that created this objective
-     * @param location    the location where the arrow should hit
-     * @param range       the range around the location where the arrow should hit
+     * @param service  the objective factory service
+     * @param location the location where the arrow should hit
+     * @param range    the range around the location where the arrow should hit
      * @throws QuestException if there is an error in the instruction
      */
-    public ArrowShootObjective(final Instruction instruction, final Argument<Location> location, final Argument<Number> range) throws QuestException {
-        super(instruction);
+    public ArrowShootObjective(final ObjectiveFactoryService service, final Argument<Location> location, final Argument<Number> range) throws QuestException {
+        super(service);
         this.location = location;
         this.range = range;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjectiveFactory.java
@@ -26,7 +26,7 @@ public class ArrowShootObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Location> location = instruction.location().get();
         final Argument<Number> range = instruction.number().get();
-        final ArrowShootObjective objective = new ArrowShootObjective(instruction, location, range);
+        final ArrowShootObjective objective = new ArrowShootObjective(service, location, range);
         service.request(ProjectileHitEvent.class).onlineHandler(objective::onArrowHit)
                 .player(this::fromEvent).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/block/BlockObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/block/BlockObjective.java
@@ -4,10 +4,10 @@ import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.BlockSelector;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.quest.action.IngameNotificationSender;
 import org.bukkit.Location;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -65,7 +65,7 @@ public class BlockObjective extends CountingObjective {
     /**
      * Constructor for the BlockObjective.
      *
-     * @param instruction      the instruction that created this objective
+     * @param service          the objective factory service
      * @param targetAmount     the target amount of blocks to break/place
      * @param selector         the block selector to match blocks
      * @param exactMatch       the exact match flag
@@ -78,12 +78,12 @@ public class BlockObjective extends CountingObjective {
      * @throws QuestException if there is an error in the instruction
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    public BlockObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public BlockObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                           final Argument<BlockSelector> selector, final FlagArgument<Boolean> exactMatch,
                           final FlagArgument<Boolean> noSafety, @Nullable final Argument<Location> location,
                           @Nullable final Argument<Location> region, final FlagArgument<Boolean> ignoreCancel,
                           final IngameNotificationSender blockBreakSender, final IngameNotificationSender blockPlaceSender) throws QuestException {
-        super(instruction, targetAmount, null);
+        super(service, targetAmount, null);
         this.selector = selector;
         this.exactMatch = exactMatch;
         this.noSafety = noSafety;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/block/BlockObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/block/BlockObjectiveFactory.java
@@ -58,7 +58,7 @@ public class BlockObjectiveFactory implements ObjectiveFactory {
                 instruction.getID().getFull(), NotificationLevel.INFO, "blocks_to_break");
         final IngameNotificationSender blockPlaceSender = new IngameNotificationSender(log, pluginMessage, instruction.getPackage(),
                 instruction.getID().getFull(), NotificationLevel.INFO, "blocks_to_place");
-        final BlockObjective objective = new BlockObjective(instruction, targetAmount, selector, exactMatch, noSafety,
+        final BlockObjective objective = new BlockObjective(service, targetAmount, selector, exactMatch, noSafety,
                 location, region, ignoreCancel, blockBreakSender, blockPlaceSender);
         service.request(BlockPlaceEvent.class).priority(EventPriority.HIGHEST).onlineHandler(objective::onBlockPlace)
                 .player(BlockPlaceEvent::getPlayer).subscribe(false);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/breed/BreedObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/breed/BreedObjective.java
@@ -3,8 +3,8 @@ package org.betonquest.betonquest.quest.objective.breed;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.EntityBreedEvent;
 
@@ -21,13 +21,13 @@ public class BreedObjective extends CountingObjective {
     /**
      * Constructor for the BreedObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of animals to breed
      * @param type         the type of animal to breed
      * @throws QuestException if there is an error in the instruction
      */
-    public BreedObjective(final Instruction instruction, final Argument<Number> targetAmount, final Argument<EntityType> type) throws QuestException {
-        super(instruction, targetAmount, "animals_to_breed");
+    public BreedObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final Argument<EntityType> type) throws QuestException {
+        super(service, targetAmount, "animals_to_breed");
         this.type = type;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/breed/BreedObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/breed/BreedObjectiveFactory.java
@@ -24,7 +24,7 @@ public class BreedObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<EntityType> type = instruction.enumeration(EntityType.class).get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final BreedObjective objective = new BreedObjective(instruction, targetAmount, type);
+        final BreedObjective objective = new BreedObjective(service, targetAmount, type);
         service.request(EntityBreedEvent.class).onlineHandler(objective::onBreeding)
                 .entity(EntityBreedEvent::getBreeder).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
@@ -4,12 +4,12 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.item.QuestItem;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.profile.ProfileProvider;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.lib.profile.ProfileValueMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -43,15 +43,15 @@ public class BrewObjective extends CountingObjective {
     /**
      * The target amount of potions to brew.
      *
-     * @param instruction     the instruction that created this objective
+     * @param service         the objective factory service
      * @param targetAmount    the target amount of potions to brew
      * @param profileProvider the profile provider to get the profile of the player
      * @param potion          the potion item to brew
      * @throws QuestException if there is an error in the instruction
      */
-    public BrewObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public BrewObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                          final ProfileProvider profileProvider, final Argument<ItemWrapper> potion) throws QuestException {
-        super(instruction, targetAmount, "potions_to_brew");
+        super(service, targetAmount, "potions_to_brew");
         this.potion = potion;
         this.locations = new ProfileValueMap<>(profileProvider);
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjectiveFactory.java
@@ -35,7 +35,7 @@ public class BrewObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<ItemWrapper> potion = instruction.item().get();
         final Argument<Number> targetAmount = instruction.number().atLeast(0).get();
-        final BrewObjective objective = new BrewObjective(instruction, targetAmount, profileProvider, potion);
+        final BrewObjective objective = new BrewObjective(service, targetAmount, profileProvider, potion);
         service.request(InventoryClickEvent.class).priority(EventPriority.LOWEST).onlineHandler(objective::onIngredientPut)
                 .entity(InventoryClickEvent::getWhoClicked).subscribe(false);
         service.request(BrewEvent.class).priority(EventPriority.MONITOR)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.quest.objective.chestput;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.condition.nullable.NullableCondition;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.quest.action.IngameNotificationSender;
 import org.betonquest.betonquest.quest.action.chest.ChestTakeAction;
 import org.bukkit.Location;
@@ -57,7 +57,7 @@ public class ChestPutObjective extends DefaultObjective {
     /**
      * Constructor for the ChestPutObjective.
      *
-     * @param instruction        the instruction that created this objective
+     * @param service            the objective factory service
      * @param chestItemCondition the condition to check if the items are in the chest
      * @param chestTakeAction    the action to execute when the items are put in the chest to take them out
      * @param loc                the location of the chest
@@ -65,11 +65,11 @@ public class ChestPutObjective extends DefaultObjective {
      * @param multipleAccess     manages the chest access for one or multiple players
      * @throws QuestException if there is an error in the instruction
      */
-    public ChestPutObjective(final Instruction instruction,
+    public ChestPutObjective(final ObjectiveFactoryService service,
                              final NullableCondition chestItemCondition, @Nullable final ChestTakeAction chestTakeAction,
                              final Argument<Location> loc, final IngameNotificationSender occupiedSender,
                              final boolean multipleAccess) throws QuestException {
-        super(instruction);
+        super(service);
         this.chestItemCondition = chestItemCondition;
         this.chestTakeAction = chestTakeAction;
         this.loc = loc;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjectiveFactory.java
@@ -58,7 +58,7 @@ public class ChestPutObjectiveFactory implements ObjectiveFactory {
         final BetonQuestLogger log = loggerFactory.create(ChestPutObjective.class);
         final IngameNotificationSender occupiedSender = new IngameNotificationSender(log, pluginMessage, instruction.getPackage(),
                 instruction.getID().getFull(), NotificationLevel.INFO, "chest_occupied");
-        final ChestPutObjective objective = new ChestPutObjective(instruction, chestItemCondition, chestTakeAction,
+        final ChestPutObjective objective = new ChestPutObjective(service, chestItemCondition, chestTakeAction,
                 loc, occupiedSender, multipleAccess);
         service.request(InventoryOpenEvent.class).onlineHandler(objective::onChestOpen)
                 .entity(InventoryOpenEvent::getPlayer).subscribe(false);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjective.java
@@ -6,10 +6,10 @@ import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.action.ActionID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import java.util.List;
@@ -47,7 +47,7 @@ public class CommandObjective extends DefaultObjective {
     /**
      * Creates a new instance of the CommandObjective.
      *
-     * @param instruction the instruction that created this objective
+     * @param service     the objective factory service
      * @param command     the command that the player has to execute
      * @param ignoreCase  whether the command should ignore the capitalization
      * @param exact       whether the command should be matched exactly or just the start
@@ -55,10 +55,10 @@ public class CommandObjective extends DefaultObjective {
      * @param failActions actions to trigger if the command is not matched
      * @throws QuestException if there is an error in the instruction
      */
-    public CommandObjective(final Instruction instruction, final Argument<String> command,
+    public CommandObjective(final ObjectiveFactoryService service, final Argument<String> command,
                             final FlagArgument<Boolean> ignoreCase, final FlagArgument<Boolean> exact,
                             final FlagArgument<Boolean> cancel, final Argument<List<ActionID>> failActions) throws QuestException {
-        super(instruction);
+        super(service);
         this.command = command;
         this.ignoreCase = ignoreCase;
         this.exact = exact;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjectiveFactory.java
@@ -33,7 +33,7 @@ public class CommandObjectiveFactory implements ObjectiveFactory {
         final FlagArgument<Boolean> cancel = instruction.bool().getFlag("cancel", true);
         final Argument<List<ActionID>> failEvents = instruction.parse(ActionID::new)
                 .list().get("failActions", Collections.emptyList());
-        final CommandObjective objective = new CommandObjective(instruction, command, ignoreCase, exact, cancel, failEvents);
+        final CommandObjective objective = new CommandObjective(service, command, ignoreCase, exact, cancel, failEvents);
         service.request(PlayerCommandPreprocessEvent.class).priority(EventPriority.LOWEST).onlineHandler(objective::onCommand)
                 .player(PlayerCommandPreprocessEvent::getPlayer).subscribe(false);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/consume/ConsumeObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/consume/ConsumeObjective.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.quest.objective.consume;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 
 /**
@@ -21,14 +21,14 @@ public class ConsumeObjective extends CountingObjective {
     /**
      * Constructs a new {@code ConsumeObjective} for the given {@code Instruction}.
      *
-     * @param instruction  the instruction out of a quest package
+     * @param service      the objective factory service
      * @param targetAmount the amount of items to consume
      * @param item         the item to consume
      * @throws QuestException if the instruction is invalid
      */
-    public ConsumeObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public ConsumeObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                             final Argument<ItemWrapper> item) throws QuestException {
-        super(instruction, targetAmount, null);
+        super(service, targetAmount, null);
         this.item = item;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/consume/ConsumeObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/consume/ConsumeObjectiveFactory.java
@@ -29,7 +29,7 @@ public class ConsumeObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<ItemWrapper> item = instruction.item().get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get(AMOUNT_ARGUMENT, 1);
-        final ConsumeObjective objective = new ConsumeObjective(instruction, targetAmount, item);
+        final ConsumeObjective objective = new ConsumeObjective(service, targetAmount, item);
         service.request(PlayerItemConsumeEvent.class).onlineHandler(objective::onConsume)
                 .player(PlayerItemConsumeEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/crafting/CraftingObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/crafting/CraftingObjective.java
@@ -4,10 +4,10 @@ import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.ItemStackCraftedEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.util.InventoryUtils;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.inventory.ItemStack;
@@ -26,14 +26,14 @@ public class CraftingObjective extends CountingObjective {
     /**
      * Constructor for the CraftingObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of items to be crafted
      * @param item         the item to be crafted
      * @throws QuestException if there is an error in the instruction
      */
-    public CraftingObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public CraftingObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                              final Argument<ItemWrapper> item) throws QuestException {
-        super(instruction, targetAmount, "items_to_craft");
+        super(service, targetAmount, "items_to_craft");
         this.item = item;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/crafting/CraftingObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/crafting/CraftingObjectiveFactory.java
@@ -26,7 +26,7 @@ public class CraftingObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<ItemWrapper> item = instruction.item().get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final CraftingObjective objective = new CraftingObjective(instruction, targetAmount, item);
+        final CraftingObjective objective = new CraftingObjective(service, targetAmount, item);
         service.request(CraftItemEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onCrafting)
                 .entity(CraftItemEvent::getWhoClicked).subscribe(true);
         service.request(ItemStackCraftedEvent.class).handler(objective::handleCustomCraft)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
@@ -5,13 +5,13 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.bukkit.event.PlayerUpdatePointEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.argument.parser.NumberParser;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveData;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveDataFactory;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveState;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.PlayerData;
 import org.betonquest.betonquest.quest.condition.number.Operation;
@@ -58,7 +58,7 @@ public class PointObjective extends DefaultObjective {
     /**
      * Create a new objective to have specified amount of points.
      *
-     * @param instruction       Instruction object representing the objective
+     * @param service           the objective factory service
      * @param playerDataStorage the storage for player data
      * @param category          the point category to check for
      * @param targetAmount      the target amount of points required for completion
@@ -66,10 +66,10 @@ public class PointObjective extends DefaultObjective {
      * @param operation         the operation to use for comparing
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public PointObjective(final Instruction instruction, final PlayerDataStorage playerDataStorage, final Argument<String> category,
+    public PointObjective(final ObjectiveFactoryService service, final PlayerDataStorage playerDataStorage, final Argument<String> category,
                           final Argument<Number> targetAmount, final Argument<CountingMode> mode, final Argument<Operation> operation)
             throws QuestException {
-        super(instruction, POINT_FACTORY);
+        super(service, POINT_FACTORY);
         this.playerDataStorage = playerDataStorage;
         this.category = category;
         this.targetAmount = targetAmount;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjectiveFactory.java
@@ -36,7 +36,7 @@ public class PointObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> targetAmount = instruction.number().get();
         final Argument<CountingMode> mode = instruction.enumeration(CountingMode.class).get("mode", CountingMode.TOTAL);
         final Argument<Operation> operation = instruction.parse(Operation::fromSymbol).get("operation", Operation.GREATER_EQUAL);
-        final PointObjective objective = new PointObjective(instruction, playerDataStorage, category, targetAmount, mode, operation);
+        final PointObjective objective = new PointObjective(service, playerDataStorage, category, targetAmount, mode, operation);
         service.request(PlayerUpdatePointEvent.class).handler(objective::onPointUpdate)
                 .profile(PlayerUpdatePointEvent::getProfile).subscribe(false);
         service.request(PlayerObjectiveChangeEvent.class).handler(objective::onStart)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
@@ -5,9 +5,9 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.bukkit.event.PlayerTagAddEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveState;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 
 /**
@@ -28,13 +28,13 @@ public class TagObjective extends DefaultObjective {
     /**
      * Creates a new tag objective.
      *
-     * @param instruction       Instruction object representing the objective
+     * @param service           the objective factory service
      * @param playerDataStorage the storage for player data
      * @param tag               the tag to get
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
-    public TagObjective(final Instruction instruction, final PlayerDataStorage playerDataStorage, final Argument<String> tag) throws QuestException {
-        super(instruction);
+    public TagObjective(final ObjectiveFactoryService service, final PlayerDataStorage playerDataStorage, final Argument<String> tag) throws QuestException {
+        super(service);
         this.playerDataStorage = playerDataStorage;
         this.tag = tag;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjectiveFactory.java
@@ -30,7 +30,7 @@ public class TagObjectiveFactory implements ObjectiveFactory {
 
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
-        final TagObjective objective = new TagObjective(instruction, playerDataStorage, instruction.packageIdentifier().get());
+        final TagObjective objective = new TagObjective(service, playerDataStorage, instruction.packageIdentifier().get());
         service.request(PlayerTagAddEvent.class).handler(objective::onTag)
                 .profile(PlayerTagAddEvent::getProfile).subscribe(false);
         service.request(PlayerObjectiveChangeEvent.class).handler(objective::onStart)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjective.java
@@ -7,12 +7,12 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.argument.parser.NumberParser;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveData;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveDataFactory;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.config.PluginMessage;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
@@ -52,14 +52,14 @@ public class DelayObjective extends DefaultObjective {
     /**
      * Constructor for the DelayObjective.
      *
-     * @param instruction the instruction that created this objective
-     * @param interval    the interval in ticks at which the objective checks if the time is up
-     * @param delay       the delay time in seconds, minutes, or ticks
+     * @param service  the objective factory service
+     * @param interval the interval in ticks at which the objective checks if the time is up
+     * @param delay    the delay time in seconds, minutes, or ticks
      * @throws QuestException if there is an error in the instruction
      */
-    public DelayObjective(final Instruction instruction, final Argument<Number> interval,
+    public DelayObjective(final ObjectiveFactoryService service, final Argument<Number> interval,
                           final Argument<Number> delay) throws QuestException {
-        super(instruction, DELAY_FACTORY);
+        super(service, DELAY_FACTORY);
         this.delay = delay;
         this.runnable = new BukkitRunnable() {
             @Override
@@ -83,12 +83,12 @@ public class DelayObjective extends DefaultObjective {
     }
 
     private double timeToMilliSeconds(final Profile profile, final double time) throws QuestException {
-        final boolean ticks = instruction.bool().getFlag("ticks", true)
+        final boolean ticks = getObjectiveID().getInstruction().bool().getFlag("ticks", true)
                 .getValue(profile).orElse(false);
         if (ticks) {
             return time * 50;
         }
-        final boolean seconds = instruction.bool().getFlag("seconds", true)
+        final boolean seconds = getObjectiveID().getInstruction().bool().getFlag("seconds", true)
                 .getValue(profile).orElse(false);
         if (seconds) {
             return time * 1000;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjectiveFactory.java
@@ -19,10 +19,10 @@ public class DelayObjectiveFactory implements ObjectiveFactory {
     }
 
     @Override
-    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService eventService) throws QuestException {
+    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Number> delay = instruction.number().atLeast(0).get();
         final Argument<Number> interval = instruction.number()
                 .atLeast(1).get("interval", 20 * 10);
-        return new DelayObjective(instruction, interval, delay);
+        return new DelayObjective(service, interval, delay);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjective.java
@@ -5,9 +5,9 @@ import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
@@ -39,13 +39,13 @@ public class DieObjective extends DefaultObjective {
     /**
      * Constructor for the DieObjective.
      *
-     * @param instruction the instruction that created this objective
-     * @param cancel      whether the death should be canceled
-     * @param location    the location where the player should respawn
+     * @param service  the objective factory service
+     * @param cancel   whether the death should be canceled
+     * @param location the location where the player should respawn
      * @throws QuestException if there is an error in the instruction
      */
-    public DieObjective(final Instruction instruction, final FlagArgument<Boolean> cancel, @Nullable final Argument<Location> location) throws QuestException {
-        super(instruction);
+    public DieObjective(final ObjectiveFactoryService service, final FlagArgument<Boolean> cancel, @Nullable final Argument<Location> location) throws QuestException {
+        super(service);
         this.cancel = cancel;
         this.location = location;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjectiveFactory.java
@@ -28,7 +28,7 @@ public class DieObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final FlagArgument<Boolean> cancel = instruction.bool().getFlag("cancel", true);
         final Argument<Location> location = instruction.location().get("respawn").orElse(null);
-        final DieObjective objective = new DieObjective(instruction, cancel, location);
+        final DieObjective objective = new DieObjective(service, cancel, location);
         service.request(EntityDeathEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onDeath)
                 .entity(EntityDeathEvent::getEntity).subscribe(true);
         service.request(PlayerRespawnEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onRespawn)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/enchant/EnchantObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/enchant/EnchantObjective.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.quest.objective.enchant;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.item.QuestItem;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 
@@ -37,16 +37,16 @@ public class EnchantObjective extends CountingObjective {
     /**
      * Constructor for the EnchantObjective.
      *
-     * @param instruction         the instruction that created this objective
+     * @param service             the objective factory service
      * @param targetAmount        the target amount of items to enchant
      * @param item                the item to enchant
      * @param desiredEnchantments the desired enchantments
      * @param requireOne          true if at least one enchantment is required, false if all enchantments are required
      * @throws QuestException if there is an error in the instruction
      */
-    public EnchantObjective(final Instruction instruction, final Argument<Number> targetAmount, final Argument<ItemWrapper> item,
+    public EnchantObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final Argument<ItemWrapper> item,
                             final Argument<List<EnchantmentData>> desiredEnchantments, final boolean requireOne) throws QuestException {
-        super(instruction, targetAmount, "items_to_enchant");
+        super(service, targetAmount, "items_to_enchant");
         this.item = item;
         this.desiredEnchantments = desiredEnchantments;
         this.requireOne = requireOne;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/enchant/EnchantObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/enchant/EnchantObjectiveFactory.java
@@ -35,7 +35,7 @@ public class EnchantObjectiveFactory implements ObjectiveFactory {
                 instruction.parse(EnchantObjective.EnchantmentData::convert).list().notEmpty().get();
         final boolean requireOne = instruction.parse(JUST_ONE_ENCHANT::equalsIgnoreCase)
                 .get("requirementMode", false).getValue(null);
-        final EnchantObjective objective = new EnchantObjective(instruction, targetAmount, item, desiredEnchantments, requireOne);
+        final EnchantObjective objective = new EnchantObjective(service, targetAmount, item, desiredEnchantments, requireOne);
         service.request(EnchantItemEvent.class).onlineHandler(objective::onEnchant)
                 .player(EnchantItemEvent::getEnchanter).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjective.java
@@ -4,10 +4,10 @@ import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Requires the player to equip a specific item in a specific slot.
@@ -27,14 +27,14 @@ public class EquipItemObjective extends DefaultObjective {
     /**
      * Constructor for the EquipItemObjective.
      *
-     * @param instruction the instruction that created this objective
-     * @param item        the item that needs to be equipped
-     * @param slotType    the slot type where the item needs to be equipped
+     * @param service  the objective factory service
+     * @param item     the item that needs to be equipped
+     * @param slotType the slot type where the item needs to be equipped
      * @throws QuestException if there is an error in the instruction
      */
-    public EquipItemObjective(final Instruction instruction, final Argument<ItemWrapper> item,
+    public EquipItemObjective(final ObjectiveFactoryService service, final Argument<ItemWrapper> item,
                               final Argument<PlayerArmorChangeEvent.SlotType> slotType) throws QuestException {
-        super(instruction);
+        super(service);
         this.item = item;
         this.slotType = slotType;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjectiveFactory.java
@@ -24,7 +24,7 @@ public class EquipItemObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<PlayerArmorChangeEvent.SlotType> slotType = instruction.enumeration(PlayerArmorChangeEvent.SlotType.class).get();
         final Argument<ItemWrapper> item = instruction.item().get();
-        final EquipItemObjective objective = new EquipItemObjective(instruction, item, slotType);
+        final EquipItemObjective objective = new EquipItemObjective(service, item, slotType);
         service.request(PlayerArmorChangeEvent.class).onlineHandler(objective::onEquipmentChange)
                 .player(PlayerArmorChangeEvent::getPlayer).subscribe(false);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjective.java
@@ -6,9 +6,9 @@ import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.common.component.VariableReplacement;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.quest.action.IngameNotificationSender;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -37,13 +37,13 @@ public class ExperienceObjective extends DefaultObjective {
     /**
      * Constructor for the ExperienceObjective.
      *
-     * @param instruction the instruction that created this objective
+     * @param service     the objective factory service
      * @param amount      the experience level the player needs to get
      * @param levelSender the notification to send when the player gains experience
      * @throws QuestException if there is an error in the instruction
      */
-    public ExperienceObjective(final Instruction instruction, final Argument<Number> amount, final IngameNotificationSender levelSender) throws QuestException {
-        super(instruction);
+    public ExperienceObjective(final ObjectiveFactoryService service, final Argument<Number> amount, final IngameNotificationSender levelSender) throws QuestException {
+        super(service);
         this.amount = amount;
         this.levelSender = levelSender;
     }
@@ -57,9 +57,9 @@ public class ExperienceObjective extends DefaultObjective {
             if (checkConditions(onlineProfile)) {
                 completeObjective(onlineProfile);
             }
-        } else if (this.notify && notify) {
+        } else if (this.hasNotify(onlineProfile) && notify) {
             final int level = (int) (amount - newAmount);
-            if (level % notifyInterval == 0) {
+            if (level % getNotifyInterval(onlineProfile) == 0) {
                 levelSender.sendNotification(onlineProfile, new VariableReplacement("amount", Component.text(level)));
             }
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjectiveFactory.java
@@ -49,7 +49,7 @@ public class ExperienceObjectiveFactory implements ObjectiveFactory {
         final IngameNotificationSender levelSender = new IngameNotificationSender(log,
                 pluginMessage, instruction.getPackage(), instruction.getID().getFull(),
                 NotificationLevel.INFO, "level_to_gain");
-        final ExperienceObjective objective = new ExperienceObjective(instruction, amount, levelSender);
+        final ExperienceObjective objective = new ExperienceObjective(service, amount, levelSender);
         service.request(PlayerLevelChangeEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onLevelChangeEvent)
                 .player(PlayerLevelChangeEvent::getPlayer).subscribe(true);
         service.request(PlayerExpChangeEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onExpChangeEvent)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/fish/FishObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/fish/FishObjective.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.quest.objective.fish;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.player.PlayerFishEvent;
@@ -39,17 +39,17 @@ public class FishObjective extends CountingObjective {
     /**
      * Constructor for the FishObjective.
      *
-     * @param instruction        the instruction that created this objective
+     * @param service            the objective factory service
      * @param targetAmount       the target amount of fish to catch
      * @param item               the item to catch
      * @param hookTargetLocation the location where the fish should be caught
      * @param range              the range around the location where the item should be fished
      * @throws QuestException if there is an error in the instruction
      */
-    public FishObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public FishObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                          final Argument<ItemWrapper> item, @Nullable final Argument<Location> hookTargetLocation,
                          @Nullable final Argument<Number> range) throws QuestException {
-        super(instruction, targetAmount, "fish_to_catch");
+        super(service, targetAmount, "fish_to_catch");
         this.item = item;
         this.hookTargetLocation = hookTargetLocation;
         this.range = range;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/fish/FishObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/fish/FishObjectiveFactory.java
@@ -28,7 +28,7 @@ public class FishObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
         final Argument<Location> hookTargetLocation = instruction.location().get("hookLocation").orElse(null);
         final Argument<Number> range = instruction.number().get("range").orElse(null);
-        final FishObjective objective = new FishObjective(instruction, targetAmount, item, hookTargetLocation, range);
+        final FishObjective objective = new FishObjective(service, targetAmount, item, hookTargetLocation, range);
         service.request(PlayerFishEvent.class).priority(EventPriority.MONITOR).onlineHandler(objective::onFishCatch)
                 .player(PlayerFishEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractObjective.java
@@ -6,9 +6,9 @@ import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveDataFactory;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.ArmorStand;
@@ -90,7 +90,7 @@ public class EntityInteractObjective extends CountingObjective {
     /**
      * Creates a new instance of the EntityInteractObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of entities to interact with
      * @param loc          the location of the entities
      * @param range        the range of the entities
@@ -104,13 +104,13 @@ public class EntityInteractObjective extends CountingObjective {
      * @throws QuestException if there is an error in the instruction
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    public EntityInteractObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public EntityInteractObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                                    @Nullable final Argument<Location> loc,
                                    final Argument<Number> range, @Nullable final Argument<Component> customName,
                                    @Nullable final Argument<String> realName, @Nullable final EquipmentSlot slot,
                                    final Argument<EntityType> mobType, @Nullable final Argument<String> marked,
                                    final Argument<Interaction> interaction, final FlagArgument<Boolean> cancel) throws QuestException {
-        super(instruction, ENTITY_INTERACT_FACTORY, targetAmount, "mobs_to_click");
+        super(service, ENTITY_INTERACT_FACTORY, targetAmount, "mobs_to_click");
         this.loc = loc;
         this.range = range;
         this.customName = customName;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractObjectiveFactory.java
@@ -35,7 +35,7 @@ public class EntityInteractObjectiveFactory implements ObjectiveFactory {
     }
 
     @Override
-    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService eventService) throws QuestException {
+    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Interaction> interaction = instruction.enumeration(Interaction.class).get();
         final Argument<EntityType> mobType = instruction.enumeration(EntityType.class).get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
@@ -46,12 +46,12 @@ public class EntityInteractObjectiveFactory implements ObjectiveFactory {
         final Argument<Location> loc = instruction.location().get("loc").orElse(null);
         final Argument<Number> range = instruction.number().get("range", 1);
         final EquipmentSlot slot = getEquipmentSlot(instruction);
-        final EntityInteractObjective objective = new EntityInteractObjective(instruction, targetAmount, loc, range, customName, realName, slot, mobType, marked, interaction, cancel);
-        eventService.request(EntityDamageByEntityEvent.class).onlineHandler(objective::onDamage)
+        final EntityInteractObjective objective = new EntityInteractObjective(service, targetAmount, loc, range, customName, realName, slot, mobType, marked, interaction, cancel);
+        service.request(EntityDamageByEntityEvent.class).onlineHandler(objective::onDamage)
                 .entity(EntityDamageByEntityEvent::getDamager).subscribe(true);
-        eventService.request(PlayerInteractEntityEvent.class).onlineHandler(objective::onRightClick)
+        service.request(PlayerInteractEntityEvent.class).onlineHandler(objective::onRightClick)
                 .player(PlayerInteractEntityEvent::getPlayer).subscribe(true);
-        eventService.request(PlayerInteractAtEntityEvent.class).onlineHandler(objective::onArmorRightClick)
+        service.request(PlayerInteractAtEntityEvent.class).onlineHandler(objective::onArmorRightClick)
                 .player(PlayerInteractAtEntityEvent::getPlayer).subscribe(true);
         return objective;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/jump/JumpObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/jump/JumpObjective.java
@@ -4,8 +4,8 @@ import com.destroystokyo.paper.event.player.PlayerJumpEvent;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 /**
  * Requires the player to jump a certain number of times.
@@ -15,12 +15,12 @@ public class JumpObjective extends CountingObjective {
     /**
      * Constructor for the JumpObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of jumps
      * @throws QuestException if there is an error in the instruction
      */
-    public JumpObjective(final Instruction instruction, final Argument<Number> targetAmount) throws QuestException {
-        super(instruction, targetAmount, "times_to_jump");
+    public JumpObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount) throws QuestException {
+        super(service, targetAmount, "times_to_jump");
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/jump/JumpObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/jump/JumpObjectiveFactory.java
@@ -22,7 +22,7 @@ public class JumpObjectiveFactory implements ObjectiveFactory {
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final JumpObjective objective = new JumpObjective(instruction, targetAmount);
+        final JumpObjective objective = new JumpObjective(service, targetAmount);
         service.request(PlayerJumpEvent.class).onlineHandler(objective::onPlayerJump)
                 .player(PlayerJumpEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/KillPlayerObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/KillPlayerObjective.java
@@ -4,9 +4,9 @@ import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.condition.ConditionID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,15 +31,15 @@ public class KillPlayerObjective extends CountingObjective {
     /**
      * Constructor for the KillPlayerObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the amount of players to kill
      * @param name         the name of the player to kill, or null for any player
      * @param required     the conditions of the victim that must be met for the objective to count
      * @throws QuestException if there is an error in the instruction
      */
-    public KillPlayerObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public KillPlayerObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                                @Nullable final Argument<String> name, final Argument<List<ConditionID>> required) throws QuestException {
-        super(instruction, targetAmount, "players_to_kill");
+        super(service, targetAmount, "players_to_kill");
         this.name = name;
         this.required = required;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/KillPlayerObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/KillPlayerObjectiveFactory.java
@@ -29,7 +29,7 @@ public class KillPlayerObjectiveFactory implements ObjectiveFactory {
         final Argument<String> name = instruction.string().get("name").orElse(null);
         final Argument<List<ConditionID>> required = instruction.parse(ConditionID::new)
                 .list().get("required", Collections.emptyList());
-        final KillPlayerObjective objective = new KillPlayerObjective(instruction, targetAmount, name, required);
+        final KillPlayerObjective objective = new KillPlayerObjective(service, targetAmount, name, required);
         service.request(PlayerDeathEvent.class).onlineHandler(objective::onKill)
                 .player(event -> event.getEntity().getKiller()).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/MobKillObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/MobKillObjective.java
@@ -5,8 +5,8 @@ import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.MobKillNotifier.MobKilledEvent;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.persistence.PersistentDataType;
@@ -41,17 +41,17 @@ public class MobKillObjective extends CountingObjective {
     /**
      * Constructor for the MobKillObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the amount of mobs to kill
      * @param entities     the entity types that should be killed
      * @param name         the optional name of the mob
      * @param marked       the optional marker for the mobs to identify them
      * @throws QuestException if there is an error in the instruction
      */
-    public MobKillObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public MobKillObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                             final Argument<List<EntityType>> entities, @Nullable final Argument<String> name,
                             @Nullable final Argument<String> marked) throws QuestException {
-        super(instruction, targetAmount, "mobs_to_kill");
+        super(service, targetAmount, "mobs_to_kill");
         this.entities = entities;
         this.name = name;
         this.marked = marked;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/MobKillObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/kill/MobKillObjectiveFactory.java
@@ -28,7 +28,7 @@ public class MobKillObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
         final Argument<String> name = instruction.string().get("name").orElse(null);
         final Argument<String> marked = instruction.packageIdentifier().get("marked").orElse(null);
-        final MobKillObjective objective = new MobKillObjective(instruction, targetAmount, entities, name, marked);
+        final MobKillObjective objective = new MobKillObjective(service, targetAmount, entities, name, marked);
         service.request(MobKilledEvent.class).handler(objective::onMobKill)
                 .profile(MobKilledEvent::getProfile).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/AbstractLocationObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/AbstractLocationObjective.java
@@ -3,7 +3,6 @@ package org.betonquest.betonquest.quest.objective.location;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
@@ -53,13 +52,13 @@ public abstract class AbstractLocationObjective extends DefaultObjective {
      * The constructor takes an Instruction object as a parameter and throws an QuestException.
      * It initializes the entry and exit booleans and the playersInsideRegion map.
      *
-     * @param instruction the Instruction object to be used in the constructor
+     * @param service the ObjectiveFactoryService to be used in the constructor
      * @throws QuestException if there is an error while parsing the instruction
      */
-    public AbstractLocationObjective(final Instruction instruction) throws QuestException {
-        super(instruction);
-        entry = instruction.bool().getFlag("entry", true);
-        exit = instruction.bool().getFlag("exit", true);
+    public AbstractLocationObjective(final ObjectiveFactoryService service) throws QuestException {
+        super(service);
+        entry = service.getObjectiveID().getInstruction().bool().getFlag("entry", true);
+        exit = service.getObjectiveID().getInstruction().bool().getFlag("exit", true);
         playersInsideRegion = new HashMap<>();
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjective.java
@@ -2,9 +2,9 @@ package org.betonquest.betonquest.quest.objective.location;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 
 /**
@@ -30,13 +30,13 @@ public class LocationObjective extends AbstractLocationObjective {
     /**
      * The constructor takes an Instruction object as a parameter and throws a QuestException.
      *
-     * @param instruction the Instruction object to be used in the constructor
-     * @param loc         the target location
-     * @param range       the radius defining the area surrounding the target location
+     * @param service the ObjectiveFactoryService to be used
+     * @param loc     the target location
+     * @param range   the radius defining the area surrounding the target location
      * @throws QuestException if there is an error while parsing the instruction
      */
-    public LocationObjective(final Instruction instruction, final Argument<Location> loc, final Argument<Number> range) throws QuestException {
-        super(instruction);
+    public LocationObjective(final ObjectiveFactoryService service, final Argument<Location> loc, final Argument<Number> range) throws QuestException {
+        super(service);
         this.loc = loc;
         this.range = range;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjectiveFactory.java
@@ -23,7 +23,7 @@ public class LocationObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Location> loc = instruction.location().get();
         final Argument<Number> range = instruction.number().get();
-        final LocationObjective objective = new LocationObjective(instruction, loc, range);
+        final LocationObjective objective = new LocationObjective(service, loc, range);
         objective.registerLocationEvents(service);
         return objective;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjective.java
@@ -2,9 +2,9 @@ package org.betonquest.betonquest.quest.objective.login;
 
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 /**
@@ -15,11 +15,11 @@ public class LoginObjective extends DefaultObjective {
     /**
      * Constructor for the LoginObjective.
      *
-     * @param instruction the instruction that created this objective
+     * @param service the objective factory service
      * @throws QuestException if there is an error in the instruction
      */
-    public LoginObjective(final Instruction instruction) throws QuestException {
-        super(instruction);
+    public LoginObjective(final ObjectiveFactoryService service) throws QuestException {
+        super(service);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjectiveFactory.java
@@ -21,7 +21,7 @@ public class LoginObjectiveFactory implements ObjectiveFactory {
 
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
-        final LoginObjective objective = new LoginObjective(instruction);
+        final LoginObjective objective = new LoginObjective(service);
         service.request(PlayerJoinEvent.class).priority(EventPriority.HIGH).onlineHandler(objective::onJoin)
                 .player(PlayerJoinEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjective.java
@@ -2,9 +2,9 @@ package org.betonquest.betonquest.quest.objective.logout;
 
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 /**
@@ -15,11 +15,11 @@ public class LogoutObjective extends DefaultObjective {
     /**
      * Constructor for the LogoutObjective.
      *
-     * @param instruction the instruction that created this objective
+     * @param service the objective factory service
      * @throws QuestException if there is an error in the instruction
      */
-    public LogoutObjective(final Instruction instruction) throws QuestException {
-        super(instruction);
+    public LogoutObjective(final ObjectiveFactoryService service) throws QuestException {
+        super(service);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjectiveFactory.java
@@ -21,7 +21,7 @@ public class LogoutObjectiveFactory implements ObjectiveFactory {
 
     @Override
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
-        final LogoutObjective objective = new LogoutObjective(instruction);
+        final LogoutObjective objective = new LogoutObjective(service);
         service.request(PlayerQuitEvent.class).priority(EventPriority.LOWEST)
                 .onlineHandler(objective::onQuit).player(PlayerQuitEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjective.java
@@ -5,9 +5,9 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.npc.NpcInteractEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.npc.NpcID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.quest.objective.interact.Interaction;
 
 import static org.betonquest.betonquest.quest.objective.interact.Interaction.ANY;
@@ -35,15 +35,15 @@ public class NpcInteractObjective extends DefaultObjective {
     /**
      * Creates a new NPCInteractObjective from the given instruction.
      *
-     * @param instruction     the user-provided instruction
+     * @param service         the objective factory service
      * @param npcId           the ID of the NPC to interact with
      * @param cancel          whether to cancel the interaction with the NPC
      * @param interactionType the type of interaction with the NPC
      * @throws QuestException if the instruction is invalid
      */
-    public NpcInteractObjective(final Instruction instruction, final Argument<NpcID> npcId,
+    public NpcInteractObjective(final ObjectiveFactoryService service, final Argument<NpcID> npcId,
                                 final FlagArgument<Boolean> cancel, final Argument<Interaction> interactionType) throws QuestException {
-        super(instruction);
+        super(service);
         this.npcId = npcId;
         this.cancel = cancel;
         this.interactionType = interactionType;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjectiveFactory.java
@@ -30,7 +30,7 @@ public class NpcInteractObjectiveFactory implements ObjectiveFactory {
         final Argument<NpcID> npcId = instruction.parse(NpcID::new).get();
         final FlagArgument<Boolean> cancel = instruction.bool().getFlag("cancel", true);
         final Argument<Interaction> interactionType = instruction.enumeration(Interaction.class).get("interaction", RIGHT);
-        final NpcInteractObjective objective = new NpcInteractObjective(instruction, npcId, cancel, interactionType);
+        final NpcInteractObjective objective = new NpcInteractObjective(service, npcId, cancel, interactionType);
         service.request(NpcInteractEvent.class).priority(EventPriority.LOWEST).handler(objective::onNPCLeftClick)
                 .profile(NpcInteractEvent::getProfile).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjective.java
@@ -6,11 +6,11 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.QuestListException;
 import org.betonquest.betonquest.api.common.function.QuestBiPredicate;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.npc.Npc;
 import org.betonquest.betonquest.api.quest.npc.NpcID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
@@ -54,15 +54,15 @@ public class NpcRangeObjective extends DefaultObjective {
     /**
      * Creates a new NPCRangeObjective from the given instruction.
      *
-     * @param instruction the user-provided instruction
-     * @param npcIds      the list of Npc IDs to check
-     * @param radius      the radius around the Npc
-     * @param trigger     the trigger type for the objective
+     * @param service the objective factory service
+     * @param npcIds  the list of Npc IDs to check
+     * @param radius  the radius around the Npc
+     * @param trigger the trigger type for the objective
      * @throws QuestException if the instruction is invalid
      */
-    public NpcRangeObjective(final Instruction instruction, final Argument<List<NpcID>> npcIds, final Argument<Number> radius,
+    public NpcRangeObjective(final ObjectiveFactoryService service, final Argument<List<NpcID>> npcIds, final Argument<Number> radius,
                              final Argument<Trigger> trigger) throws QuestException {
-        super(instruction);
+        super(service);
         this.npcIds = npcIds;
         this.radius = radius;
         this.checkStuff = getStuff(trigger);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjectiveFactory.java
@@ -22,10 +22,10 @@ public class NpcRangeObjectiveFactory implements ObjectiveFactory {
     }
 
     @Override
-    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService eventService) throws QuestException {
+    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<List<NpcID>> npcIds = instruction.parse(NpcID::new).list().get();
         final Argument<Trigger> trigger = instruction.enumeration(Trigger.class).get();
         final Argument<Number> radius = instruction.number().get();
-        return new NpcRangeObjective(instruction, npcIds, radius, trigger);
+        return new NpcRangeObjective(service, npcIds, radius, trigger);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjective.java
@@ -6,10 +6,10 @@ import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.action.ActionID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Bukkit;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -43,15 +43,15 @@ public class PasswordObjective extends DefaultObjective {
     /**
      * Constructor for the PasswordObjective.
      *
-     * @param instruction    the instruction that created this objective
+     * @param service        the objective factory service
      * @param regex          the regex pattern to match the password
      * @param passwordPrefix the prefix to be shown to the player
      * @param failActions    the actions to be triggered on failure
      * @throws QuestException if there is an error in the instruction
      */
-    public PasswordObjective(final Instruction instruction, final FlagArgument<Pattern> regex,
+    public PasswordObjective(final ObjectiveFactoryService service, final FlagArgument<Pattern> regex,
                              @Nullable final String passwordPrefix, final Argument<List<ActionID>> failActions) throws QuestException {
-        super(instruction);
+        super(service);
         this.regex = regex;
         this.passwordPrefix = passwordPrefix;
         this.failActions = failActions;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjectiveFactory.java
@@ -38,7 +38,7 @@ public class PasswordObjectiveFactory implements ObjectiveFactory {
         final String resolvedPrefix = prefix == null ? null : prefix.getValue(null);
         final String passwordPrefix = resolvedPrefix == null || resolvedPrefix.isEmpty() ? resolvedPrefix : resolvedPrefix + ": ";
         final Argument<List<ActionID>> failEvents = instruction.parse(ActionID::new).list().get("fail", Collections.emptyList());
-        final PasswordObjective objective = new PasswordObjective(instruction, regex, passwordPrefix, failEvents);
+        final PasswordObjective objective = new PasswordObjective(service, regex, passwordPrefix, failEvents);
         service.request(AsyncPlayerChatEvent.class).priority(EventPriority.LOW).onlineHandler(objective::onChat)
                 .player(AsyncPlayerChatEvent::getPlayer).subscribe(true);
         service.request(PlayerCommandPreprocessEvent.class).priority(EventPriority.LOW).onlineHandler(objective::onCommand)

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/pickup/PickupObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/pickup/PickupObjective.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.quest.objective.pickup;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -24,14 +24,14 @@ public class PickupObjective extends CountingObjective {
     /**
      * Constructor for the PickupObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of items to be picked up
      * @param pickupItems  the items to be picked up
      * @throws QuestException if there is an error in the instruction
      */
-    public PickupObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public PickupObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                            final Argument<List<ItemWrapper>> pickupItems) throws QuestException {
-        super(instruction, targetAmount, "items_to_pickup");
+        super(service, targetAmount, "items_to_pickup");
         this.pickupItems = pickupItems;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/pickup/PickupObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/pickup/PickupObjectiveFactory.java
@@ -26,7 +26,7 @@ public class PickupObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<List<ItemWrapper>> pickupItems = instruction.item().list().get();
         final Argument<Number> targetAmount = instruction.number().get("amount", 1);
-        final PickupObjective objective = new PickupObjective(instruction, targetAmount, pickupItems);
+        final PickupObjective objective = new PickupObjective(service, targetAmount, pickupItems);
         service.request(EntityPickupItemEvent.class).onlineHandler(objective::onPickup)
                 .entity(EntityPickupItemEvent::getEntity).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjective.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.quest.objective.resourcepack;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 
 /**
@@ -21,12 +21,12 @@ public class ResourcepackObjective extends DefaultObjective {
     /**
      * Constructs a new ResourcepackObjective instance.
      *
-     * @param instruction  The instruction object.
-     * @param targetStatus The target status for the received resource pack.
+     * @param service      the objective factory service.
+     * @param targetStatus the target status for the received resource pack.
      * @throws QuestException if an error occurs while parsing the instruction.
      */
-    public ResourcepackObjective(final Instruction instruction, final Argument<PlayerResourcePackStatusEvent.Status> targetStatus) throws QuestException {
-        super(instruction);
+    public ResourcepackObjective(final ObjectiveFactoryService service, final Argument<PlayerResourcePackStatusEvent.Status> targetStatus) throws QuestException {
+        super(service);
         this.targetStatus = targetStatus;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjectiveFactory.java
@@ -23,7 +23,7 @@ public class ResourcepackObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<PlayerResourcePackStatusEvent.Status> targetStatus =
                 instruction.enumeration(PlayerResourcePackStatusEvent.Status.class).get();
-        final ResourcepackObjective objective = new ResourcepackObjective(instruction, targetStatus);
+        final ResourcepackObjective objective = new ResourcepackObjective(service, targetStatus);
         service.request(PlayerResourcePackStatusEvent.class).onlineHandler(objective::onResourcePackReceived)
                 .player(PlayerResourcePackStatusEvent::getPlayer).subscribe(false);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjective.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.quest.objective.ride;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.entity.EntityType;
 import org.spigotmc.event.entity.EntityMountEvent;
 
@@ -24,12 +24,12 @@ public class RideObjective extends DefaultObjective {
     /**
      * Constructor for the RideObjective.
      *
-     * @param instruction the instruction that created this objective
-     * @param vehicle     the type of vehicle that is required, or null if any vehicle is allowed
+     * @param service the objective factory service
+     * @param vehicle the type of vehicle that is required, or null if any vehicle is allowed
      * @throws QuestException if there is an error in the instruction
      */
-    public RideObjective(final Instruction instruction, final Argument<Optional<EntityType>> vehicle) throws QuestException {
-        super(instruction);
+    public RideObjective(final ObjectiveFactoryService service, final Argument<Optional<EntityType>> vehicle) throws QuestException {
+        super(service);
         this.vehicle = vehicle;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjectiveFactory.java
@@ -31,7 +31,7 @@ public class RideObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Optional<EntityType>> vehicle = instruction.enumeration(EntityType.class)
                 .prefilterOptional(ANY_PROPERTY, null).get();
-        final RideObjective objective = new RideObjective(instruction, vehicle);
+        final RideObjective objective = new RideObjective(service, vehicle);
         service.request(EntityMountEvent.class).onlineHandler(objective::onMount)
                 .entity(EntityMountEvent::getEntity).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/shear/ShearObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/shear/ShearObjective.java
@@ -3,8 +3,8 @@ package org.betonquest.betonquest.quest.objective.shear;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Sheep;
@@ -31,15 +31,15 @@ public class ShearObjective extends CountingObjective {
     /**
      * Constructor for the ShearObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of sheep to shear
      * @param name         the name of the sheep to shear
      * @param color        the color of the sheep to shear
      * @throws QuestException if there is an error in the instruction
      */
-    public ShearObjective(final Instruction instruction, final Argument<Number> targetAmount, @Nullable final Argument<String> name,
+    public ShearObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, @Nullable final Argument<String> name,
                           @Nullable final Argument<DyeColor> color) throws QuestException {
-        super(instruction, targetAmount, "sheep_to_shear");
+        super(service, targetAmount, "sheep_to_shear");
         this.name = name;
         this.color = color;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/shear/ShearObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/shear/ShearObjectiveFactory.java
@@ -25,7 +25,7 @@ public class ShearObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
         final Argument<String> name = instruction.string().get("name").orElse(null);
         final Argument<DyeColor> color = instruction.enumeration(DyeColor.class).get("color").orElse(null);
-        final ShearObjective objective = new ShearObjective(instruction, targetAmount, name, color);
+        final ShearObjective objective = new ShearObjective(service, targetAmount, name, color);
         service.request(PlayerShearEntityEvent.class).onlineHandler(objective::onShear)
                 .player(PlayerShearEntityEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/smelt/SmeltingObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/smelt/SmeltingObjective.java
@@ -3,9 +3,9 @@ package org.betonquest.betonquest.quest.objective.smelt;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.betonquest.betonquest.util.InventoryUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -26,14 +26,14 @@ public class SmeltingObjective extends CountingObjective {
     /**
      * Constructor for the SmeltingObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of items to be smelted
      * @param item         the item to be smelted
      * @throws QuestException if there is an error in the instruction
      */
-    public SmeltingObjective(final Instruction instruction, final Argument<Number> targetAmount, final Argument<ItemWrapper> item)
+    public SmeltingObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final Argument<ItemWrapper> item)
             throws QuestException {
-        super(instruction, targetAmount, "items_to_smelt");
+        super(service, targetAmount, "items_to_smelt");
         this.item = item;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/smelt/SmeltingObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/smelt/SmeltingObjectiveFactory.java
@@ -24,7 +24,7 @@ public class SmeltingObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<ItemWrapper> item = instruction.item().get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final SmeltingObjective objective = new SmeltingObjective(instruction, targetAmount, item);
+        final SmeltingObjective objective = new SmeltingObjective(service, targetAmount, item);
         service.request(InventoryClickEvent.class).onlineHandler(objective::onSmelting)
                 .entity(InventoryClickEvent::getWhoClicked).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjective.java
@@ -5,11 +5,11 @@ import com.google.common.collect.HashBiMap;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveData;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveDataFactory;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 
 import java.util.List;
 import java.util.Locale;
@@ -38,13 +38,13 @@ public class StageObjective extends DefaultObjective {
     /**
      * Creates a new stage objective.
      *
-     * @param instruction       the instruction
+     * @param service           the objective factory service
      * @param stageMap          the mapping of stages to indices
      * @param preventCompletion true if the increase of stages should not complete the objective
      * @throws QuestException if the instruction is invalid
      */
-    public StageObjective(final Instruction instruction, final StageMap stageMap, final FlagArgument<Boolean> preventCompletion) throws QuestException {
-        super(instruction, STAGE_FACTORY);
+    public StageObjective(final ObjectiveFactoryService service, final StageMap stageMap, final FlagArgument<Boolean> preventCompletion) throws QuestException {
+        super(service, STAGE_FACTORY);
         this.stageMap = stageMap;
         this.preventCompletion = preventCompletion;
     }
@@ -75,14 +75,14 @@ public class StageObjective extends DefaultObjective {
     public String getStage(final Profile profile) throws QuestException {
         final StageData stageData = (StageObjective.StageData) dataMap.get(profile);
         if (stageData == null) {
-            throw new QuestException("No data found for profile '" + profile + "' for objective '" + instruction.getID() + "'."
+            throw new QuestException("No data found for profile '" + profile + "' for objective '" + getObjectiveID() + "'."
                     + " Make sure the objective is started before setting the stage.");
         }
         final String stage = stageData.getStage();
         if (stageMap.isValidStage(stage)) {
             return stage;
         }
-        throw new QuestException(profile + " has invalid stage '" + stage + "' for objective '" + instruction.getID() + "'.");
+        throw new QuestException(profile + " has invalid stage '" + stage + "' for objective '" + getObjectiveID() + "'.");
     }
 
     /**
@@ -95,7 +95,7 @@ public class StageObjective extends DefaultObjective {
     public void setStage(final Profile profile, final String stage) throws QuestException {
         final StageData stageData = (StageObjective.StageData) dataMap.get(profile);
         if (stageData == null) {
-            throw new QuestException("No data found for profile '" + profile + "' for objective '" + instruction.getID() + "'."
+            throw new QuestException("No data found for profile '" + profile + "' for objective '" + getObjectiveID() + "'."
                     + " Make sure the objective is started before setting the stage.");
         }
         if (stageMap.isValidStage(stage)) {
@@ -104,7 +104,7 @@ public class StageObjective extends DefaultObjective {
             }
             return;
         }
-        throw new QuestException("Invalid stage '" + stage + "' for objective '" + instruction.getID() + "'.");
+        throw new QuestException("Invalid stage '" + stage + "' for objective '" + getObjectiveID() + "'.");
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjectiveFactory.java
@@ -22,10 +22,10 @@ public class StageObjectiveFactory implements ObjectiveFactory {
     }
 
     @Override
-    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService eventService) throws QuestException {
+    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final List<String> stages = instruction.string().list().get().getValue(null);
         final StageObjective.StageMap stageMap = new StageObjective.StageMap(stages, (ObjectiveID) instruction.getID());
         final FlagArgument<Boolean> preventCompletion = instruction.bool().getFlag("preventCompletion", true);
-        return new StageObjective(instruction, stageMap, preventCompletion);
+        return new StageObjective(service, stageMap, preventCompletion);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjective.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.quest.objective.step;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.BlockSelector;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.Action;
@@ -36,13 +36,13 @@ public class StepObjective extends DefaultObjective {
     /**
      * Constructor for the StepObjective.
      *
-     * @param instruction           the instruction that created this objective
+     * @param service               the objective factory service
      * @param loc                   the location of the pressure plate
      * @param pressurePlateSelector the selector for the pressure plate block
      * @throws QuestException if there is an error in the instruction
      */
-    public StepObjective(final Instruction instruction, final Argument<Location> loc, final BlockSelector pressurePlateSelector) throws QuestException {
-        super(instruction);
+    public StepObjective(final ObjectiveFactoryService service, final Argument<Location> loc, final BlockSelector pressurePlateSelector) throws QuestException {
+        super(service);
         this.loc = loc;
         this.pressurePlateSelector = pressurePlateSelector;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjectiveFactory.java
@@ -26,7 +26,7 @@ public class StepObjectiveFactory implements ObjectiveFactory {
     public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<Location> loc = instruction.location().get();
         final BlockSelector selector = new DefaultBlockSelector(".*_PRESSURE_PLATE");
-        final StepObjective objective = new StepObjective(instruction, loc, selector);
+        final StepObjective objective = new StepObjective(service, loc, selector);
         service.request(PlayerInteractEvent.class).onlineHandler(objective::onStep)
                 .player(PlayerInteractEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/tame/TameObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/tame/TameObjective.java
@@ -3,8 +3,8 @@ package org.betonquest.betonquest.quest.objective.tame;
 import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.EntityTameEvent;
 
@@ -21,14 +21,14 @@ public class TameObjective extends CountingObjective {
     /**
      * Constructor for the TameObjective.
      *
-     * @param instruction  the instruction that created this objective
+     * @param service      the objective factory service
      * @param targetAmount the target amount of entities to be tamed
      * @param type         the entity type to be tamed
      * @throws QuestException if there is an error in the instruction
      */
-    public TameObjective(final Instruction instruction, final Argument<Number> targetAmount,
+    public TameObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                          final Argument<EntityType> type) throws QuestException {
-        super(instruction, targetAmount, "animals_to_tame");
+        super(service, targetAmount, "animals_to_tame");
         this.type = type;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/tame/TameObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/tame/TameObjectiveFactory.java
@@ -24,15 +24,15 @@ public class TameObjectiveFactory implements ObjectiveFactory {
     }
 
     @Override
-    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService eventService) throws QuestException {
+    public DefaultObjective parseInstruction(final Instruction instruction, final ObjectiveFactoryService service) throws QuestException {
         final Argument<EntityType> type = instruction.enumeration(EntityType.class)
                 .validate(entityType -> entityType.getEntityClass() != null
                                 && Tameable.class.isAssignableFrom(entityType.getEntityClass()),
                         "Entity cannot be tamed: '%s'")
                 .get();
         final Argument<Number> targetAmount = instruction.number().atLeast(1).get();
-        final TameObjective objective = new TameObjective(instruction, targetAmount, type);
-        eventService.request(EntityTameEvent.class).onlineHandler(objective::onTaming)
+        final TameObjective objective = new TameObjective(service, targetAmount, type);
+        service.request(EntityTameEvent.class).onlineHandler(objective::onTaming)
                 .player(this::fromEvent).subscribe(true);
         return objective;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/timer/TimerObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/timer/TimerObjective.java
@@ -5,11 +5,11 @@ import org.betonquest.betonquest.api.CountingObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.PlayerObjectiveChangeEvent;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.QuestTypeApi;
 import org.betonquest.betonquest.api.quest.action.ActionID;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveState;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -49,7 +49,7 @@ public class TimerObjective extends CountingObjective implements Runnable {
     /**
      * Constructs a new TrackingObjective.
      *
-     * @param instruction  the instruction that created this objective.
+     * @param service      the objective factory service.
      * @param targetAmount the target amount for the objective.
      * @param questTypeApi the QuestTypeApi instance.
      * @param name         the name of the objective.
@@ -57,9 +57,9 @@ public class TimerObjective extends CountingObjective implements Runnable {
      * @param doneActions  actions to run before the objective is actually removed.
      * @throws QuestException if an error occurs while creating the objective.
      */
-    public TimerObjective(final Instruction instruction, final Argument<Number> targetAmount, final QuestTypeApi questTypeApi, final Argument<String> name,
+    public TimerObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final QuestTypeApi questTypeApi, final Argument<String> name,
                           final Argument<Number> interval, final Argument<List<ActionID>> doneActions) throws QuestException {
-        super(instruction, targetAmount, null);
+        super(service, targetAmount, null);
         this.questTypeApi = questTypeApi;
         this.name = name;
         this.doneActions = doneActions;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/timer/TimerObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/timer/TimerObjectiveFactory.java
@@ -38,7 +38,7 @@ public class TimerObjectiveFactory implements ObjectiveFactory {
         final Argument<String> name = instruction.string().get("name", "");
         final Argument<Number> interval = instruction.number().get("interval", 1);
         final Argument<List<ActionID>> doneEvents = instruction.parse(ActionID::new).list().get("done", Collections.emptyList());
-        final TimerObjective objective = new TimerObjective(instruction, targetAmount, questTypeApi, name, interval, doneEvents);
+        final TimerObjective objective = new TimerObjective(service, targetAmount, questTypeApi, name, interval, doneEvents);
         service.request(PlayerObjectiveChangeEvent.class).handler(objective::onPlayerObjectiveChange)
                 .profile(PlayerObjectiveChangeEvent::getProfile).subscribe(false);
         return objective;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/ChatVariableObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/ChatVariableObjective.java
@@ -4,8 +4,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.betonquest.betonquest.api.QuestException;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 import java.util.Locale;
@@ -25,11 +25,11 @@ public class ChatVariableObjective extends VariableObjective {
     /**
      * Creates a new VariableObjective instance which also captures chat input.
      *
-     * @param instruction the instruction that created this objective
+     * @param service the objective factory service
      * @throws QuestException if there is an error in the instruction
      */
-    public ChatVariableObjective(final Instruction instruction) throws QuestException {
-        super(instruction);
+    public ChatVariableObjective(final ObjectiveFactoryService service) throws QuestException {
+        super(service);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjective.java
@@ -2,11 +2,11 @@ package org.betonquest.betonquest.quest.objective.variable;
 
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
-import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveData;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveDataFactory;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveID;
+import org.betonquest.betonquest.api.quest.objective.event.ObjectiveFactoryService;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -33,11 +33,11 @@ public class VariableObjective extends DefaultObjective {
     /**
      * Creates a new VariableObjective instance.
      *
-     * @param instruction the instruction that created this objective
+     * @param service the objective factory service
      * @throws QuestException if there is an error in the instruction
      */
-    public VariableObjective(final Instruction instruction) throws QuestException {
-        super(instruction, VARIABLE_FACTORY);
+    public VariableObjective(final ObjectiveFactoryService service) throws QuestException {
+        super(service, VARIABLE_FACTORY);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjectiveFactory.java
@@ -23,9 +23,9 @@ public class VariableObjectiveFactory implements ObjectiveFactory {
         final boolean noChat = instruction.bool().getFlag("no-chat", true)
                 .getValue(null).orElse(false);
         if (noChat) {
-            return new VariableObjective(instruction);
+            return new VariableObjective(service);
         }
-        final ChatVariableObjective objective = new ChatVariableObjective(instruction);
+        final ChatVariableObjective objective = new ChatVariableObjective(service);
         service.request(AsyncPlayerChatEvent.class).onlineHandler(objective::onChat)
                 .player(AsyncPlayerChatEvent::getPlayer).subscribe(true);
         return objective;

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/bukkit/event/DefaultBukkitEventService.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/bukkit/event/DefaultBukkitEventService.java
@@ -85,4 +85,12 @@ public class DefaultBukkitEventService implements BukkitEventService {
         }
         require(event).ifPresent(group -> group.unsubscribe(priority, subscriber));
     }
+
+    @Override
+    public void unsubscribeAll() {
+        for (final EventListenerGroup<?> group : listeners.values()) {
+            group.disable();
+        }
+        listeners.clear();
+    }
 }


### PR DESCRIPTION
Introduce ObjectiveServiceData and ObjectiveServiceDataProvider

- Add Objective interface in preparation of replacing DefaultObjective
- Extract functionality from DefaultObjective and move it ObjectiveService and ObjectiveFactoryService
- Redirect calls to DefaultObjective via the service until all further extractions are done and Objective may replace DefaultObjective

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
