### PR TITLE
[Api-dev#6] Add DefaultQualifier to api module

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/package-info.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/package-info.java
@@ -2,4 +2,12 @@
  * The root package of the API containing classes that are used across the API
  * and are not easy to associate with a single subpackage.
  */
+@DefaultQualifier(value = NotNull.class, locations = {FIELD, PARAMETER, RETURN})
 package org.betonquest.betonquest.api;
+
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jetbrains.annotations.NotNull;
+
+import static org.checkerframework.framework.qual.TypeUseLocation.FIELD;
+import static org.checkerframework.framework.qual.TypeUseLocation.PARAMETER;
+import static org.checkerframework.framework.qual.TypeUseLocation.RETURN;


### PR DESCRIPTION
Add the default modifier used in the entire project but was missing in the api module somehow.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
