### PR TITLE
Move functions from DefaultObjective to QuestTypeApi and ObjectiveProcessor

### DIFF
--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/JoinJobObjective.java
@@ -45,11 +45,6 @@ public class JoinJobObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LeaveJobObjective.java
@@ -45,11 +45,6 @@ public class LeaveJobObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/LevelUpObjective.java
@@ -45,11 +45,6 @@ public class LevelUpObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/PaymentObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/jobsreborn/objective/PaymentObjective.java
@@ -41,10 +41,12 @@ public class PaymentObjective extends DefaultObjective {
      * @param paymentSender the {@link IngameNotificationSender} to send notifications
      * @throws QuestException if the instruction is invalid
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public PaymentObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount, final IngameNotificationSender paymentSender) throws QuestException {
         super(service);
         this.targetAmount = targetAmount;
         this.paymentSender = paymentSender;
+        getService().setDefaultData(this::getDefaultDataInstruction);
     }
 
     /**
@@ -73,8 +75,7 @@ public class PaymentObjective extends DefaultObjective {
         }
     }
 
-    @Override
-    public String getDefaultDataInstruction(final Profile profile) throws QuestException {
+    private String getDefaultDataInstruction(final Profile profile) throws QuestException {
         return String.valueOf(targetAmount.getValue(profile).doubleValue());
     }
 

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreChangeClassObjective.java
@@ -51,11 +51,6 @@ public class MMOCoreChangeClassObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmocore/objective/MMOCoreProfessionObjective.java
@@ -63,11 +63,6 @@ public class MMOCoreProfessionObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsApplyGemObjective.java
@@ -66,11 +66,6 @@ public class MMOItemsApplyGemObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/objective/MMOItemsUpgradeObjective.java
@@ -55,11 +55,6 @@ public class MMOItemsUpgradeObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibSkillObjective.java
@@ -61,11 +61,6 @@ public class MythicLibSkillObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsExitObjective.java
@@ -46,11 +46,6 @@ public class TrainCartsExitObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/traincarts/objectives/TrainCartsLocationObjective.java
@@ -39,11 +39,6 @@ public class TrainCartsLocationObjective extends AbstractLocationObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/RegionObjective.java
@@ -36,11 +36,6 @@ public class RegionObjective extends AbstractLocationObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/CountingObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/CountingObjective.java
@@ -25,15 +25,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class CountingObjective extends DefaultObjective {
 
     /**
+     * The number of units required for completion.
+     */
+    protected final Argument<Number> targetAmount;
+
+    /**
      * The message used for notifying the player.
      */
     @Nullable
     private final IngameNotificationSender countSender;
