### PR TITLE
Fix bug where profile extraction was attempted with null values

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultEventServiceSubscriptionBuilder.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultEventServiceSubscriptionBuilder.java
@@ -147,7 +147,7 @@ public class DefaultEventServiceSubscriptionBuilder<T extends Event> implements 
         if (this.profileExtractor != null) {
             throw new IllegalStateException("Cannot set more than one extractor!");
         }
-        this.profileExtractor = (provider, event) -> Optional.ofNullable(provider.getProfile(extractor.apply(event)));
+        this.profileExtractor = (provider, event) -> Optional.ofNullable(extractor.apply(event)).map(provider::getProfile);
         return this;
     }
 
@@ -156,7 +156,7 @@ public class DefaultEventServiceSubscriptionBuilder<T extends Event> implements 
         if (this.profileExtractor != null) {
             throw new IllegalStateException("Cannot set more than one extractor!");
         }
-        this.profileExtractor = (provider, event) -> Optional.ofNullable(provider.getProfile(extractor.apply(event)));
+        this.profileExtractor = (provider, event) -> Optional.ofNullable(extractor.apply(event)).map(provider::getProfile);
         return this;
     }
 
@@ -165,7 +165,7 @@ public class DefaultEventServiceSubscriptionBuilder<T extends Event> implements 
         if (this.profileExtractor != null) {
             throw new IllegalStateException("Cannot set more than one extractor!");
         }
-        this.profileExtractor = (provider, event) -> Optional.ofNullable(provider.getProfile(extractor.apply(event)));
+        this.profileExtractor = (provider, event) -> Optional.ofNullable(extractor.apply(event)).map(provider::getProfile);
         return this;
     }
 
@@ -174,9 +174,8 @@ public class DefaultEventServiceSubscriptionBuilder<T extends Event> implements 
         if (this.profileExtractor != null) {
             throw new IllegalStateException("Cannot set more than one extractor!");
         }
-        this.profileExtractor = (provider, event) ->
-                extractor.apply(event) instanceof final Player player
-                        ? Optional.ofNullable(provider.getProfile(player)) : Optional.empty();
+        this.profileExtractor = (provider, event) -> Optional.ofNullable(extractor.apply(event))
+                .map(entity -> entity instanceof final Player player ? provider.getProfile(player) : null);
         return this;
     }
 


### PR DESCRIPTION
Fix bug where profile extraction was attempted with null values.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
