### PR TITLE
Fix line splitting pattern in ComponentLineWrapper

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/api/common/component/ComponentLineWrapper.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/common/component/ComponentLineWrapper.java
@@ -28,7 +28,7 @@ public class ComponentLineWrapper {
     /**
      * The newline string to split text components by new lines.
      */
-    private static final Pattern NEW_LINE = Pattern.compile("\n");
+    private static final Pattern NEW_LINE = Pattern.compile("\\n");
 
     /**
      * The leading space pattern to split text components by leading spaces.


### PR DESCRIPTION
Fix line splitting pattern in ComponentLineWrapper causing titleIO to not split at manual line breaks.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [ ]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... wrote a Migration?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
