### PR TITLE
Add scale boolean to MMOItem which was missed on its migration

### DIFF
--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOQuestItemFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOQuestItemFactory.java
@@ -32,7 +32,8 @@ public class MMOQuestItemFactory implements TypeFactory<QuestItemWrapper> {
     public QuestItemWrapper parseInstruction(final Instruction instruction) throws QuestException {
         final Argument<Type> itemType = instruction.parse(MMOItemsUtils::getMMOItemType).get();
         final Argument<String> itemId = instruction.string().get();
+        final FlagArgument<Boolean> scale = instruction.bool().getFlag("scale", true);
         final FlagArgument<Number> soulBound = instruction.number().getFlag("soulBound", 1);
-        return new MMOQuestItemWrapper(mmoPlugin, itemType, itemId, soulBound);
+        return new MMOQuestItemWrapper(mmoPlugin, itemType, itemId, scale, soulBound);
     }
 }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOQuestItemWrapper.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmoitems/MMOQuestItemWrapper.java
@@ -35,6 +35,11 @@ public class MMOQuestItemWrapper implements QuestItemWrapper {
     private final Argument<String> itemId;
 
     /**
+     * Whether to scale the item with the player.
+     */
+    private final FlagArgument<Boolean> scale;
+
+    /**
      * Whether to add the soul bound stat to the generated item.
      */
     private final FlagArgument<Number> soulBound;
@@ -45,13 +50,15 @@ public class MMOQuestItemWrapper implements QuestItemWrapper {
      * @param mmoPlugin the mmo items plugin instance to get the item
      * @param itemType  the item type
      * @param itemId    the item id
+     * @param scale     whether to scale the item with the player
      * @param soulBound whether to add the soul bound stat to the generated item
      */
     public MMOQuestItemWrapper(final MMOItems mmoPlugin, final Argument<Type> itemType, final Argument<String> itemId,
-                               final FlagArgument<Number> soulBound) {
+                               final FlagArgument<Boolean> scale, final FlagArgument<Number> soulBound) {
         this.mmoPlugin = mmoPlugin;
         this.itemType = itemType;
         this.itemId = itemId;
+        this.scale = scale;
         this.soulBound = soulBound;
     }
 
@@ -60,7 +67,7 @@ public class MMOQuestItemWrapper implements QuestItemWrapper {
         final Type type = itemType.getValue(profile);
         final String identifier = itemId.getValue(profile);
         final MMOItem item;
-        if (profile == null) {
+        if (profile == null || !scale.getValue(profile).orElse(false)) {
             item = mmoPlugin.getMMOItem(type, identifier);
         } else {
             item = mmoPlugin.getMMOItem(type, identifier, PlayerData.get(profile.getPlayerUUID()));

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/MMOItems.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/MMOItems.md
@@ -7,6 +7,7 @@
 MMOItems usage is integrated to the [Items](../../../../Features/Items.md) system and thus used for actions and 
 conditions.
 
+The item can be adjusted to the players level by adding the `scale` option.  
 The [`soulbound`](https://docs.phoenixdevt.fr/mmoitems/features/soulbound.html) keyword can be used
 with an optional `amount`, defaulting to `1`.  
 In addition, you can also add `quest-item` argument to tag them as "QuestItem".
@@ -14,7 +15,7 @@ In addition, you can also add `quest-item` argument to tag them as "QuestItem".
 ```YAML title="Example"
 items:
   crown: "mmoitem ARMOR SKELETON_CROWN"
-  boundBoot: "mmoitem ARMOR TRAVELERS_BOOTS soulbound:100"
+  boundBoot: "mmoitem ARMOR TRAVELERS_BOOTS scale soulbound:100"
   gem: "mmoitem GEMS SPEED_GEM quest-item"
 conditions:
   hasCrown: "hand crown"


### PR DESCRIPTION
<!-- Please describe your changes here. -->
The function was there but no way to disable it.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
