### PR TITLE
End interceptor even when player is not online

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/conversation/Conversation.java
@@ -324,8 +324,8 @@ public class Conversation {
             new BukkitRunnable() {
                 @Override
                 public void run() {
+                    interceptor.end();
                     if (onlineProfile.getOnlineProfile().isPresent()) {
-                        interceptor.end();
                         endSender.sendNotification(onlineProfile, new VariableReplacement("npc", data.getPublicData().getQuester(log, onlineProfile)));
                     }
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Fix issue that player's can't get messages at all when an interceptor is used.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