-
-    /**
-     * The number of units required for completion.
-     */
-    private final Argument<Number> targetAmount;
 
     /**
      * Create a counting objective.
@@ -43,6 +43,7 @@ public abstract class CountingObjective extends DefaultObjective {
      * @param notifyMessageName the message name used for notifying by default
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public CountingObjective(final ObjectiveFactoryService service, final Argument<Number> targetAmount,
                              @Nullable final String notifyMessageName) throws QuestException {
         super(service);
@@ -52,10 +53,10 @@ public abstract class CountingObjective extends DefaultObjective {
         countSender = notifyMessageName == null ? null : new IngameNotificationSender(loggerFactory.create(CountingObjective.class),
                 instance.getPluginMessage(), service.getObjectiveID().getPackage(), service.getObjectiveID().getFull(),
                 NotificationLevel.INFO, notifyMessageName);
+        getService().setDefaultData(this::getDefaultDataInstruction);
     }
 
-    @Override
-    public String getDefaultDataInstruction(final Profile profile) throws QuestException {
+    private String getDefaultDataInstruction(final Profile profile) throws QuestException {
         return String.valueOf(targetAmount.getValue(profile).intValue());
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/api/DefaultObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/DefaultObjective.java
@@ -64,16 +64,6 @@ public abstract class DefaultObjective implements Objective {
     }
 
     /**
-     * This method should return the default data instruction for the objective,
-     * ready to be parsed by the ObjectiveData class.
-     *
-     * @param profile the {@link Profile} to parse the instruction for
-     * @return the default data instruction string
-     * @throws QuestException when values could not be resolved for the profile
-     */
-    public abstract String getDefaultDataInstruction(Profile profile) throws QuestException;
-
-    /**
      * This method fires actions for the objective and removes it from the profile's
      * list of active objectives. Use it when you detect that the objective has
      * been completed. It deletes the objective using delete() method.
@@ -89,7 +79,7 @@ public abstract class DefaultObjective implements Objective {
         try {
             if (getService().getServiceDataProvider().isPersistent(profile)) {
                 try {
-                    final String defaultDataInstruction = getDefaultDataInstruction(profile);
+                    final String defaultDataInstruction = getService().getDefaultData(profile);
                     playerData.addRawObjective(objectiveID, defaultDataInstruction);
                     playerData.addObjToDB(objectiveID, defaultDataInstruction);
                     createObjectiveForPlayer(profile, defaultDataInstruction);
@@ -111,23 +101,6 @@ public abstract class DefaultObjective implements Objective {
         }
         getLogger().debug(questPackage,
                 "Firing actions in objective '" + objectiveID + "' for " + profile + " finished");
-    }
-
-    /**
-     * Adds this new objective to the profile. Also updates the database with the
-     * objective.
-     *
-     * @param profile the {@link Profile} for which the objective is to be added
-     */
-    public final void newPlayer(final Profile profile) {
-        try {
-            final String defaultInstruction = getDefaultDataInstruction(profile);
-            createObjectiveForPlayer(profile, defaultInstruction);
-            BetonQuest.getInstance().getPlayerDataStorage().get(profile).addObjToDB(getObjectiveID(), defaultInstruction);
-        } catch (final QuestException e) {
-            getLogger().warn(getPackage(), "Could not create new Objective for '" + getObjectiveID()
-                    + "' for '" + profile + "' objective: The Objective Instruction could not be resolved: " + e.getMessage(), e);
-        }
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultObjectiveFactoryService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/DefaultObjectiveFactoryService.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.api.quest.objective.event;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.bukkit.event.QuestDataUpdateEvent;
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.identifier.DefaultIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.instruction.FlagArgument;
@@ -74,6 +75,11 @@ public class DefaultObjectiveFactoryService implements ObjectiveFactoryService {
     private final ProfileProvider profileProvider;
 
     /**
+     * The default data supplier.
+     */
+    private QuestFunction<Profile, String> defaultDataSupplier;
+
+    /**
      * The objective related to this service.
      */
     private ObjectiveID objectiveID;
@@ -101,6 +107,7 @@ public class DefaultObjectiveFactoryService implements ObjectiveFactoryService {
         this.questExceptionHandler = new QuestExceptionHandler(objectiveID.getPackage(), this.logger, objectiveID.getFull());
         this.objectiveServiceData = parseObjectiveData(objectiveID.getInstruction());
         this.objectiveData = new ProfileKeyMap<>(profileProvider);
+        this.defaultDataSupplier = profile -> "";
     }
 
     private static ObjectiveServiceData parseObjectiveData(final Instruction instruction) throws QuestException {
@@ -148,6 +155,16 @@ public class DefaultObjectiveFactoryService implements ObjectiveFactoryService {
         if (profile.getOnlineProfile().isPresent()) {
             plugin.getPlayerDataStorage().get(profile).getJournal().update();
         }
+    }
+
+    @Override
+    public String getDefaultData(final Profile profile) throws QuestException {
+        return defaultDataSupplier.apply(profile);
+    }
+
+    @Override
+    public void setDefaultData(final QuestFunction<Profile, String> supplier) {
+        this.defaultDataSupplier = supplier;
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveFactoryService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/event/ObjectiveFactoryService.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.api.quest.objective.event;
 
 import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.common.function.QuestFunction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.profile.ProfileProvider;
@@ -71,6 +72,26 @@ public interface ObjectiveFactoryService {
      */
     @Deprecated
     void updateData(Profile profile);
+
+    /**
+     * Get the default objective data.
+     *
+     * @param profile the profile to get the data for
+     * @return the supplier
+     * @throws QuestException when argument resolving fails
+     * @deprecated do not use this method. it's scheduled for removal and only exists for compatibility.
+     */
+    @Deprecated
+    String getDefaultData(Profile profile) throws QuestException;
+
+    /**
+     * Set the default objective data supplier.
+     *
+     * @param supplier the supplier to use
+     * @deprecated do not use this method. it's scheduled for removal and only exists for compatibility.
+     */
+    @Deprecated
+    void setDefaultData(QuestFunction<Profile, String> supplier);
 
     /**
      * Do not use this method directly. It is used for internal logic.

--- a/code/core/src/main/java/org/betonquest/betonquest/database/PlayerData.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/PlayerData.java
@@ -380,7 +380,7 @@ public class PlayerData implements TagData, PointData {
         }
         final String data;
         try {
-            data = obj.getDefaultDataInstruction(profile);
+            data = obj.getService().getDefaultData(profile);
         } catch (final QuestException e) {
             log.warn(objectiveID.getPackage(), "Cannot add objective to player data: Could Not get resolved instruction: "
                     + e.getMessage(), e);

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/betonquest/MenuObjective.java
@@ -73,11 +73,6 @@ public class MenuObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         if (MENU_PROPERTY.equalsIgnoreCase(name)) {
             final Menu menuData;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/action/ActionObjective.java
@@ -139,11 +139,6 @@ public class ActionObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
         if (PROPERTY_LOCATION.equalsIgnoreCase(name)) {
             if (loc == null) {

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/arrow/ArrowShootObjective.java
@@ -71,11 +71,6 @@ public class ArrowShootObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -154,11 +154,6 @@ public class ChestPutObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/command/CommandObjective.java
@@ -86,11 +86,6 @@ public class CommandObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
@@ -59,6 +59,7 @@ public class PointObjective extends DefaultObjective {
      * @param operation         the operation to use for comparing
      * @throws QuestException if the syntax is wrong or any error happens while parsing
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public PointObjective(final ObjectiveFactoryService service, final PlayerDataStorage playerDataStorage, final Argument<String> category,
                           final Argument<Number> targetAmount, final Argument<CountingMode> mode, final Argument<Operation> operation)
             throws QuestException {
@@ -68,10 +69,10 @@ public class PointObjective extends DefaultObjective {
         this.targetAmount = targetAmount;
         this.mode = mode;
         this.operation = operation;
+        getService().setDefaultData(this::getDefaultDataInstruction);
     }
 
-    @Override
-    public String getDefaultDataInstruction(final Profile profile) throws QuestException {
+    private String getDefaultDataInstruction(final Profile profile) throws QuestException {
         final long targetValue = this.targetAmount.getValue(profile).intValue();
         final CountingMode value = mode.getValue(profile);
         if (value == CountingMode.TOTAL) {

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
@@ -40,11 +40,6 @@ public class TagObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
         return tag.getValue(profile);
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/delay/DelayObjective.java
@@ -51,6 +51,7 @@ public class DelayObjective extends DefaultObjective {
      * @param delay    the delay time in seconds, minutes, or ticks
      * @throws QuestException if there is an error in the instruction
      */
+    @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public DelayObjective(final ObjectiveFactoryService service, final Argument<Number> interval,
                           final Argument<Number> delay) throws QuestException {
         super(service);
@@ -80,6 +81,7 @@ public class DelayObjective extends DefaultObjective {
                 }
             }
         }.runTaskTimer(BetonQuest.getInstance(), 0, interval.getValue(null).longValue());
+        getService().setDefaultData(this::getDefaultDataInstruction);
     }
 
     private double timeToMilliSeconds(final Profile profile, final double time) throws QuestException {
@@ -102,8 +104,7 @@ public class DelayObjective extends DefaultObjective {
         super.close();
     }
 
-    @Override
-    public String getDefaultDataInstruction(final Profile profile) throws QuestException {
+    private String getDefaultDataInstruction(final Profile profile) throws QuestException {
         final double millis = timeToMilliSeconds(profile, delay.getValue(profile).doubleValue());
         return Double.toString(System.currentTimeMillis() + millis);
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/die/DieObjective.java
@@ -121,11 +121,6 @@ public class DieObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/equip/EquipItemObjective.java
@@ -54,11 +54,6 @@ public class EquipItemObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/experience/ExperienceObjective.java
@@ -81,11 +81,6 @@ public class ExperienceObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
         return switch (name.toLowerCase(Locale.ROOT)) {
             case "amount" -> profile.getOnlineProfile()

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/location/LocationObjective.java
@@ -52,11 +52,6 @@ public class LocationObjective extends AbstractLocationObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
         if (LOCATION_PROPERTY.equalsIgnoreCase(name)) {
             final Location location = loc.getValue(profile);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/login/LoginObjective.java
@@ -33,11 +33,6 @@ public class LoginObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/logout/LogoutObjective.java
@@ -33,11 +33,6 @@ public class LogoutObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcInteractObjective.java
@@ -70,11 +70,6 @@ public class NpcInteractObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/npc/NpcRangeObjective.java
@@ -168,11 +168,6 @@ public class NpcRangeObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/password/PasswordObjective.java
@@ -110,11 +110,6 @@ public class PasswordObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/resourcepack/ResourcepackObjective.java
@@ -58,11 +58,6 @@ public class ResourcepackObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/ride/RideObjective.java
@@ -49,11 +49,6 @@ public class RideObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjective.java
@@ -44,11 +44,6 @@ public class StageObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) throws QuestException {
-        return stageMap.getStage(0);
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         return getExceptionHandler().handle(() -> switch (name.toLowerCase(Locale.ROOT)) {
             case "index" -> String.valueOf(stageMap.getIndex(getStage(profile)));

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/stage/StageObjectiveFactory.java
@@ -26,6 +26,7 @@ public class StageObjectiveFactory implements ObjectiveFactory {
         final List<String> stages = instruction.string().list().get().getValue(null);
         final StageObjective.StageMap stageMap = new StageObjective.StageMap(stages, (ObjectiveID) instruction.getID());
         final FlagArgument<Boolean> preventCompletion = instruction.bool().getFlag("preventCompletion", true);
+        service.setDefaultData(profile -> stageMap.getStage(0));
         return new StageObjective(service, stageMap, preventCompletion);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/step/StepObjective.java
@@ -77,11 +77,6 @@ public class StepObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
         if (LOCATION_KEY.equalsIgnoreCase(name)) {
             final Block block = loc.getValue(profile).getBlock();

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/variable/VariableObjective.java
@@ -52,11 +52,6 @@ public class VariableObjective extends DefaultObjective {
     }
 
     @Override
-    public String getDefaultDataInstruction(final Profile profile) {
-        return "";
-    }
-
-    @Override
     public String getProperty(final String name, final Profile profile) {
         final String value = getVariableData(profile).get(name);
         return value == null ? "" : value;


### PR DESCRIPTION
Move functions from DefaultObjective to QuestTypeApi and ObjectiveProcessor
- move default instruction data to service and keep it deprecated

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
