### PR TITLE
Add FancyHolograms integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `brew` item type
 - `mainhand` selection order to `take` action
 - menu `bind` item for specific clicks
+- `FancyHolograms` as compatible Hologram plugin
 ### Changed
 - Spigot is no longer supported, paper is now required 
 - message.yml file was deleted and instead the lang folder now contains all translations

--- a/code/build/src/main/resources/plugin.yml
+++ b/code/build/src/main/resources/plugin.yml
@@ -42,6 +42,7 @@ softdepend:
   - CraftEngine
   - ItemsAdder
   - Nexo
+  - FancyHolograms
 commands:
   journal:
     description: Adds journal to your inventory

--- a/code/compatibility/pom.xml
+++ b/code/compatibility/pom.xml
@@ -44,6 +44,7 @@
     <ShopkeepersAPI.version>2.22.3</ShopkeepersAPI.version>
     <TrainCarts.version>1.20.6-v1</TrainCarts.version>
     <FancyNpcs.version>2.4.2</FancyNpcs.version>
+    <FancyHolograms.version>2.8.0</FancyHolograms.version>
     <znpcsplus-api.version>2.1.0-SNAPSHOT</znpcsplus-api.version>
     <Skript.version>2.9.1</Skript.version>
     <fake-block-api.version>v2.0.0</fake-block-api.version>
