### PR TITLE
Add MultiLineChart for version types to bstats metrics

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/bstats/BStatsMetrics.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/bstats/BStatsMetrics.java
@@ -5,15 +5,19 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.identifier.ReadableIdentifier;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.service.instruction.Instructions;
+import org.betonquest.betonquest.api.version.Version;
 import org.betonquest.betonquest.compatibility.Compatibility;
+import org.betonquest.betonquest.lib.version.BetonQuestVersion;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
 import org.bstats.charts.DrilldownPie;
+import org.bstats.charts.MultiLineChart;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -67,6 +71,10 @@ public class BStatsMetrics {
 
         metrics.addCustomChart(new DrilldownPie("versionMcBq", () -> getDrillDownPie(versionPlugin, versionMc)));
         metrics.addCustomChart(new DrilldownPie("versionBqMc", () -> getDrillDownPie(versionMc, versionPlugin)));
+
+        final Version betonQuestVersion = BetonQuestVersion.parse(versionPlugin);
+        final String versionType = betonQuestVersion.getNamedElement("type").orElse("other").toLowerCase(Locale.ROOT);
+        metrics.addCustomChart(new MultiLineChart("versionTypes", () -> Map.of(versionType, 1)));
     }
 
     private Map<String, Map<String, Integer>> getDrillDownPie(final String firstValue, final String secondValue) {

--- a/code/core/src/test/java/org/betonquest/betonquest/bstats/BStatsMetricsTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/bstats/BStatsMetricsTest.java
@@ -161,10 +161,10 @@ class BStatsMetricsTest {
 
         new BStatsMetrics(plugin, bstatsMetrics, Map.of("id", metricsSupplier), mock(Compatibility.class), instructionApi);
 
-        verify(bstatsMetrics, times(6)).addCustomChart(chartArgumentCaptor.capture());
+        verify(bstatsMetrics, times(7)).addCustomChart(chartArgumentCaptor.capture());
         final List<CustomChart> customCharts = chartArgumentCaptor.getAllValues();
-        final CustomChart countChart = customCharts.get(2);
-        final CustomChart enabledChart = customCharts.get(3);
+        final CustomChart countChart = customCharts.get(3);
+        final CustomChart enabledChart = customCharts.get(4);
 
         assertCollectedChartData("{\"chartId\":\"idCount\",\"data\":{\"values\":{\"test\":1}}}", countChart);
         assertCollectedChartData("{\"chartId\":\"idEnabled\",\"data\":{\"values\":{\"test\":1}}}", enabledChart);


### PR DESCRIPTION
Trying out the MultiLineChart with bstats while offering helpful information for release cycles: version type usage.

We will be able to see usage changes of `release`, `dev` and other version types accumulated and comparable in one graph.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
