### PR TITLE
Integrate dummy class `FictiveTime` into test classes to prevent checkstyle violations

### DIFF
--- a/code/core/src/test/java/org/betonquest/betonquest/api/schedule/FictiveTime.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/schedule/FictiveTime.java
@@ -1,8 +1,0 @@
-package org.betonquest.betonquest.api.schedule;
-
-/**
- * Fictive time class used for testing.
- */
-public record FictiveTime() {
-
-}

--- a/code/core/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/schedule/SchedulerTest.java
@@ -99,4 +99,11 @@ class SchedulerTest {
             return new FictiveTime();
         }
     }
+
+    /**
+     * Fictive time class used for testing.
+     */
+    public record FictiveTime() {
+
+    }
 }

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/ActionSchedulingTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/ActionSchedulingTest.java
@@ -11,7 +11,6 @@ import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.schedule.CatchupStrategy;
-import org.betonquest.betonquest.api.schedule.FictiveTime;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.api.service.instruction.Instructions;
@@ -220,5 +219,12 @@ class ActionSchedulingTest {
         public MockedSchedule createNewInstance(final ScheduleIdentifier scheduleID, final SectionInstruction instruction) {
             return new MockedSchedule(scheduleID, List.of(), CatchupStrategy.NONE);
         }
+    }
+
+    /**
+     * Fictive time class used for testing.
+     */
+    public record FictiveTime() {
+
     }
 }

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/ScheduleTypeTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/ScheduleTypeTest.java
@@ -14,7 +14,6 @@ import org.betonquest.betonquest.api.instruction.section.SectionInstruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.schedule.CatchupStrategy;
-import org.betonquest.betonquest.api.schedule.FictiveTime;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.schedule.Scheduler;
 import org.betonquest.betonquest.api.service.identifier.Identifiers;
@@ -216,5 +215,12 @@ class ScheduleTypeTest {
             final ScheduleData scheduleData = parseScheduleData(instruction);
             return new ThrowingUncheckedSchedule(scheduleID, scheduleData.actions(), scheduleData.catchup());
         }
+    }
+
+    /**
+     * Fictive time class used for testing.
+     */
+    public record FictiveTime() {
+
     }
 }

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/ExecutorServiceSchedulerTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/ExecutorServiceSchedulerTest.java
@@ -2,7 +2,6 @@ package org.betonquest.betonquest.schedule.impl;
 
 import org.betonquest.betonquest.api.identifier.ScheduleIdentifier;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
-import org.betonquest.betonquest.api.schedule.FictiveTime;
 import org.betonquest.betonquest.api.schedule.Schedule;
 import org.betonquest.betonquest.api.service.action.ActionManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,5 +129,12 @@ class ExecutorServiceSchedulerTest {
         verify(logger, times(1)).error(eq("Error while stopping scheduler"), any(TimeoutException.class));
         verify(logger, times(1)).debug("Stop complete.");
         verifyNoMoreInteractions(logger);
+    }
+
+    /**
+     * Fictive time class used for testing.
+     */
+    public record FictiveTime() {
+
     }
 }


### PR DESCRIPTION
Integrate dummy class `FictiveTime` into test classes to prevent checkstyle violations, since it's the path of minimal change.
Changes to checkstyle either reduce it's effectiveness or require a ton of configuration changes - as well as changes to two projects.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
