### PR TITLE
Update download logic to include version in filenames

### DIFF
--- a/.github/scripts/discord.sh
+++ b/.github/scripts/discord.sh
@@ -75,7 +75,7 @@ case "$JOB_STATUS" in
     EMBED_COLOR=3066993
     DEV_BUILD_DOWNLOAD="Click to Download $VERSION!"
     STATUS_MESSAGE="$RELEASE_NAME is now available"
-    BUILD_DOWNLOAD_URL="${DOCS_URL}${DOCS_VERSION}/Downloads/?path=$UPLOAD_PATH&filename=BetonQuest.jar"
+    BUILD_DOWNLOAD_URL="${DOCS_URL}${DOCS_VERSION}/Downloads/?path=$UPLOAD_PATH&filename=BetonQuest-$VERSION.jar"
     DESCRIPTION="${RELEASE_NAME}s available [HERE](${RELEASE_DOWNLOAD_URL}). Report bugs [HERE](https://github.com/BetonQuest/BetonQuest/issues)"
     COMMIT_ICON="$RELEASE_COMMIT_ICON_SUCCESS"
     ;;

--- a/code/core/src/main/java/org/betonquest/betonquest/BetonQuest.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/BetonQuest.java
@@ -88,7 +88,7 @@ public class BetonQuest extends JavaPlugin {
         this.coreComponentLoader.init(IntegrationManager.class, integrationManager);
 
         initPluginDependencies(coreComponentLoader);
-        BetonQuestComponents.createDefaults(this.getFile()).forEach(coreComponentLoader::register);
+        BetonQuestComponents.createDefaults().forEach(coreComponentLoader::register);
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/BetonQuestComponents.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/BetonQuestComponents.java
@@ -60,9 +60,7 @@ import org.betonquest.betonquest.kernel.component.types.PlaceholderTypeComponent
 import org.betonquest.betonquest.kernel.component.types.ScheduleTypesComponent;
 import org.betonquest.betonquest.kernel.component.types.TextParserTypesComponent;
 import org.betonquest.betonquest.lib.dependency.component.RequirementComponentWrapper;
-import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -78,12 +76,11 @@ public final class BetonQuestComponents {
     /**
      * Create a set of all default components.
      *
-     * @param betonQuestPluginFile the plugin file of BetonQuest obtained through {@link JavaPlugin#getFile()}.
      * @return a set of all default components
      */
-    public static Set<CoreComponent> createDefaults(final File betonQuestPluginFile) {
+    public static Set<CoreComponent> createDefaults() {
         return Set.of(createEssentials(), createDefaultFeatures(), createDefaultTypes(),
-                        createAdditionalFeatures(betonQuestPluginFile), createIntegrationsAndAPI())
+                        createAdditionalFeatures(), createIntegrationsAndAPI())
                 .stream().flatMap(Set::stream).collect(Collectors.toSet());
     }
 
@@ -137,7 +134,7 @@ public final class BetonQuestComponents {
         );
     }
 
-    private static Set<CoreComponent> createAdditionalFeatures(final File betonQuestPluginFile) {
+    private static Set<CoreComponent> createAdditionalFeatures() {
         return Set.of(
                 new BStatsMetricsComponent(),
                 new VersionInfoComponent(),
@@ -146,7 +143,7 @@ public final class BetonQuestComponents {
                 new PostEnableComponent(),
                 new LogHandlerComponent(),
                 new FontRegistryComponent(),
-                new UpdaterComponent(betonQuestPluginFile),
+                new UpdaterComponent(),
                 new PlayerHiderComponent(),
                 new ConversationColorsComponent(),
                 new ExecutionCacheComponent(),

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/UpdaterComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/UpdaterComponent.java
@@ -23,10 +23,8 @@ import org.betonquest.betonquest.web.updater.source.implementations.ReposiliteRe
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 
-import java.io.File;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.Set;
@@ -62,18 +60,10 @@ public class UpdaterComponent extends AbstractCoreComponent {
     public static final String REPO_API_URL = "https://api.github.com/repos/BetonQuest/BetonQuest";
 
     /**
-     * The plugin file sourced from {@link JavaPlugin}.
-     */
-    private final File pluginFile;
-
-    /**
      * Creates a new UpdaterComponent.
-     *
-     * @param pluginFile the plugin file
      */
-    public UpdaterComponent(final File pluginFile) {
+    public UpdaterComponent() {
         super();
-        this.pluginFile = pluginFile;
     }
 
     @Override
@@ -97,10 +87,8 @@ public class UpdaterComponent extends AbstractCoreComponent {
         final BetonQuestLoggerFactory loggerFactory = getDependency(BetonQuestLoggerFactory.class);
         final Reloader reloader = getDependency(Reloader.class);
 
-        final File updateFolder = server.getUpdateFolderFile();
-        final File file = new File(updateFolder, pluginFile.getName());
         final DownloadSource downloadSource = new TempFileDownloadSource(new WebDownloadSource());
-        final UpdateDownloader updateDownloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader updateDownloader = new UpdateDownloader(downloadSource, server.getUpdateFolderFile(), plugin.getDescription());
         final ReposiliteReleaseAndDevelopmentSource reposiliteReleaseAndDevelopmentSource =
                 new ReposiliteReleaseAndDevelopmentSource(REPOSILITE_URL, REPOSITORY_NAME, POM_MAPPER_ID, new WebContentSource());
         final GitHubReleaseSource gitHubReleaseSource = new GitHubReleaseSource(REPO_API_URL, new WebContentSource(GitHubReleaseSource.HTTP_CODE_HANDLER));

--- a/code/core/src/main/java/org/betonquest/betonquest/web/updater/UpdateDownloader.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/web/updater/UpdateDownloader.java
@@ -1,7 +1,9 @@
 package org.betonquest.betonquest.web.updater;
 
 import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.version.Version;
 import org.betonquest.betonquest.web.DownloadSource;
+import org.bukkit.plugin.PluginDescriptionFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,9 +24,14 @@ public class UpdateDownloader {
     private final DownloadSource downloadSource;
 
     /**
-     * The final {@link File} for the download.
+     * The folder where the update jar will be saved.
      */
-    private final File file;
+    private final File updateFolder;
+
+    /**
+     * The plugin description to get the plugin name from.
+     */
+    private final PluginDescriptionFile pluginDescriptionFile;
 
     /**
      * A flag to check if the download is currently running.
@@ -34,29 +41,33 @@ public class UpdateDownloader {
     /**
      * Creates a new {@link UpdateDownloader} with the given file locations.
      *
-     * @param downloadSource The {@link DownloadSource} to use.
-     * @param file           The final {@link File} for the download.
+     * @param downloadSource        The {@link DownloadSource} to use.
+     * @param updateFolder          The folder where the update jar will be saved.
+     * @param pluginDescriptionFile The plugin description to get the plugin name from.
      */
-    public UpdateDownloader(final DownloadSource downloadSource, final File file) {
+    public UpdateDownloader(final DownloadSource downloadSource, final File updateFolder,
+                            final PluginDescriptionFile pluginDescriptionFile) {
         this.downloadSource = downloadSource;
-        this.file = file;
+        this.updateFolder = updateFolder;
+        this.pluginDescriptionFile = pluginDescriptionFile;
         this.currentlyDownloading = new AtomicBoolean(false);
     }
 
     /**
      * Downloads a given URL to the chosen file from the constructor.
      *
-     * @param url The {@link URL} where to download this jar from
+     * @param version The version of the update to download
+     * @param url     The {@link URL} where to download this jar from
      * @throws QuestException Is thrown if there was any exception during the download process.
      */
-    public void downloadToFile(final URL url) throws QuestException {
-        checkAndCreateFolder(file.getParentFile());
+    public void downloadToFile(final Version version, final URL url) throws QuestException {
+        checkAndCreateFolder(updateFolder);
         try {
             final boolean runningDownload = currentlyDownloading.compareAndSet(false, true);
             if (!runningDownload) {
                 throw new QuestException("The updater is already downloading the update! Please wait until it is finished!");
             }
-            downloadSource.get(url, file);
+            downloadSource.get(url, getUpdateFile(version));
         } catch (final IOException e) {
             throw new QuestException("The download was interrupted! The updater could not download the file!"
                     + " You can try it again, if it still does not work use a manual download."
@@ -69,15 +80,20 @@ public class UpdateDownloader {
     /**
      * Checks if the final {@link File} was already downloaded, by checking for its existence.
      *
+     * @param version The version of the update to check
      * @return true if a successful download was already done
      */
-    public boolean alreadyDownloaded() {
-        return file.exists();
+    public boolean alreadyDownloaded(final Version version) {
+        return getUpdateFile(version).exists();
     }
 
     private void checkAndCreateFolder(final File file) throws QuestException {
         if (!file.exists() && !file.mkdirs()) {
             throw new QuestException("The updater could not create the folder '" + file.getAbsolutePath() + "'!");
         }
+    }
+
+    private File getUpdateFile(final Version version) {
+        return new File(updateFolder, pluginDescriptionFile.getName() + "-" + version + ".jar");
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/web/updater/Updater.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/web/updater/Updater.java
@@ -248,7 +248,7 @@ public class Updater {
                     + getUpdateVersion() + "'! You can execute '/bq update' again to update.");
         }
         if (latest.getValue() == null) {
-            if (updateDownloader.alreadyDownloaded()) {
+            if (updateDownloader.alreadyDownloaded(latest.getKey())) {
                 throw new QuestException("The update was already downloaded! Restart the server to update the plugin.");
             }
             throw new QuestException("The updater did not find an update!"
@@ -258,7 +258,7 @@ public class Updater {
 
     private void executeUpdate() throws QuestException {
         try {
-            updateDownloader.downloadToFile(new URL(latest.getValue()));
+            updateDownloader.downloadToFile(latest.getKey(), new URL(latest.getValue()));
             latest = Pair.of(latest.getKey(), null);
         } catch (final MalformedURLException e) {
             throw new QuestException("There was an error resolving the url '" + latest.getValue() + "'! Reason: " + e.getMessage(), e);

--- a/code/core/src/test/java/org/betonquest/betonquest/kernel/BetonQuestComponentsIT.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/kernel/BetonQuestComponentsIT.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.File;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,7 @@ class BetonQuestComponentsIT {
 
     @BeforeEach
     void setUp() {
-        this.components = BetonQuestComponents.createDefaults(new File("test.jar"));
+        this.components = BetonQuestComponents.createDefaults();
     }
 
     @Test
@@ -60,7 +59,7 @@ class BetonQuestComponentsIT {
 
         @Test
         void invalidate_blocking_dependencies() {
-            final Set<CoreComponent> modifiedComponents = BetonQuestComponents.createDefaults(new File("test.jar"));
+            final Set<CoreComponent> modifiedComponents = BetonQuestComponents.createDefaults();
             modifiedComponents.removeIf(comp -> comp instanceof QuestPackageManagerComponent);
             assertThrows(IllegalStateException.class, () -> DependencyHelper.topologicalOrder(modifiedComponents, loadedDependencies), "Missing dependencies should be detected");
         }

--- a/code/core/src/test/java/org/betonquest/betonquest/web/updater/UpdateDownloaderTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/web/updater/UpdateDownloaderTest.java
@@ -1,7 +1,11 @@
 package org.betonquest.betonquest.web.updater;
 
 import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.version.Version;
+import org.betonquest.betonquest.lib.version.BetonQuestVersion;
 import org.betonquest.betonquest.web.DownloadSource;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -22,51 +26,64 @@ import static org.mockito.Mockito.*;
  */
 class UpdateDownloaderTest {
 
+    /**
+     * The plugin description file used for testing.
+     */
+    private static final PluginDescriptionFile PLUGIN_DESCRIPTION_FILE = mock(PluginDescriptionFile.class);
+
+    /**
+     * The version used for testing.
+     */
+    private static final Version VERSION = BetonQuestVersion.parse("1.2.3");
+
+    @BeforeAll
+    static void setup() {
+        when(PLUGIN_DESCRIPTION_FILE.getName()).thenReturn("BetonQuest");
+    }
+
     @Test
     void testDownloadFile(@TempDir final File tempDir) throws IOException, QuestException {
-        final File file = new File(tempDir, "BetonQuest.jar");
+        final File file = new File(tempDir, "BetonQuest-1.2.3.jar");
         final URL url = mock(URL.class);
         final DownloadSource downloadSource = mock(DownloadSource.class);
-        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, tempDir, PLUGIN_DESCRIPTION_FILE);
 
-        downloader.downloadToFile(url);
+        downloader.downloadToFile(VERSION, url);
         verify(downloadSource, times(1)).get(url, file);
     }
 
     @Test
     void testDownloadFileAlreadyExists(@TempDir final File tempDir) throws IOException {
-        final File file = new File(tempDir, "BetonQuest.jar");
+        final File file = new File(tempDir, "BetonQuest-1.2.3.jar");
         final DownloadSource downloadSource = mock(DownloadSource.class);
-        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, tempDir, PLUGIN_DESCRIPTION_FILE);
 
-        assertFalse(downloader.alreadyDownloaded(), "There shouldn't be a BetonQuest.jar file");
+        assertFalse(downloader.alreadyDownloaded(VERSION), "There shouldn't be a BetonQuest.jar file");
         Files.createFile(file.toPath());
-        assertTrue(downloader.alreadyDownloaded(), "There should be a BetonQuest.jar file");
+        assertTrue(downloader.alreadyDownloaded(VERSION), "There should be a BetonQuest.jar file");
     }
 
     @Test
     void testExceptionOnDownload(@TempDir final File tempDir) throws IOException {
-        final File file = new File(tempDir, "BetonQuest.jar");
+        final File file = new File(tempDir, "BetonQuest-1.2.3.jar");
         final URL url = mock(URL.class);
         final DownloadSource downloadSource = mock(DownloadSource.class);
         doThrow(new IOException("Test Exception")).when(downloadSource).get(url, file);
-        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, tempDir, PLUGIN_DESCRIPTION_FILE);
 
-        final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(url), "Expected QuestException");
+        final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(VERSION, url), "Expected QuestException");
         assertEquals("The download was interrupted! The updater could not download the file! You can try it again, if it still does not work use a manual download. The original exception was: Test Exception", exception.getMessage(), "Expected exception message does not Match");
     }
 
     @Test
     void testExceptionOnFolderCreation(@TempDir final File tempDir) {
         final File updateFolder = spy(new File(tempDir, "updater"));
-        final File file = spy(new File(updateFolder, "BetonQuest.jar"));
         final DownloadSource downloadSource = mock(DownloadSource.class);
-        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, updateFolder, PLUGIN_DESCRIPTION_FILE);
 
-        when(file.getParentFile()).thenReturn(updateFolder);
         doReturn(false).when(updateFolder).mkdirs();
 
-        final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(mock(URL.class)), "Expected QuestException");
+        final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(mock(Version.class), mock(URL.class)), "Expected QuestException");
         assertEquals("The updater could not create the folder '" + updateFolder.getAbsolutePath() + "'!", exception.getMessage(), "Expected exception message does not Match");
     }
 
@@ -77,10 +94,9 @@ class UpdateDownloaderTest {
     void testConcurrentDownloads(@TempDir final File tempDir) throws IOException, InterruptedException {
         final ExecutorService service = Executors.newFixedThreadPool(1);
 
-        final File file = new File(tempDir, "BetonQuest.jar");
         final URL url = mock(URL.class);
         final DownloadSource downloadSource = mock(DownloadSource.class);
-        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, file);
+        final UpdateDownloader downloader = new UpdateDownloader(downloadSource, tempDir, PLUGIN_DESCRIPTION_FILE);
 
         final Semaphore semaphore = new Semaphore(0);
         final CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -88,17 +104,17 @@ class UpdateDownloaderTest {
             countDownLatch.countDown();
             semaphore.acquire();
             return null;
-        }).when(downloadSource).get(url, file);
+        }).when(downloadSource).get(any(), any());
         try {
             service.execute(() -> {
                 try {
-                    downloader.downloadToFile(url);
+                    downloader.downloadToFile(VERSION, url);
                 } catch (final QuestException e) {
                     throw new IllegalStateException(e);
                 }
             });
             countDownLatch.await();
-            final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(url), "Expected QuestException");
+            final QuestException exception = assertThrows(QuestException.class, () -> downloader.downloadToFile(VERSION, url), "Expected QuestException");
             assertEquals("The updater is already downloading the update! Please wait until it is finished!", exception.getMessage(), "Expected exception message does not Match");
         } finally {
             semaphore.release();

--- a/code/core/src/test/java/org/betonquest/betonquest/web/updater/UpdaterTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/web/updater/UpdaterTest.java
@@ -293,8 +293,8 @@ class UpdaterTest {
         final BetonQuest plugin = mock(BetonQuest.class);
         final InstantSource instantSource = InstantSource.system();
 
-        when(handler.searchUpdate(any(), any())).thenReturn(Pair.of(BetonQuestVersion.parse("2.0.0-DEV-3"), null));
-        when(downloader.alreadyDownloaded()).thenReturn(true);
+        when(handler.searchUpdate(any(), any())).thenReturn(Pair.of(version, null));
+        when(downloader.alreadyDownloaded(version)).thenReturn(true);
 
         final UpdaterConfigTest.Input patchDev = new UpdaterConfigTest.Input(null, true, false, "PATCH_DEV", false);
         final UpdaterConfig updaterConfig = UpdaterConfigTest.getMockedConfig(logger, patchDev, version);

--- a/docs/_webCode/js/downloads.js
+++ b/docs/_webCode/js/downloads.js
@@ -32,10 +32,11 @@ document$.subscribe(async () => {
   async function loadBuilds(idKey, builds) {
     const latestBuild = document.getElementsByClassName("download-latest-" + idKey)[0];
     if (builds.length > 0) {
-      latestBuild.textContent = builds[0].version;
+      const version = builds[0].version;
+      latestBuild.textContent = version;
       const downloadUrl = builds[0].downloadUrl;
       latestBuild.onclick = function () {
-        downloadWithRename(downloadUrl, "BetonQuest.jar");
+        downloadWithRename(downloadUrl, "BetonQuest-" + version + ".jar");
       };
       resetDisabled(latestBuild);
     } else {
@@ -56,10 +57,11 @@ document$.subscribe(async () => {
         const li = document.createElement("li");
         li.style.cssText = "padding: 0";
         const a = document.createElement("a");
-        a.textContent = build.version;
+        const version = build.version;
+        a.textContent = version;
         a.href = "#";
         a.onclick = function () {
-          downloadWithRename(build.downloadUrl, "BetonQuest.jar");
+          downloadWithRename(build.downloadUrl, "BetonQuest-" + version + ".jar");
         };
         a.style.cssText = "width: 100%; text-align: center;";
         a.classList.add("md-button");


### PR DESCRIPTION
- Appended version number to `.jar` filenames during download operations.
- Adjusted Discord build download URLs to reflect the updated filename format.

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
