### PR TITLE
No longer ignore canceled events in menu conv io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `hologram` `top:` line to customizable format
 - Variables to Placeholders. This change won't harm any user scripts, it's only a conceptual change
 - Events to Actions.
+- `menu` conv io no longer ignores canceled events to process as input
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/code/core/src/main/java/org/betonquest/betonquest/conversation/menu/MenuConvIO.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/conversation/menu/MenuConvIO.java
@@ -220,7 +220,7 @@ public class MenuConvIO extends ChatConvIO {
      * @param event the event
      */
     @SuppressWarnings("PMD.CollapsibleIfStatements")
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void playerInteractEvent(final PlayerInteractEvent event) {
         if (state.isInactive() || !event.getPlayer().equals(onlineProfile.getPlayer())) {
             return;
@@ -250,7 +250,7 @@ public class MenuConvIO extends ChatConvIO {
      *
      * @param event the event
      */
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void playerInteractEntityEvent(final PlayerInteractEntityEvent event) {
         if (state.isInactive() || !event.getPlayer().equals(onlineProfile.getPlayer())) {
             return;
@@ -277,7 +277,7 @@ public class MenuConvIO extends ChatConvIO {
      *
      * @param event the event
      */
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void entityDamageByEntityEvent(final EntityDamageByEntityEvent event) {
         if (state.isInactive() || !event.getDamager().equals(onlineProfile.getPlayer())) {
             return;
@@ -329,7 +329,7 @@ public class MenuConvIO extends ChatConvIO {
      *
      * @param event the event
      */
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void playerItemHeldEvent(final PlayerItemHeldEvent event) {
         if (state.isInactive() || !event.getPlayer().equals(onlineProfile.getPlayer())) {
             return;


### PR DESCRIPTION
<!-- Please describe your changes here. -->
to allow progress in conversation again even when for example the conversation listener already canceled the event.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
