### PR TITLE
Use brew event result to check for changes instead delaying by one tick 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `menu` conv io no longer ignores canceled events to process as input
 - `citizens` npc hiding now uses the inbuilt player filter trait
 - `global` property for objectives renamed to `auto-once`
+- `brew` objective now checks brewed items in a more accurate way
 ### Deprecated
 ### Removed
 - undocumented prefix feature in conversation

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
@@ -15,7 +15,6 @@ import org.bukkit.block.BrewingStand;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -117,11 +116,13 @@ public class BrewObjective extends CountingObjective {
             return;
         }
         final QuestItem potion = this.potion.getValue(profile).getItem(profile);
-        final boolean[] newlyDone = getMatchingPotions(potion, event.getResults(), event.getContents());
+        final List<ItemStack> results = event.getResults();
+        final ItemStack[] currentContents = event.getContents().getStorageContents();
 
         int progress = 0;
-        for (final boolean brewed : newlyDone) {
-            if (brewed) {
+        for (int index = 0; index < Math.min(results.size(), 3); index++) {
+            if (!results.get(index).equals(currentContents[index])
+                    && potion.matches(currentContents[index])) {
                 progress++;
             }
         }
@@ -137,23 +138,5 @@ public class BrewObjective extends CountingObjective {
                 removals.forEach(locations::remove);
             }
         }
-    }
-
-    /**
-     * Generates an array that matches potions in slots to if they are match the quest item. A filter array can be
-     * provided that excludes all indices that are {@code true}.
-     *
-     * @param newly     the result items
-     * @param inventory the brewer inventory containing the old items
-     * @return array mapping slot index to potion match
-     */
-    private boolean[] getMatchingPotions(final QuestItem potion, final List<ItemStack> newly, final BrewerInventory inventory) {
-        final boolean[] resultPotions = new boolean[3];
-        final ItemStack[] storageContents = inventory.getStorageContents();
-        for (int index = 0; index < Math.min(newly.size(), 3); index++) {
-            resultPotions[index] = !newly.get(index).equals(storageContents[index])
-                    && potion.matches(storageContents[index]);
-        }
-        return resultPotions;
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/brew/BrewObjective.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -116,48 +117,41 @@ public class BrewObjective extends CountingObjective {
             return;
         }
         final QuestItem potion = this.potion.getValue(profile).getItem(profile);
-        final boolean[] alreadyDone = getMatchingPotions(potion, event.getContents());
+        final boolean[] newlyDone = getMatchingPotions(potion, event.getResults(), event.getContents());
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                final boolean[] newlyDone = getMatchingPotions(potion, event.getContents(), alreadyDone);
-
-                int progress = 0;
-                for (final boolean brewed : newlyDone) {
-                    if (brewed) {
-                        progress++;
-                    }
-                }
-
-                if (progress > 0) {
-                    getCountingData(profile).progress(progress);
-                    final boolean completed = completeIfDoneOrNotify(profile);
-                    if (completed) {
-                        final Set<Location> removals = locations.entrySet().stream()
-                                .filter(location -> profile.equals(location.getValue()))
-                                .map(Map.Entry::getKey)
-                                .collect(Collectors.toSet());
-                        removals.forEach(locations::remove);
-                    }
-                }
+        int progress = 0;
+        for (final boolean brewed : newlyDone) {
+            if (brewed) {
+                progress++;
             }
-        }.runTask(plugin);
+        }
+
+        if (progress > 0) {
+            getCountingData(profile).progress(progress);
+            final boolean completed = completeIfDoneOrNotify(profile);
+            if (completed) {
+                final Set<Location> removals = locations.entrySet().stream()
+                        .filter(location -> profile.equals(location.getValue()))
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toSet());
+                removals.forEach(locations::remove);
+            }
+        }
     }
 
     /**
      * Generates an array that matches potions in slots to if they are match the quest item. A filter array can be
      * provided that excludes all indices that are {@code true}.
      *
-     * @param inventory  the brewer inventory to check
-     * @param exclusions the excluded indices
+     * @param newly     the result items
+     * @param inventory the brewer inventory containing the old items
      * @return array mapping slot index to potion match
      */
-    private boolean[] getMatchingPotions(final QuestItem potion, final BrewerInventory inventory, final boolean... exclusions) {
+    private boolean[] getMatchingPotions(final QuestItem potion, final List<ItemStack> newly, final BrewerInventory inventory) {
         final boolean[] resultPotions = new boolean[3];
         final ItemStack[] storageContents = inventory.getStorageContents();
-        for (int index = 0; index < 3; index++) {
-            resultPotions[index] = (exclusions.length <= index || !exclusions[index])
+        for (int index = 0; index < Math.min(newly.size(), 3); index++) {
+            resultPotions[index] = !newly.get(index).equals(storageContents[index])
                     && potion.matches(storageContents[index]);
         }
         return resultPotions;


### PR DESCRIPTION
<!-- Please describe your changes here. -->
this allows the input brew be a valid brew as well and counting it (only when it also changes)

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
