### PR TITLE
Use instructionApi instead of creating an own section instruction

### DIFF
--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibIntegrator.java
@@ -3,7 +3,6 @@ package org.betonquest.betonquest.compatibility.effectlib;
 import de.slikey.effectlib.EffectManager;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.BetonQuestApi;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.compatibility.Integrator;
 import org.betonquest.betonquest.compatibility.effectlib.action.ParticleActionFactory;
@@ -37,14 +36,13 @@ public class EffectLibIntegrator implements Integrator {
     @Override
     public void hook(final BetonQuestApi api) {
         manager = new EffectManager(plugin);
-        final ArgumentParsers parsers = plugin.getArgumentParsers();
         final BetonQuestLoggerFactory loggerFactory = api.getLoggerFactory();
         final ParticleIdentifierFactory factory = new ParticleIdentifierFactory(api.getQuestPackageManager());
         api.getQuestRegistries().identifier().register(ParticleIdentifier.class, factory);
         api.getQuestRegistries().action().register("particle", new ParticleActionFactory(loggerFactory, manager));
         plugin.addProcessor(new EffectLibParticleManager(loggerFactory.create(EffectLibParticleManager.class), loggerFactory,
-                api.getQuestPackageManager(), api.getQuestTypeApi(), api.getFeatureApi(), api.getProfileProvider(),
-                api.getQuestTypeApi().placeholders(), factory, manager, plugin, parsers));
+                api.getQuestTypeApi(), api.getFeatureApi(), api.getProfileProvider(),
+                api.getInstructionApi(), factory, manager, plugin));
     }
 
     @Override

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibParticleManager.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/effectlib/EffectLibParticleManager.java
@@ -2,18 +2,16 @@ package org.betonquest.betonquest.compatibility.effectlib;
 
 import de.slikey.effectlib.EffectManager;
 import org.betonquest.betonquest.api.QuestException;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.feature.FeatureApi;
 import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.NpcIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.profile.ProfileProvider;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.quest.QuestTypeApi;
 import org.betonquest.betonquest.compatibility.effectlib.identifier.ParticleIdentifier;
 import org.betonquest.betonquest.kernel.processor.SectionProcessor;
@@ -64,23 +62,20 @@ public class EffectLibParticleManager extends SectionProcessor<ParticleIdentifie
      *
      * @param log               the custom logger for this class
      * @param loggerFactory     the logger factory to create new custom loggers
-     * @param packManager       the quest package manager to get quest packages from
      * @param questTypeApi      the Quest Type API
      * @param featureApi        the Feature API
      * @param profileProvider   the profile provider instance
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param identifierFactory the identifier factory
      * @param manager           the effect manager starting and controlling particles
      * @param plugin            the plugin to start new tasks with