@@ -261,6 +262,13 @@
       <groupId>de.oliver</groupId>
       <artifactId>FancyNpcs</artifactId>
       <version>${FancyNpcs.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>de.oliver</groupId>
+      <artifactId>FancyHolograms</artifactId>
+      <version>${FancyHolograms.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
@@ -14,6 +14,7 @@ import org.betonquest.betonquest.compatibility.fabled.FabledIntegrator;
 import org.betonquest.betonquest.compatibility.fakeblock.FakeBlockIntegrator;
 import org.betonquest.betonquest.compatibility.heroes.HeroesIntegrator;
 import org.betonquest.betonquest.compatibility.holograms.decentholograms.DecentHologramsIntegrator;
+import org.betonquest.betonquest.compatibility.holograms.fancyholograms.FancyHologramsIntegrator;
 import org.betonquest.betonquest.compatibility.holograms.holographicdisplays.HolographicDisplaysIntegrator;
 import org.betonquest.betonquest.compatibility.itemsadder.ItemsAdderIntegrator;
 import org.betonquest.betonquest.compatibility.jobsreborn.JobsRebornIntegrator;
@@ -159,6 +160,7 @@ public final class BundledCompatibility {
         register("RedisChat", () -> new RedisChatIntegrator());
         register("Train_Carts", () -> new TrainCartsIntegrator());
         register(FancyNpcsIntegrator.PREFIX, () -> new FancyNpcsIntegrator(plugin));
+        register(FancyHologramsIntegrator.NAME, () -> new FancyHologramsIntegrator(), FancyHologramsIntegrator.getPolicies());
         register(ZNPCsPlusIntegrator.PREFIX, () -> new ZNPCsPlusIntegrator(), ZNPCsPlusIntegrator.REQUIRED_VERSION);
         register("Nexo", () -> new NexoIntegrator());
         register("CraftEngine", () -> new CraftEngineIntegrator());

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsHologram.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsHologram.java
@@ -1,0 +1,257 @@
+package org.betonquest.betonquest.compatibility.holograms.fancyholograms;
+
+import de.oliver.fancyholograms.api.HologramManager;
+import de.oliver.fancyholograms.api.data.ItemHologramData;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.data.property.Visibility;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
+import org.betonquest.betonquest.compatibility.holograms.BetonHologram;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * FancyHolograms specific implementation of BetonHologram.
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public class FancyHologramsHologram implements BetonHologram {
+
+    /**
+     * Vertical spacing between lines.
+     */
+    private static final float LINE_SPACING = 0.3f;
+
+    /**
+     * Instance containing only click events to remove them.
+     */
+    private static final MiniMessage CLICK_INSTANCE = MiniMessage.builder().tags(StandardTags.clickEvent()).build();
+
+    /**
+     * Instance containing all tags used for to serializing.
+     */
+    private static final MiniMessage NORMAL_INSTANCE = MiniMessage.miniMessage();
+
+    /**
+     * The hologram manager to create new Holograms.
+     */
+    private final HologramManager manager;
+
+    /**
+     * Data of the primary hologram.
+     */
+    private final TextHologramData baseData;
+
+    /**
+     * Primary hologram used for test display.
+     */
+    private final Hologram baseHologram;
+
+    /**
+     * Holograms representing each one line.
+     */
+    private final List<Hologram> holograms;
+
+    /**
+     * If the hologram is created but disabled.
+     */
+    private boolean disabled;
+
+    /**
+     * Create a BetonHologram to wrap the given DecentHolograms hologram.
+     *
+     * @param manager  The hologram manager to create new holograms
+     * @param location Zhe base location for the hologram
+     */
+    public FancyHologramsHologram(final HologramManager manager, final Location location) {
+        this.manager = manager;
+        this.baseData = new TextHologramData("BQ Base Hologram", location);
+        this.baseData.setPersistent(false);
+        this.baseData.setVisibility(Visibility.MANUAL);
+        this.baseData.setBackground(Hologram.TRANSPARENT);
+        this.baseData.setText(List.of());
+        this.baseHologram = manager.create(this.baseData);
+        this.holograms = new ArrayList<>();
+    }
+
+    private Hologram createTextLine(final int offset, final Component text) {
+        final Location location = getLocation();
+        location.subtract(0, offset * LINE_SPACING, 0);
+        final TextHologramData data = new TextHologramData("BQ Text Hologram", location);
+        data.setPersistent(false);
+        data.setVisibility(Visibility.MANUAL);
+        data.setBackground(Hologram.TRANSPARENT);
+        data.setText(List.of(translate(text)));
+        final Hologram hologram = manager.create(data);
+        hologram.createHologram();
+        return hologram;
+    }
+
+    private Hologram createItemLine(final int offset, final ItemStack item) {
+        final Location location = getLocation();
+        location.subtract(0, offset * LINE_SPACING, 0);
+        final ItemHologramData data = new ItemHologramData("BQ Item Line", location);
+        data.setPersistent(false);
+        data.setVisibility(Visibility.MANUAL);
+        data.setItemStack(item);
+        final Hologram hologram = manager.create(data);
+        hologram.createHologram();
+        return hologram;
+    }
+
+    @Override
+    public void appendLine(final ItemStack item) {
+        final int size = holograms.size();
+        holograms.add(createItemLine(size, item));
+    }
+
+    @Override
+    public void appendLine(final Component text) {
+        final int size = holograms.size();
+        holograms.add(createTextLine(size, text));
+    }
+
+    @Override
+    public void setLine(final int index, final ItemStack item) {
+        final Hologram oldLine = holograms.get(index);
+        if (oldLine.getData() instanceof final ItemHologramData itemData) {
+            itemData.setItemStack(item);
+            return;
+        }
+        forceHide(oldLine);
+        oldLine.deleteHologram();
+        holograms.set(index, createItemLine(index, item));
+    }
+
+    @Override
+    public void setLine(final int index, final Component text) {
+        final Hologram oldLine = holograms.get(index);
+        if (oldLine.getData() instanceof final TextHologramData textData) {
+            textData.setText(List.of(translate(text)));
+            return;
+        }
+        forceHide(oldLine);
+        oldLine.deleteHologram();
+        holograms.set(index, createTextLine(index, text));
+    }
+
+    /**
+     * Converts into MiniMessage format and strips the url click events because they break placeholder resolving.
+     */
+    private String translate(final Component text) {
+        return CLICK_INSTANCE.stripTags(NORMAL_INSTANCE.serialize(text));
+    }
+
+    @Override
+    public void createLines(final int startingIndex, final int linesAdded) {
+        for (int i = startingIndex; i < linesAdded; i++) {
+            holograms.add(createTextLine(i, Component.empty()));
+        }
+    }
+
+    @Override
+    public void removeLine(final int index) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    private void forAllHolograms(final Consumer<Hologram> consumer) {
+        consumer.accept(baseHologram);
+        holograms.forEach(consumer);
+    }
+
+    @Override
+    public void show(final Player player) {
+        if (baseHologram.isViewer(player)) {
+            return;
+        }
+        forAllHolograms(hologram -> hologram.forceShowHologram(player));
+    }
+
+    @Override
+    public void hide(final Player player) {
+        if (!baseHologram.isViewer(player)) {
+            return;
+        }
+        forAllHolograms(hologram -> hologram.forceHideHologram(player));
+    }
+
+    @Override
+    public void move(final Location location) {
+        baseData.setLocation(location);
+        for (final Hologram hologram : holograms) {
+            hologram.getData().setLocation(location);
+            hologram.refreshForViewers();
+            location.subtract(0, LINE_SPACING, 0);
+        }
+    }
+
+    @Override
+    public void showAll() {
+        if (disabled) {
+            return;
+        }
+        Bukkit.getOnlinePlayers().forEach(player ->
+                forAllHolograms(hologram -> hologram.forceShowHologram(player)));
+    }
+
+    @Override
+    public void hideAll() {
+        forAllHolograms(this::forceHide);
+    }
+
+    private void forceHide(final Hologram hologram) {
+        for (final UUID viewer : hologram.getViewers()) {
+            final Player player = Bukkit.getPlayer(viewer);
+            if (player != null) {
+                hologram.forceHideHologram(player);
+            }
+        }
+    }
+
+    @Override
+    public void delete() {
+        clear();
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    @Override
+    public void disable() {
+        this.disabled = true;
+        hideAll();
+        forAllHolograms(Hologram::deleteHologram);
+    }
+
+    @Override
+    public void enable() {
+        this.disabled = false;
+        forAllHolograms(Hologram::createHologram);
+    }
+
+    @Override
+    public int size() {
+        return holograms.size();
+    }
+
+    @Override
+    public void clear() {
+        hideAll();
+        holograms.clear();
+    }
+
+    @Override
+    public Location getLocation() {
+        return baseData.getLocation();
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsHologramFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsHologramFactory.java
@@ -1,0 +1,80 @@
+package org.betonquest.betonquest.compatibility.holograms.fancyholograms;
+
+import de.oliver.fancyholograms.api.FancyHologramsPlugin;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.identifier.PlaceholderIdentifier;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.service.instruction.Instructions;
+import org.betonquest.betonquest.compatibility.holograms.BetonHologram;
+import org.betonquest.betonquest.compatibility.holograms.BetonHologramFactory;
+import org.betonquest.betonquest.compatibility.holograms.HologramProvider;
+import org.bukkit.Location;
+
+import java.util.regex.Matcher;
+
+/**
+ * Hologram Factory implementation for FancyHolograms.
+ */
+public class FancyHologramsHologramFactory implements BetonHologramFactory {
+
+    /**
+     * Custom {@link BetonQuestLogger} instance for this class.
+     */
+    private final BetonQuestLogger log;
+
+    /**
+     * The instruction api to use.
+     */
+    private final Instructions instructionApi;
+
+    /**
+     * The identifier factory for placeholders.
+     */
+    private final IdentifierFactory<PlaceholderIdentifier> identifierFactory;
+
+    /**
+     * Creates a new {@link BetonHologramFactory} for DecentHolograms.
+     *
+     * @param log               the custom logger for this class
+     * @param identifierFactory the identifier factory for placeholders
+     * @param instructionApi    the instruction api to use
+     */
+    public FancyHologramsHologramFactory(final BetonQuestLogger log, final Instructions instructionApi,
+                                         final IdentifierFactory<PlaceholderIdentifier> identifierFactory) {
+        this.log = log;
+        this.instructionApi = instructionApi;
+        this.identifierFactory = identifierFactory;
+    }
+
+    @Override
+    public BetonHologram createHologram(final Location location) {
+        return new FancyHologramsHologram(FancyHologramsPlugin.get().getHologramManager(), location);
+    }
+
+    /**
+     * Parses a package-specific BetonQuest placeholder and converts it to the PlaceholderAPI format since
+     * FancyHolograms requires it.
+     *
+     * @param pack the quest pack where the placeholder resides
+     * @param text the raw text
+     * @return the parsed and formatted full string
+     */
+    @Override
+    public String parsePlaceholder(final QuestPackage pack, final String text) {
+        final Matcher matcher = HologramProvider.PLACEHOLDER_VALIDATOR.matcher(text);
+        return matcher.replaceAll(match -> {
+            final String group = match.group();
+            try {
+                final PlaceholderIdentifier placeholderIdentifier = identifierFactory.parseIdentifier(pack, group);
+                final Instruction instruction = instructionApi.createPlaceholder(placeholderIdentifier, placeholderIdentifier.readRawInstruction());
+                return "%betonquest_" + placeholderIdentifier.getPackage().getQuestPath() + ":" + instruction + "%";
+            } catch (final QuestException exception) {
+                log.warn("Could not create placeholder '" + group + "': " + exception.getMessage(), exception);
+            }
+            return group;
+        });
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/FancyHologramsIntegrator.java
@@ -1,0 +1,79 @@
+package org.betonquest.betonquest.compatibility.holograms.fancyholograms;
+
+import org.betonquest.betonquest.api.BetonQuestApi;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.identifier.PlaceholderIdentifier;
+import org.betonquest.betonquest.api.integration.policy.Policy;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.compatibility.holograms.BetonHologramFactory;
+import org.betonquest.betonquest.compatibility.holograms.HologramIntegration;
+import org.betonquest.betonquest.lib.integration.policy.Policies;
+import org.betonquest.betonquest.lib.version.DefaultVersionType;
+import org.betonquest.betonquest.lib.version.VersionParser;
+import org.bukkit.Bukkit;
+
+/**
+ * Integrates with FancyHolograms.
+ */
+public class FancyHologramsIntegrator implements HologramIntegration {
+
+    /**
+     * The minimum required version of FancyHolograms.
+     */
+    public static final String REQUIRED_VERSION = "2.8.0";
+
+    /**
+     * The name of the integrated plugin.
+     */
+    public static final String NAME = "FancyHolograms";
+
+    /**
+     * The empty default constructor.
+     */
+    public FancyHologramsIntegrator() {
+    }
+
+    /**
+     * Checks for the valid version range of the 'FancyHolograms' plugin.
+     *
+     * @return whether the correct version is installed or not
+     */
+    public static Policy[] getPolicies() {
+        return Policies.pluginVersionRange(NAME,
+                VersionParser.parse(DefaultVersionType.SIMPLE_SEMANTIC_VERSION, REQUIRED_VERSION),
+                VersionParser.parse(DefaultVersionType.SIMPLE_SEMANTIC_VERSION, "2.999"));
+    }
+
+    @Override
+    public void enable(final BetonQuestApi api) throws QuestException {
+        // Empty
+    }
+
+    @Override
+    public void postEnable(final BetonQuestApi api) {
+        // Empty
+    }
+
+    @Override
+    public void disable() {
+        // Empty
+    }
+
+    @Override
+    public String getPluginName() {
+        return NAME;
+    }
+
+    @Override
+    public BetonHologramFactory getHologramFactory(final BetonQuestApi api) throws QuestException {
+        final BetonQuestLogger log = api.loggerFactory().create(FancyHologramsHologramFactory.class);
+        if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            log.warn("Holograms from FancyHolograms will not be able to use BetonQuest placeholders in text lines "
+                    + "without PlaceholderAPI plugin! Install it to use holograms with placeholders!");
+        }
+        final IdentifierFactory<PlaceholderIdentifier> placeholderIdentifierFactory =
+                api.identifiers().getFactory(PlaceholderIdentifier.class);
+        return new FancyHologramsHologramFactory(log, api.instructions(), placeholderIdentifierFactory);
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/package-info.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/holograms/fancyholograms/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The FancyHolograms integration.
+ */
+package org.betonquest.betonquest.compatibility.holograms.fancyholograms;

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramProvider.java
@@ -16,6 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.Comparator;
 import java.util.List;
@@ -168,6 +169,16 @@ public final class HologramProvider {
         @EventHandler
         public void onPlayerJoin(final PlayerJoinEvent event) {
             HologramRunner.refresh(profileProvider.getProfile(event.getPlayer()));
+        }
+
+        /**
+         * Refreshes Holograms when a player leaves the server.
+         *
+         * @param event The event.
+         */
+        @EventHandler
+        public void onPlayerQuit(final PlayerQuitEvent event) {
+            HologramRunner.remove(event.getPlayer());
         }
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramRunner.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/compatibility/holograms/HologramRunner.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.compatibility.holograms;
 
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
@@ -82,6 +83,21 @@ public final class HologramRunner {
     public static void refresh(final OnlineProfile profile) {
         for (final HologramRunner hologramRunner : RUNNERS.values()) {
             hologramRunner.refreshRunner(profile);
+        }
+    }
+
+    /**
+     * Hides all holograms for the given player.
+     *
+     * @param player the player to hide all holograms  for
+     */
+    public static void remove(final Player player) {
+        for (final HologramRunner hologramRunner : RUNNERS.values()) {
+            for (final HologramWrapper wrapper : hologramRunner.holograms) {
+                for (final BetonHologram hologram : wrapper.holograms()) {
+                    hologram.hide(player);
+                }
+            }
         }
     }
 

--- a/code/core/src/main/resources/config.patch.yml
+++ b/code/core/src/main/resources/config.patch.yml
@@ -1,4 +1,12 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.0.0.24:
+  - type: SET
+    key: hook.fancyholograms
+    value: true
+  - type: VALUE_RENAME
+    key: hologram.default
+    oldValueRegex: 'DecentHolograms,HolographicDisplays'
+    newValue: 'DecentHolograms,FancyHolograms,HolographicDisplays'
 3.0.0.23:
   - type: SET
     key: hook.craftengine

--- a/code/core/src/main/resources/config.yml
+++ b/code/core/src/main/resources/config.yml
@@ -80,7 +80,7 @@ npc:
   accept_left_click: false
   interaction_limit: 500
 hologram:
-  default: DecentHolograms,HolographicDisplays
+  default: DecentHolograms,FancyHolograms,HolographicDisplays
   update_interval: 200
 hider:
   player_update_interval: 20
@@ -154,3 +154,4 @@ hook:
   craftengine: true
   itemsadder: true
   nexo: true
+  fancyholograms: true

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/FancyHolograms.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/FancyHolograms.md
@@ -1,0 +1,9 @@
+# [FancyHolograms](https://modrinth.com/plugin/fancyholograms)
+
+!!! info ""
+    **Required FancyHolograms version: _2.8.0_ or above, but below _3.0.0_**
+
+Please note that this integration requires [PlaceholderAPI](../Administration/PlaceholderAPI.md).
+
+!!! info
+    FancyHolograms integration supports [BetonQuest Hologram](./index.md) features.

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/HolographicDisplays.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/HolographicDisplays.md
@@ -1,4 +1,4 @@
-# [HolographicDisplays](https://dev.bukkit.org/projects/holographic-displays).
+# [HolographicDisplays](https://dev.bukkit.org/projects/holographic-displays)
 
 This is an older hologram plugin.
 

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/index.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/index.md
@@ -8,12 +8,15 @@ tags:
 
 This feature can be activated by installing any of the following hologram plugins:
 
-| Plugin                                           | Required Version | Additional Dependencies                                                         |
-|--------------------------------------------------|------------------|---------------------------------------------------------------------------------|
-| [DecentHolograms](./DecentHolograms.md)          | 2.7.5 or above   | [PlaceholderAPI](../Administration/PlaceholderAPI.md) for in-line placeholders. |
-| [Holographic Displays](./HolographicDisplays.md) | 3.0.0 or above   | None                                                                            |
+| Plugin                                           | Required Version                | Additional Dependencies                                                         |
+|--------------------------------------------------|---------------------------------|---------------------------------------------------------------------------------|
+| [DecentHolograms](./DecentHolograms.md)          | 2.7.5 or above                  | [PlaceholderAPI](../Administration/PlaceholderAPI.md) for in-line placeholders. |
+| [FancyHolograms](./FancyHolograms.md)            | 2.8.0 or above, but below 3.0.0 | [PlaceholderAPI](../Administration/PlaceholderAPI.md) for in-line placeholders. |
+| [Holographic Displays](./HolographicDisplays.md) | 3.0.0 or above                  | None                                                                            |
 
-If you have both plugins installed, you can use the [`hologram.default` option in the "_config.yml_"](../../../../Configuration/Plugin-Config.md#hologram-hologram-settings) to set which plugin should be used.
+If you have more than one installed, you can use the
+[`hologram.default` option in the "_config.yml_"](../../../../Configuration/Plugin-Config.md#hologram-hologram-settings)
+to set which plugin should be used.
 
 ### NPC Holograms
 ```YAML title="Example"

--- a/docs/_snippets/constants.yml
+++ b/docs/_snippets/constants.yml
@@ -1,1 +1,1 @@
-totalIntegratedPluginsNumber: "45"
+totalIntegratedPluginsNumber: "46"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
               - 'Holograms':
                   - 'Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/index.md'
                   - 'DecentHolograms': Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/DecentHolograms.md
+                  - 'FancyHolograms': Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/FancyHolograms.md
                   - 'HolographicDisplays': Documentation/Scripting/Building-Blocks/Integrations-List/Holograms/HolographicDisplays.md
               - 'Visuals':
                   - 'Documentation/Scripting/Building-Blocks/Integrations-List/Visuals/index.md'


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Since it does not have a combined method of setting lines and items I manually used the values you can configure in DecentHolograms.
The biggest difference to DH is the items do not have extra spacing, so you need an empty line abovethem to not have the text in them. Also I removed the holograms background.

I would like to have some config options like the menu io but I think that does not belong to the general config.yml and thus will not be an option right now but only the base implementation.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
