### PR TITLE
Fix issue with properties when using uppercase letters

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultObjectiveProperties.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultObjectiveProperties.java
@@ -44,7 +44,7 @@ public class DefaultObjectiveProperties implements ObjectiveProperties {
 
     @Override
     public String getProperty(final String name, final Profile profile) throws QuestException {
-        final QuestFunction<Profile, String> retriever = properties.get(name);
+        final QuestFunction<Profile, String> retriever = properties.get(name.toLowerCase(Locale.ROOT));
         if (retriever != null) {
             return retriever.apply(profile);
         }


### PR DESCRIPTION
Fixes an issue mentioned on discord.

```
%objective.<name>.amount% works perfectly
but %objective.<name>.absoluteAmount% doesn't return anything
```

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