-     * @param parsers           the argument parsers to use
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     public EffectLibParticleManager(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
-                                    final QuestPackageManager packManager, final QuestTypeApi questTypeApi, final FeatureApi featureApi,
-                                    final ProfileProvider profileProvider, final Placeholders placeholders,
+                                    final QuestTypeApi questTypeApi, final FeatureApi featureApi,
+                                    final ProfileProvider profileProvider, final InstructionApi instructionApi,
                                     final IdentifierFactory<ParticleIdentifier> identifierFactory,
-                                    final EffectManager manager, final Plugin plugin, final ArgumentParsers parsers) {
-        super(loggerFactory, log, placeholders, packManager, parsers, identifierFactory, "Effect", "effectlib");
+                                    final EffectManager manager, final Plugin plugin) {
+        super(log, instructionApi, identifierFactory, "Effect", "effectlib");
         this.loggerFactory = loggerFactory;
         this.questTypeApi = questTypeApi;
         this.featureApi = featureApi;

--- a/code/core/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -443,7 +443,7 @@ public class BetonQuest extends JavaPlugin implements BetonQuestApi, LanguagePro
         new BStatsMetrics(this, new Metrics(this, BSTATS_METRICS_ID), questRegistry.metricsSupplier(), compatibility, getInstructionApi());
 
         try {
-            rpgMenu = new RPGMenu(loggerFactory.create(RPGMenu.class), loggerFactory, questManager, config,
+            rpgMenu = new RPGMenu(loggerFactory.create(RPGMenu.class), loggerFactory, getInstructionApi(), config,
                     pluginMessage, textCreator, coreQuestRegistry, profileProvider, getArgumentParsers());
         } catch (final QuestException e) {
             throw new IllegalStateException("Could not load the RPGMenu!", e);

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/npc/NpcHider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/npc/NpcHider.java
@@ -20,7 +20,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -104,19 +103,22 @@ public class NpcHider {
         this.npcs = new HashMap<>();
     }
 
-    private void loadFromConfig(final Collection<QuestPackage> packages) {
-        for (final QuestPackage pack : packages) {
-            final ConfigurationSection section = pack.getConfig().getConfigurationSection("hide_npcs");
-            if (section == null) {
-                continue;
-            }
-            for (final String idString : section.getKeys(false)) {
-                try {
-                    final SectionInstruction sectionInstruction = instructionApi.createSectionInstruction(pack, section);
-                    loadKey(sectionInstruction, idString);
-                } catch (final QuestException e) {
-                    log.warn("Could not load hide_npcs '" + idString + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
-                }
+    /**
+     * Load all npc hidings from the QuestPackage.
+     *
+     * @param pack to load from
+     */
+    public void load(final QuestPackage pack) {
+        final ConfigurationSection section = pack.getConfig().getConfigurationSection("hide_npcs");
+        if (section == null) {
+            return;
+        }
+        for (final String idString : section.getKeys(false)) {
+            try {
+                final SectionInstruction sectionInstruction = instructionApi.createSectionInstruction(pack, section);
+                loadKey(sectionInstruction, idString);
+            } catch (final QuestException e) {
+                log.warn("Could not load hide_npcs '" + idString + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
             }
         }
     }
@@ -135,17 +137,16 @@ public class NpcHider {
 
     /**
      * Reloads the Npc Hider, restarting runnable etc.
+     * Individual packs need to be loaded with the {@link #load(QuestPackage)}
      *
-     * @param packages       the quest packages to load
      * @param updateInterval the interval in ticks to check refresh hiding
      * @param plugin         the plugin instance to schedule update
      */
-    public void reload(final Collection<QuestPackage> packages, final int updateInterval, final Plugin plugin) {
+    public void reload(final int updateInterval, final Plugin plugin) {
         if (task != null) {
             task.cancel();
         }
         npcs.clear();
-        loadFromConfig(packages);
         task = new BukkitRunnable() {
             @Override
             public void run() {

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramLoop.java
@@ -8,6 +8,7 @@ import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentParser;
 import org.betonquest.betonquest.api.instruction.argument.parser.PackageIdentifierParser;
@@ -62,6 +63,16 @@ public abstract class HologramLoop extends SectionProcessor<HologramIdentifier, 
     protected final HologramProvider hologramProvider;
 
     /**
+     * The {@link Placeholders} to create and resolve placeholders.
+     */
+    protected final Placeholders placeholders;
+
+    /**
+     * The quest package manager to get quest packages from.
+     */
+    protected final QuestPackageManager packManager;
+
+    /**
      * The {@link BetonQuestLoggerFactory} to use for creating {@link BetonQuestLogger} instances.
      */
     private final BetonQuestLoggerFactory loggerFactory;
@@ -86,6 +97,7 @@ public abstract class HologramLoop extends SectionProcessor<HologramIdentifier, 
      *
      * @param loggerFactory     logger factory to use
      * @param log               the logger that will be used for logging
+     * @param instructionApi    the instruction api to use
      * @param packManager       the quest package manager to get quest packages from
      * @param placeholders      the {@link Placeholders} to create and resolve placeholders
      * @param hologramProvider  the hologram provider to create new holograms
@@ -97,12 +109,14 @@ public abstract class HologramLoop extends SectionProcessor<HologramIdentifier, 
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public HologramLoop(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log,
-                        final Placeholders placeholders, final QuestPackageManager packManager,
+                        final Placeholders placeholders, final InstructionApi instructionApi, final QuestPackageManager packManager,
                         final HologramProvider hologramProvider, final String readable, final String internal,
                         final TextParser textParser, final ArgumentParsers parsers, final IdentifierFactory<HologramIdentifier> identifierFactory) {
-        super(loggerFactory, log, placeholders, packManager, parsers, identifierFactory, readable, internal);
+        super(log, instructionApi, identifierFactory, readable, internal);
         this.loggerFactory = loggerFactory;
         this.hologramProvider = hologramProvider;
+        this.placeholders = placeholders;
+        this.packManager = packManager;
         this.textParser = textParser;
         this.itemParser = parsers.item();
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
@@ -103,10 +103,10 @@ public class HologramProvider implements Integrator {
         api.getQuestRegistries().identifier().register(HologramIdentifier.class, hologramIdentifierFactory);
         final ArgumentParsers parsers = plugin.getArgumentParsers();
         this.locationHologramLoop = new LocationHologramLoop(loggerFactory, loggerFactory.create(LocationHologramLoop.class),
-                api.getQuestTypeApi().placeholders(), api.getQuestPackageManager(), hologramIdentifierFactory, this, plugin, textParser, parsers);
+                api.getQuestTypeApi().placeholders(), api.getInstructionApi(), api.getQuestPackageManager(), hologramIdentifierFactory, this, plugin, textParser, parsers);
         plugin.addProcessor(locationHologramLoop);
         this.npcHologramLoop = new NpcHologramLoop(loggerFactory, loggerFactory.create(NpcHologramLoop.class),
-                api.getQuestTypeApi().placeholders(), plugin.getQuestPackageManager(), plugin, this,
+                api.getQuestTypeApi().placeholders(), api.getInstructionApi(), plugin.getQuestPackageManager(), plugin, this,
                 parsers, hologramIdentifierFactory, api.getFeatureApi(), api.getFeatureRegistries().npc(), textParser);
         plugin.addProcessor(npcHologramLoop);
         plugin.getServer().getPluginManager().registerEvents(new HologramListener(api.getProfileProvider()), plugin);

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/LocationHologramLoop.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/LocationHologramLoop.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.compatibility.holograms;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
@@ -32,6 +33,7 @@ public class LocationHologramLoop extends HologramLoop implements StartTask {
      * @param loggerFactory     logger factory to use
      * @param log               the logger that will be used for logging
      * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param packManager       the quest package manager to get quest packages from
      * @param identifierFactory the identifier factory to create {@link HologramIdentifier}s for this type
      * @param hologramProvider  the hologram provider to create new holograms
@@ -39,12 +41,13 @@ public class LocationHologramLoop extends HologramLoop implements StartTask {
      * @param textParser        the text parser used to parse text and colors
      * @param parsers           the argument parsers
      */
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public LocationHologramLoop(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log,
-                                final Placeholders placeholders, final QuestPackageManager packManager,
+                                final Placeholders placeholders, final InstructionApi instructionApi, final QuestPackageManager packManager,
                                 final IdentifierFactory<HologramIdentifier> identifierFactory,
                                 final HologramProvider hologramProvider, final Plugin plugin, final TextParser textParser,
                                 final ArgumentParsers parsers) {
-        super(loggerFactory, log, placeholders, packManager, hologramProvider, "Hologram", "holograms",
+        super(loggerFactory, log, placeholders, instructionApi, packManager, hologramProvider, "Hologram", "holograms",
                 textParser, parsers, identifierFactory);
         this.plugin = plugin;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/NpcHologramLoop.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/NpcHologramLoop.java
@@ -7,6 +7,7 @@ import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.feature.FeatureApi;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.NpcIdentifier;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.argument.parser.VectorParser;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
@@ -72,6 +73,7 @@ public class NpcHologramLoop extends HologramLoop implements Listener, StartTask
      * @param loggerFactory     logger factory to use
      * @param log               the logger that will be used for logging
      * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param packManager       the quest package manager to get quest packages from
      * @param plugin            the plugin to schedule tasks
      * @param hologramProvider  the hologram provider to create new holograms
@@ -83,11 +85,11 @@ public class NpcHologramLoop extends HologramLoop implements Listener, StartTask
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public NpcHologramLoop(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log,
-                           final Placeholders placeholders, final QuestPackageManager packManager, final Plugin plugin,
+                           final Placeholders placeholders, final InstructionApi instructionApi, final QuestPackageManager packManager, final Plugin plugin,
                            final HologramProvider hologramProvider, final ArgumentParsers parsers,
                            final IdentifierFactory<HologramIdentifier> identifierFactory,
                            final FeatureApi featureApi, final NpcRegistry npcRegistry, final TextParser textParser) {
-        super(loggerFactory, log, placeholders, packManager, hologramProvider,
+        super(loggerFactory, log, placeholders, instructionApi, packManager, hologramProvider,
                 "Npc Hologram", "npc_holograms", textParser, parsers, identifierFactory);
         this.plugin = plugin;
         this.featureApi = featureApi;
@@ -172,7 +174,7 @@ public class NpcHologramLoop extends HologramLoop implements Listener, StartTask
 
     private void updateHologram(final NpcHologram npcHologram) {
         npcHologram.npcHolograms().entrySet().forEach(entry -> {
-            final NpcIdentifier npcID = entry.getKey();
+                    final NpcIdentifier npcID = entry.getKey();
                     final BetonHologram hologram = entry.getValue();
                     final Npc<?> npc;
                     try {

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/QuestProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/QuestProcessor.java
@@ -2,11 +2,9 @@ package org.betonquest.betonquest.kernel.processor;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.Identifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -24,16 +22,6 @@ public abstract class QuestProcessor<I extends Identifier, T> {
      * Custom {@link BetonQuestLogger} instance for this class.
      */
     protected final BetonQuestLogger log;
-
-    /**
-     * The {@link Placeholders} to create and resolve placeholders.
-     */
-    protected final Placeholders placeholders;
-
-    /**
-     * The quest package manager to get quest packages from.
-     */
-    protected final QuestPackageManager packManager;
 
     /**
      * The identifier factory to create {@link Identifier}s for this type.
@@ -59,17 +47,13 @@ public abstract class QuestProcessor<I extends Identifier, T> {
      * Create a new QuestProcessor to store and execute {@link T} logic.
      *
      * @param log               the custom logger for this class
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
-     * @param packManager       the quest package manager to get quest packages from
      * @param identifierFactory the identifier factory to create {@link Identifier}s for this type
      * @param readable          the type name used for logging, with the first letter in upper case
      * @param internal          the section name and/or bstats topic identifier
      */
-    public QuestProcessor(final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
+    public QuestProcessor(final BetonQuestLogger log,
                           final IdentifierFactory<I> identifierFactory, final String readable, final String internal) {
         this.log = log;
-        this.placeholders = placeholders;
-        this.packManager = packManager;
         this.identifierFactory = identifierFactory;
         this.values = new HashMap<>();
         this.readable = readable;

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/QuestRegistry.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/QuestRegistry.java
@@ -16,8 +16,7 @@ import org.betonquest.betonquest.api.identifier.NpcIdentifier;
 import org.betonquest.betonquest.api.identifier.QuestCancelerIdentifier;
 import org.betonquest.betonquest.api.identifier.ReadableIdentifier;
 import org.betonquest.betonquest.api.identifier.ScheduleIdentifier;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
-import org.betonquest.betonquest.api.instruction.argument.parser.DefaultArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.item.QuestItem;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -117,30 +116,29 @@ public record QuestRegistry(
         final IdentifierFactory<CompassIdentifier> compassIdentifierFactory = identifiers.getFactory(CompassIdentifier.class);
         final IdentifierFactory<ScheduleIdentifier> scheduleIdentifierFactory = identifiers.getFactory(ScheduleIdentifier.class);
 
-        final ItemProcessor items = new ItemProcessor(loggerFactory.create(ItemProcessor.class), placeholders,
-                itemIdentifierFactory, packManager, otherRegistries.item(), plugin.getInstructionApi());
-        final ArgumentParsers parsers = new DefaultArgumentParsers((id, profile) -> items.get(id).getItem(profile),
-                plugin.getTextParser(), plugin.getServer(), identifiers);
+        final InstructionApi instructionApi = plugin.getInstructionApi();
+        final ItemProcessor items = new ItemProcessor(loggerFactory.create(ItemProcessor.class),
+                itemIdentifierFactory, otherRegistries.item(), instructionApi);
 
-        final ActionScheduling actionScheduling = new ActionScheduling(loggerFactory,
-                loggerFactory.create(ActionScheduling.class, "Schedules"), placeholders, packManager,
-                otherRegistries.actionScheduling(), scheduleIdentifierFactory, parsers);
+        final ActionScheduling actionScheduling = new ActionScheduling(
+                loggerFactory.create(ActionScheduling.class, "Schedules"), instructionApi, packManager,
+                otherRegistries.actionScheduling(), scheduleIdentifierFactory);
         final CancelerProcessor cancelers = new CancelerProcessor(loggerFactory.create(CancelerProcessor.class),
-                loggerFactory, plugin, pluginMessage, parsers, placeholders, textCreator, coreQuestRegistry,
+                loggerFactory, plugin, pluginMessage, instructionApi, textCreator, coreQuestRegistry,
                 playerDataStorage, cancelerIdentifierIdentifierFactory);
-        final CompassProcessor compasses = new CompassProcessor(loggerFactory, loggerFactory.create(CompassProcessor.class),
-                placeholders, packManager, textCreator, compassIdentifierFactory, parsers);
+        final CompassProcessor compasses = new CompassProcessor(loggerFactory.create(CompassProcessor.class),
+                instructionApi, packManager, textCreator, compassIdentifierFactory);
         final ConversationProcessor conversations = new ConversationProcessor(loggerFactory.create(ConversationProcessor.class),
                 loggerFactory, plugin, textCreator, otherRegistries.conversationIO(), otherRegistries.interceptor(),
-                placeholders, pluginMessage, parsers, conversationIdentifierFactory);
+                instructionApi, pluginMessage, conversationIdentifierFactory);
         final JournalEntryProcessor journalEntries = new JournalEntryProcessor(loggerFactory.create(JournalEntryProcessor.class),
                 placeholders, packManager, entryIdentifierIdentifierFactory, textCreator);
-        final JournalMainPageProcessor journalMainPages = new JournalMainPageProcessor(loggerFactory,
-                loggerFactory.create(JournalMainPageProcessor.class), placeholders, packManager, textCreator, parsers,
+        final JournalMainPageProcessor journalMainPages = new JournalMainPageProcessor(
+                loggerFactory.create(JournalMainPageProcessor.class), instructionApi, packManager, textCreator,
                 journalMainPageIdentifierFactory);
         final NpcProcessor npcs = new NpcProcessor(loggerFactory.create(NpcProcessor.class), loggerFactory, placeholders,
                 packManager, npcIdentifierFactory, conversationIdentifierFactory, otherRegistries.npc(), pluginMessage,
-                plugin, profileProvider, coreQuestRegistry, conversations.getStarter(), plugin.getInstructionApi());
+                plugin, profileProvider, coreQuestRegistry, conversations.getStarter(), instructionApi);
         return new QuestRegistry(log, coreQuestRegistry, actionScheduling, cancelers, compasses, conversations,
                 items, journalEntries, journalMainPages, npcs, new ArrayList<>());
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/TypedQuestProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/TypedQuestProcessor.java
@@ -2,13 +2,11 @@ package org.betonquest.betonquest.kernel.processor;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.ReadableIdentifier;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.quest.TypeFactory;
 import org.betonquest.betonquest.bstats.CompositeInstructionMetricsSupplier;
 import org.betonquest.betonquest.kernel.registry.FactoryTypeRegistry;
@@ -39,18 +37,16 @@ public abstract class TypedQuestProcessor<I extends ReadableIdentifier, T> exten
      * Create a new QuestProcessor to store and execute type logic.
      *
      * @param log               the custom logger for this class
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
-     * @param packManager       the quest package manager to get quest packages from
      * @param types             the available types
      * @param identifierFactory the identifier factory to create {@link ReadableIdentifier}s for this type
      * @param instructionApi    the instruction api
      * @param readable          the type name used for logging, with the first letter in upper case
      * @param internal          the section name and/or bstats topic identifier
      */
-    public TypedQuestProcessor(final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
+    public TypedQuestProcessor(final BetonQuestLogger log,
                                final FactoryTypeRegistry<T> types, final IdentifierFactory<I> identifierFactory,
                                final InstructionApi instructionApi, final String readable, final String internal) {
-        super(log, placeholders, packManager, identifierFactory, readable, internal);
+        super(log, identifierFactory, readable, internal);
         this.types = types;
         this.instructionApi = instructionApi;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/CancelerProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/CancelerProcessor.java
@@ -11,11 +11,10 @@ import org.betonquest.betonquest.api.identifier.JournalEntryIdentifier;
 import org.betonquest.betonquest.api.identifier.ObjectiveIdentifier;
 import org.betonquest.betonquest.api.identifier.QuestCancelerIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.quest.QuestTypeApi;
 import org.betonquest.betonquest.api.text.Text;
 import org.betonquest.betonquest.config.PluginMessage;
@@ -73,20 +72,18 @@ public class CancelerProcessor extends SectionProcessor<QuestCancelerIdentifier,
      * @param loggerFactory     the logger factory to create new class-specific logger
      * @param api               the BetonQuest API instance
      * @param pluginMessage     the {@link PluginMessage} instance
-     * @param parsers           the argument parsers to use
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param textCreator       the text creator to parse text
      * @param questTypeApi      the Quest Type API
      * @param playerDataStorage the storage for player data
      * @param identifierFactory the identifier factory to create {@link QuestCancelerIdentifier}s for this type
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     public CancelerProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
-                             final BetonQuestApi api, final PluginMessage pluginMessage, final ArgumentParsers parsers,
-                             final Placeholders placeholders, final ParsedSectionTextCreator textCreator,
+                             final BetonQuestApi api, final PluginMessage pluginMessage,
+                             final InstructionApi instructionApi, final ParsedSectionTextCreator textCreator,
                              final QuestTypeApi questTypeApi, final PlayerDataStorage playerDataStorage,
                              final IdentifierFactory<QuestCancelerIdentifier> identifierFactory) {
-        super(loggerFactory, log, placeholders, api.getQuestPackageManager(), parsers, identifierFactory, "Quest Canceler", "cancel");
+        super(log, instructionApi, identifierFactory, "Quest Canceler", "cancel");
         this.loggerFactory = loggerFactory;
         this.api = api;
         this.pluginMessage = pluginMessage;
@@ -100,7 +97,7 @@ public class CancelerProcessor extends SectionProcessor<QuestCancelerIdentifier,
         final QuestPackage pack = instruction.getPackage();
         final Text name = textCreator.parseFromSection(pack, instruction.getSection(), "name");
         final String rawItem = instruction.read().value("item").string().getOptional(pack.getConfig().getString("item.cancel_button")).getValue(null);
-        final ItemIdentifier item = rawItem == null ? null : instruction.getParsers().forIdentifier(ItemIdentifier.class).apply(placeholders, packManager, pack, rawItem);
+        final ItemIdentifier item = rawItem == null ? null : instruction.chainForArgument(rawItem).identifier(ItemIdentifier.class).get().getValue(null);
 
         final Optional<Argument<Location>> location = instruction.read().value("location").location().getOptional();
         final Argument<List<ConditionIdentifier>> conditions = instruction.read().value("conditions").identifier(ConditionIdentifier.class).list().getOptional(Collections.emptyList());

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/CompassProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/CompassProcessor.java
@@ -7,11 +7,9 @@ import org.betonquest.betonquest.api.identifier.CompassIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.ItemIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.text.Text;
 import org.betonquest.betonquest.feature.QuestCompass;
 import org.betonquest.betonquest.kernel.processor.SectionProcessor;
@@ -34,17 +32,15 @@ public class CompassProcessor extends SectionProcessor<CompassIdentifier, QuestC
     /**
      * Create a new QuestProcessor to store {@link QuestCompass}es.
      *
-     * @param loggerFactory     the logger factory to create new class-specific loggers
      * @param log               the custom logger for this class
      * @param packManager       the quest package manager to get quest packages from
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param textCreator       the text creator to parse text
      * @param identifierFactory the identifier factory to create {@link CompassIdentifier}s for this type
-     * @param parsers           the {@link ArgumentParsers} to use for parsing arguments
      */
-    public CompassProcessor(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
-                            final ParsedSectionTextCreator textCreator, final IdentifierFactory<CompassIdentifier> identifierFactory, final ArgumentParsers parsers) {
-        super(loggerFactory, log, placeholders, packManager, parsers, identifierFactory, "Compass", "compass");
+    public CompassProcessor(final BetonQuestLogger log, final InstructionApi instructionApi, final QuestPackageManager packManager,
+                            final ParsedSectionTextCreator textCreator, final IdentifierFactory<CompassIdentifier> identifierFactory) {
+        super(log, instructionApi, identifierFactory, "Compass", "compass");
         this.textCreator = textCreator;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ConversationProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ConversationProcessor.java
@@ -8,7 +8,7 @@ import org.betonquest.betonquest.api.identifier.ActionIdentifier;
 import org.betonquest.betonquest.api.identifier.ConversationIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -93,16 +93,15 @@ public class ConversationProcessor extends SectionProcessor<ConversationIdentifi
      * @param interceptorRegistry the registry for available Interceptors
      * @param placeholders        the {@link Placeholders} to create and resolve placeholders
      * @param pluginMessage       the plugin message instance to use for ingame notifications
-     * @param parsers             the argument parsers to use
      * @param identifierFactory   the identifier factory to create {@link ConversationIdentifier}s for this type
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     public ConversationProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
                                  final BetonQuest plugin, final ParsedSectionTextCreator textCreator,
                                  final ConversationIORegistry convIORegistry, final InterceptorRegistry interceptorRegistry,
-                                 final Placeholders placeholders, final PluginMessage pluginMessage,
-                                 final ArgumentParsers parsers, final IdentifierFactory<ConversationIdentifier> identifierFactory) {
-        super(loggerFactory, log, placeholders, plugin.getQuestPackageManager(), parsers, identifierFactory, "Conversation", "conversations");
+                                 final InstructionApi placeholders, final PluginMessage pluginMessage,
+                                 final IdentifierFactory<ConversationIdentifier> identifierFactory) {
+        super(log, placeholders, identifierFactory, "Conversation", "conversations");
+
         this.loggerFactory = loggerFactory;
         this.activeConversations = new ProfileKeyMap<>(plugin.getProfileProvider(), new ConcurrentHashMap<>());
         this.starter = new ConversationStarter(loggerFactory, loggerFactory.create(ConversationStarter.class),
@@ -144,8 +143,8 @@ public class ConversationProcessor extends SectionProcessor<ConversationIdentifi
                 .validate(delay -> delay.doubleValue() > 0, "Expected a non-negative number for 'interceptor_delay', got '%s' instead.").get();
 
         final ConversationData.PublicData publicData = new ConversationData.PublicData(identifier, quester, stop, finalActions, conversationIO, interceptor, interceptorDelay, invincible);
-        final ConversationData conversationData = new ConversationData(loggerFactory.create(ConversationData.class), packManager,
-                placeholders, plugin.getQuestTypeApi(), instruction, plugin.getFeatureApi().conversationApi(), textCreator, section, publicData);
+        final ConversationData conversationData = new ConversationData(loggerFactory.create(ConversationData.class), plugin.getQuestPackageManager(),
+                plugin.getQuestTypeApi().placeholders(), plugin.getQuestTypeApi(), instruction, plugin.getFeatureApi().conversationApi(), textCreator, section, publicData);
         return Map.entry(identifier, conversationData);
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ItemProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/ItemProcessor.java
@@ -1,13 +1,11 @@
 package org.betonquest.betonquest.kernel.processor.feature;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.ItemIdentifier;
 import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.item.QuestItem;
 import org.betonquest.betonquest.api.item.QuestItemWrapper;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.kernel.processor.TypedQuestProcessor;
 import org.betonquest.betonquest.kernel.registry.feature.ItemTypeRegistry;
 
@@ -20,16 +18,14 @@ public class ItemProcessor extends TypedQuestProcessor<ItemIdentifier, QuestItem
      * Create a new ItemProcessor to store and get {@link QuestItem}s.
      *
      * @param log                   the custom logger for this class
-     * @param placeholders          the {@link Placeholders} to create and resolve placeholders
      * @param itemIdentifierFactory the factory to create item identifiers
-     * @param packManager           the quest package manager to get quest packages from
      * @param types                 the available types
      * @param instructionApi        the instruction api
      */
-    public ItemProcessor(final BetonQuestLogger log, final Placeholders placeholders,
+    public ItemProcessor(final BetonQuestLogger log,
                          final IdentifierFactory<ItemIdentifier> itemIdentifierFactory,
-                         final QuestPackageManager packManager, final ItemTypeRegistry types,
+                         final ItemTypeRegistry types,
                          final InstructionApi instructionApi) {
-        super(log, placeholders, packManager, types, itemIdentifierFactory, instructionApi, "Item", "items");
+        super(log, types, itemIdentifierFactory, instructionApi, "Item", "items");
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/JournalEntryProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/JournalEntryProcessor.java
@@ -35,7 +35,7 @@ public class JournalEntryProcessor extends QuestProcessor<JournalEntryIdentifier
      */
     public JournalEntryProcessor(final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
                                  final IdentifierFactory<JournalEntryIdentifier> journalEntryIdentifierFactory, final ParsedSectionTextCreator textCreator) {
-        super(log, placeholders, packManager, journalEntryIdentifierFactory, "Journal Entry", "journal");
+        super(log, journalEntryIdentifierFactory, "Journal Entry", "journal");
         this.textCreator = textCreator;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/JournalMainPageProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/feature/JournalMainPageProcessor.java
@@ -7,11 +7,9 @@ import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.JournalMainPageIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.text.Text;
 import org.betonquest.betonquest.feature.journal.JournalMainPageEntry;
 import org.betonquest.betonquest.kernel.processor.SectionProcessor;
@@ -34,17 +32,15 @@ public class JournalMainPageProcessor extends SectionProcessor<JournalMainPageId
     /**
      * Create a new QuestProcessor to store and execute type logic.
      *
-     * @param loggerFactory     the logger factory to create new class-specific loggers
      * @param log               the custom logger for this class
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param packManager       the quest package manager to get quest packages from
      * @param textCreator       the text creator to parse text
-     * @param parsers           the {@link ArgumentParsers} to use for parsing arguments
      * @param identifierFactory the identifier factory to create {@link JournalMainPageIdentifier}s for this type
      */
-    public JournalMainPageProcessor(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
-                                    final ParsedSectionTextCreator textCreator, final ArgumentParsers parsers, final IdentifierFactory<JournalMainPageIdentifier> identifierFactory) {
-        super(loggerFactory, log, placeholders, packManager, parsers, identifierFactory, "Journal Main Page", "journal_main_page");
+    public JournalMainPageProcessor(final BetonQuestLogger log, final InstructionApi instructionApi, final QuestPackageManager packManager,
+                                    final ParsedSectionTextCreator textCreator, final IdentifierFactory<JournalMainPageIdentifier> identifierFactory) {
+        super(log, instructionApi, identifierFactory, "Journal Main Page", "journal_main_page");
         this.textCreator = textCreator;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ActionProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ActionProcessor.java
@@ -54,7 +54,7 @@ public class ActionProcessor extends TypedQuestProcessor<ActionIdentifier, Actio
                            final IdentifierFactory<ActionIdentifier> actionIdentifierFactory,
                            final ActionTypeRegistry actionTypes, final BukkitScheduler scheduler,
                            final InstructionApi instructionApi, final Plugin plugin) {
-        super(log, placeholders, packManager, actionTypes, actionIdentifierFactory, instructionApi, "Action", "actions");
+        super(log, actionTypes, actionIdentifierFactory, instructionApi, "Action", "actions");
         this.scheduler = scheduler;
         this.plugin = plugin;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ConditionProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ConditionProcessor.java
@@ -56,7 +56,7 @@ public class ConditionProcessor extends TypedQuestProcessor<ConditionIdentifier,
                               final ConditionTypeRegistry conditionTypes, final BukkitScheduler scheduler,
                               final IdentifierFactory<ConditionIdentifier> conditionIdentifierFactory, final Plugin plugin,
                               final InstructionApi instructionApi) {
-        super(log, placeholders, packManager, conditionTypes, conditionIdentifierFactory, instructionApi, "Condition", "conditions");
+        super(log, conditionTypes, conditionIdentifierFactory, instructionApi, "Condition", "conditions");
         this.scheduler = scheduler;
         this.plugin = plugin;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/NpcProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/NpcProcessor.java
@@ -135,7 +135,7 @@ public class NpcProcessor extends TypedQuestProcessor<NpcIdentifier, NpcWrapper<
                         final NpcTypeRegistry npcTypes, final PluginMessage pluginMessage, final BetonQuest plugin,
                         final ProfileProvider profileProvider, final QuestTypeApi questTypeApi, final ConversationStarter convStarter,
                         final InstructionApi instructionApi) {
-        super(log, placeholders, packManager, npcTypes, npcIdentifierFactory, instructionApi, "Npc", "npcs");
+        super(log, npcTypes, npcIdentifierFactory, instructionApi, "Npc", "npcs");
         this.loggerFactory = loggerFactory;
         this.pluginMessage = pluginMessage;
         this.convStarter = convStarter;
@@ -151,6 +151,7 @@ public class NpcProcessor extends TypedQuestProcessor<NpcIdentifier, NpcWrapper<
     public void load(final QuestPackage pack) {
         super.load(pack);
         loadBindings(pack);
+        npcHider.load(pack);
     }
 
     /**
@@ -188,7 +189,7 @@ public class NpcProcessor extends TypedQuestProcessor<NpcIdentifier, NpcWrapper<
         interactionLimit = plugin.getPluginConfig().getInt("npc.interaction_limit", 500);
         acceptNpcLeftClick = plugin.getPluginConfig().getBoolean("npc.accept_left_click");
         final int updateInterval = plugin.getPluginConfig().getInt("hider.npc_update_interval", 5 * 20);
-        npcHider.reload(packManager.getPackages().values(), updateInterval, plugin);
+        npcHider.reload(updateInterval, plugin);
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ObjectiveProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ObjectiveProcessor.java
@@ -88,7 +88,7 @@ public class ObjectiveProcessor extends QuestProcessor<ObjectiveIdentifier, Obje
                               final IdentifierFactory<ObjectiveIdentifier> objectiveIdentifierFactory,
                               final PluginManager pluginManager, final ObjectiveServiceProvider service,
                               final InstructionApi instructionApi, final Plugin plugin) {
-        super(log, placeholders, packManager, objectiveIdentifierFactory, "Objective", "objectives");
+        super(log, objectiveIdentifierFactory, "Objective", "objectives");
         this.instructionApi = instructionApi;
         this.pluginManager = pluginManager;
         this.objectiveService = service;

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/PlaceholderProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/PlaceholderProcessor.java
@@ -47,6 +47,11 @@ public class PlaceholderProcessor extends TypedQuestProcessor<PlaceholderIdentif
     };
 
     /**
+     * The quest package manager to get quest packages from.
+     */
+    private final QuestPackageManager packManager;
+
+    /**
      * The Bukkit scheduler to run sync tasks.
      */
     private final BukkitScheduler scheduler;
@@ -71,8 +76,9 @@ public class PlaceholderProcessor extends TypedQuestProcessor<PlaceholderIdentif
                                 final PlaceholderTypeRegistry placeholderTypes, final BukkitScheduler scheduler,
                                 final IdentifierFactory<PlaceholderIdentifier> placeholderIdentifierFactory,
                                 final InstructionApi instructionApi, final Plugin plugin) {
-        super(log, EMPTY_PLACEHOLDER, packManager, placeholderTypes, placeholderIdentifierFactory,
+        super(log, placeholderTypes, placeholderIdentifierFactory,
                 instructionApi, "Placeholders", "placeholders");
+        this.packManager = packManager;
         this.scheduler = scheduler;
         this.plugin = plugin;
     }
@@ -99,7 +105,7 @@ public class PlaceholderProcessor extends TypedQuestProcessor<PlaceholderIdentif
         final TypeFactory<PlaceholderAdapter> placeholderFactory = types.getFactory(instructionVar.current());
         final PlaceholderAdapter placeholder = placeholderFactory.parseInstruction(instructionVar);
         values.put(placeholderID, placeholder);
-        log.debug(pack, "Placeholder " + placeholderID + " loaded");
+        log.debug(placeholder.getPackage(), "Placeholder " + placeholderID + " loaded");
         return placeholder;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/RPGMenu.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/RPGMenu.java
@@ -3,10 +3,10 @@ package org.betonquest.betonquest.menu;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.ConfigAccessor;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.MenuIdentifier;
 import org.betonquest.betonquest.api.identifier.MenuItemIdentifier;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -72,7 +72,7 @@ public class RPGMenu {
      *
      * @param log             the custom logger for this class
      * @param loggerFactory   the factory to create new custom logger instances
-     * @param packManager     the quest package manager to get quest packages from
+     * @param instructionApi  the instruction api to use
      * @param pluginConfig    the plugin config
      * @param pluginMessage   the plugin message instance
      * @param textCreator     the text creator to parse text
@@ -82,7 +82,7 @@ public class RPGMenu {
      * @throws QuestException if there is an error while loading the menus
      */
     public RPGMenu(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
-                   final QuestPackageManager packManager, final ConfigAccessor pluginConfig,
+                   final InstructionApi instructionApi, final ConfigAccessor pluginConfig,
                    final PluginMessage pluginMessage, final ParsedSectionTextCreator textCreator,
                    final QuestTypeApi questTypeApi, final ProfileProvider profileProvider,
                    final ArgumentParsers parsers) throws QuestException {
@@ -102,11 +102,11 @@ public class RPGMenu {
         pluginCommand.register();
         pluginCommand.syncCraftBukkitCommands();
         this.menuItemProcessor = new MenuItemProcessor(loggerFactory.create(MenuItemProcessor.class), loggerFactory,
-                packManager, textCreator, questRegistries.identifier().getFactory(MenuItemIdentifier.class),
+                instructionApi, textCreator, questRegistries.identifier().getFactory(MenuItemIdentifier.class),
                 questTypeApi, pluginConfig, parsers);
         betonQuest.addProcessor(menuItemProcessor);
         this.menuProcessor = new MenuProcessor(loggerFactory.create(MenuProcessor.class), loggerFactory,
-                packManager, textCreator, questTypeApi, parsers, this, menuIdentifierFactory, profileProvider);
+                instructionApi, textCreator, questTypeApi, parsers, this, menuIdentifierFactory, profileProvider);
         betonQuest.addProcessor(menuProcessor);
         this.menuItemListener = new MenuItemListener(loggerFactory.create(MenuItemListener.class), this,
                 menuProcessor, profileProvider, pluginMessage);

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/MenuItemProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/MenuItemProcessor.java
@@ -3,12 +3,12 @@ package org.betonquest.betonquest.menu.kernel;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.ActionIdentifier;
 import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.MenuItemIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
@@ -44,7 +44,7 @@ public class MenuItemProcessor extends RPGMenuProcessor<MenuItemIdentifier, Menu
      *
      * @param log               the custom logger for this class
      * @param loggerFactory     the logger factory to class specific loggers with
-     * @param packManager       the quest package manager to get quest packages from
+     * @param instructionApi    the instruction api to use
      * @param textCreator       the text creator to parse text
      * @param identifierFactory the identifier factory to create {@link MenuItemIdentifier}s for this type
      * @param questTypeApi      the QuestTypeApi
@@ -52,10 +52,10 @@ public class MenuItemProcessor extends RPGMenuProcessor<MenuItemIdentifier, Menu
      * @param parsers           the argument parsers
      */
     public MenuItemProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
-                             final QuestPackageManager packManager, final ParsedSectionTextCreator textCreator,
+                             final InstructionApi instructionApi, final ParsedSectionTextCreator textCreator,
                              final IdentifierFactory<MenuItemIdentifier> identifierFactory,
                              final QuestTypeApi questTypeApi, final ConfigAccessor config, final ArgumentParsers parsers) {
-        super(log, packManager, "Menu Item", "menu_items", loggerFactory, textCreator, parsers, identifierFactory, questTypeApi);
+        super(log, instructionApi, "Menu Item", "menu_items", loggerFactory, textCreator, parsers, identifierFactory, questTypeApi);
         this.config = config;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/MenuProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/MenuProcessor.java
@@ -2,13 +2,13 @@ package org.betonquest.betonquest.menu.kernel;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.ActionIdentifier;
 import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.MenuIdentifier;
 import org.betonquest.betonquest.api.identifier.MenuItemIdentifier;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.chain.InstructionChainParser;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
@@ -60,7 +60,7 @@ public class MenuProcessor extends RPGMenuProcessor<MenuIdentifier, Menu> {
      *
      * @param log               the custom logger for this class
      * @param loggerFactory     the logger factory to class specific loggers with
-     * @param packManager       the quest package manager to get quest packages from
+     * @param instructionApi    the instruction api to use
      * @param textCreator       the text creator to parse text
      * @param questTypeApi      the QuestTypeApi
      * @param parsers           the argument parsers
@@ -69,10 +69,10 @@ public class MenuProcessor extends RPGMenuProcessor<MenuIdentifier, Menu> {
      * @param profileProvider   the Profile Provider
      */
     public MenuProcessor(final BetonQuestLogger log, final BetonQuestLoggerFactory loggerFactory,
-                         final QuestPackageManager packManager, final ParsedSectionTextCreator textCreator,
+                         final InstructionApi instructionApi, final ParsedSectionTextCreator textCreator,
                          final QuestTypeApi questTypeApi, final ArgumentParsers parsers, final RPGMenu rpgMenu,
                          final IdentifierFactory<MenuIdentifier> identifierFactory, final ProfileProvider profileProvider) {
-        super(log, packManager, "Menu", "menus", loggerFactory, textCreator, parsers, identifierFactory, questTypeApi);
+        super(log, instructionApi, "Menu", "menus", loggerFactory, textCreator, parsers, identifierFactory, questTypeApi);
         this.rpgMenu = rpgMenu;
         this.profileProvider = profileProvider;
         this.boundCommands = new HashSet<>();

--- a/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/RPGMenuProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/menu/kernel/RPGMenuProcessor.java
@@ -1,8 +1,8 @@
 package org.betonquest.betonquest.menu.kernel;
 
-import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.Identifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentParser;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
@@ -44,7 +44,7 @@ public abstract class RPGMenuProcessor<I extends Identifier, T> extends SectionP
      * Create a new Processor to create and store Menu Items.
      *
      * @param log               the custom logger for this class
-     * @param packManager       the quest package manager to get quest packages from
+     * @param instructionApi    the instruction api to use
      * @param readable          the type name used for logging, with the first letter in upper case
      * @param internal          the section name and/or bstats topic identifier
      * @param loggerFactory     the logger factory to class specific loggers with
@@ -53,11 +53,11 @@ public abstract class RPGMenuProcessor<I extends Identifier, T> extends SectionP
      * @param identifierFactory the identifier factory
      * @param questTypeApi      the QuestTypeApi
      */
-    public RPGMenuProcessor(final BetonQuestLogger log, final QuestPackageManager packManager, final String readable,
+    public RPGMenuProcessor(final BetonQuestLogger log, final InstructionApi instructionApi, final String readable,
                             final String internal, final BetonQuestLoggerFactory loggerFactory,
                             final ParsedSectionTextCreator textCreator, final ArgumentParsers parsers,
                             final IdentifierFactory<I> identifierFactory, final QuestTypeApi questTypeApi) {
-        super(loggerFactory, log, questTypeApi.placeholders(), packManager, parsers, identifierFactory, readable, internal);
+        super(log, instructionApi, identifierFactory, readable, internal);
         this.loggerFactory = loggerFactory;
         this.textCreator = textCreator;
         this.questTypeApi = questTypeApi;

--- a/code/core/src/main/java/org/betonquest/betonquest/schedule/ActionScheduling.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/schedule/ActionScheduling.java
@@ -4,11 +4,9 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.identifier.ScheduleIdentifier;
-import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
-import org.betonquest.betonquest.api.quest.Placeholders;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.kernel.processor.SectionProcessor;
@@ -30,17 +28,15 @@ public class ActionScheduling extends SectionProcessor<ScheduleIdentifier, Sched
     /**
      * Creates a new instance of the action scheduling class.
      *
-     * @param loggerFactory     logger factory to use
      * @param log               the logger that will be used for logging
-     * @param placeholders      the {@link Placeholders} to create and resolve placeholders
+     * @param instructionApi    the instruction api to use
      * @param packManager       the quest package manager to get quest packages from
      * @param scheduleTypes     map containing the schedule types, provided by {@link org.betonquest.betonquest.BetonQuest}
      * @param identifierFactory the identifier factory to create {@link ScheduleIdentifier}s for this type
-     * @param parsers           the argument parsers
      */
-    public ActionScheduling(final BetonQuestLoggerFactory loggerFactory, final BetonQuestLogger log, final Placeholders placeholders, final QuestPackageManager packManager,
-                            final ScheduleRegistry scheduleTypes, final IdentifierFactory<ScheduleIdentifier> identifierFactory, final ArgumentParsers parsers) {
-        super(loggerFactory, log, placeholders, packManager, parsers, identifierFactory, "Schedules", "schedules");
+    public ActionScheduling(final BetonQuestLogger log, final InstructionApi instructionApi, final QuestPackageManager packManager,
+                            final ScheduleRegistry scheduleTypes, final IdentifierFactory<ScheduleIdentifier> identifierFactory) {
+        super(log, instructionApi, identifierFactory, "Schedules", "schedules");
         this.scheduleTypes = scheduleTypes;
     }
 

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/ActionSchedulingTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/ActionSchedulingTest.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.config.quest.QuestPackage;
 import org.betonquest.betonquest.api.config.quest.QuestPackageManager;
 import org.betonquest.betonquest.api.identifier.ActionIdentifier;
 import org.betonquest.betonquest.api.identifier.ScheduleIdentifier;
+import org.betonquest.betonquest.api.instruction.InstructionApi;
 import org.betonquest.betonquest.api.instruction.argument.ArgumentParsers;
 import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
@@ -20,6 +21,7 @@ import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.id.schedule.ScheduleIdentifierFactory;
 import org.betonquest.betonquest.kernel.registry.feature.ScheduleRegistry;
+import org.betonquest.betonquest.lib.instruction.section.DefaultSectionInstruction;
 import org.betonquest.betonquest.logger.util.BetonQuestLoggerService;
 import org.betonquest.betonquest.schedule.ActionScheduling.ScheduleType;
 import org.betonquest.betonquest.schedule.impl.BaseScheduleFactory;
@@ -56,12 +58,15 @@ class ActionSchedulingTest {
     private ScheduleRegistry scheduleTypes;
 
     @BeforeEach
-    void setUp(final BetonQuestLoggerFactory loggerFactory) {
+    void setUp(final BetonQuestLoggerFactory loggerFactory) throws QuestException {
         scheduleTypes = new ScheduleRegistry(mock(BetonQuestLogger.class));
-        final ArgumentParsers parsers = mock(ArgumentParsers.class);
         final QuestPackageManager packManager = mock(QuestPackageManager.class);
-        scheduling = new ActionScheduling(loggerFactory, mock(BetonQuestLogger.class), mock(Placeholders.class),
-                packManager, scheduleTypes, new ScheduleIdentifierFactory(packManager), parsers);
+        final InstructionApi instructionApi = mock(InstructionApi.class);
+        lenient().when(instructionApi.createSectionInstruction(any(), any())).thenAnswer(onMock ->
+                new DefaultSectionInstruction(mock(ArgumentParsers.class), mock(Placeholders.class),
+                        packManager, onMock.getArgument(0), onMock.getArgument(1), loggerFactory));
+        scheduling = new ActionScheduling(mock(BetonQuestLogger.class), instructionApi,
+                packManager, scheduleTypes, new ScheduleIdentifierFactory(packManager));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
<!-- Please describe your changes here. -->

in the section processor

and don't store mostly unsued fields in QuestProcessor

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
