### PR TITLE
Improve Integration of Magic - Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - new notification category `conversation_nothing_to_start`
 - `check` flag to `menu` action to respect the menu's open conditions
 - `abort` flag and `fail` actions to (chest) take action
+- item support for the integration `magic`
 ### Changed
 - Spigot is no longer supported, paper is now required 
 - message.yml file was deleted and instead the lang folder now contains all translations

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/MagicIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/MagicIntegrator.java
@@ -4,10 +4,12 @@ import com.elmakers.mine.bukkit.api.event.SpellInventoryEvent;
 import com.elmakers.mine.bukkit.api.magic.MagicAPI;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.BetonQuestApi;
-import org.betonquest.betonquest.api.integration.Integration;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.ProfileProvider;
+import org.betonquest.betonquest.compatibility.magic.item.MagicItemFactory;
+import org.betonquest.betonquest.compatibility.magic.item.MagicQuestItemSerializer;
 import org.betonquest.betonquest.data.PlayerDataStorage;
+import org.betonquest.betonquest.lib.integration.IntegrationTemplate;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -17,7 +19,7 @@ import java.util.Objects;
 /**
  * Integrator for the Magic plugin.
  */
-public class MagicIntegrator implements Integration {
+public class MagicIntegrator extends IntegrationTemplate {
 
     /**
      * The minimum required version of Magic.
@@ -28,13 +30,16 @@ public class MagicIntegrator implements Integration {
      * Creates a new Integrator.
      */
     public MagicIntegrator() {
+        super();
     }
 
     @Override
     public void enable(final BetonQuestApi api) {
         final MagicAPI magicApi = Objects.requireNonNull((MagicAPI) Bukkit.getPluginManager().getPlugin("Magic"));
-        api.conditions().registry().register("wand", new WandConditionFactory(magicApi));
+        playerCondition("wand", new WandConditionFactory(magicApi));
         api.bukkit().registerEvents(new InventoryListener(BetonQuest.getInstance().getPlayerDataStorage(), api.profiles()));
+        item("magic", new MagicItemFactory(magicApi.getController()), new MagicQuestItemSerializer(magicApi.getController()));
+        registerFeatures(api);
     }
 
     @Override

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/MagicItemFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/MagicItemFactory.java
@@ -1,0 +1,99 @@
+package org.betonquest.betonquest.compatibility.magic.item;
+
+import com.elmakers.mine.bukkit.api.item.ItemData;
+import com.elmakers.mine.bukkit.api.magic.MageController;
+import net.kyori.adventure.text.Component;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.common.function.QuestFunction;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.item.QuestItem;
+import org.betonquest.betonquest.api.item.QuestItemWrapper;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.TypeFactory;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Factory for creating Magic items.
+ */
+public class MagicItemFactory implements TypeFactory<QuestItemWrapper> {
+
+    /**
+     * The MageController instance to use.
+     */
+    private final MageController mageController;
+
+    /**
+     * Mapper to retrieve the item data from the Magic API using the item ID.
+     */
+    private final QuestFunction<String, ItemData> itemDataMapper;
+
+    /**
+     * Create a new QuestItemFactory for the Magic integration.
+     *
+     * @param mageController the MageController instance retrieved from the Magic API
+     */
+    public MagicItemFactory(final MageController mageController) {
+        this.mageController = mageController;
+        this.itemDataMapper = key -> {
+            final ItemData item = mageController.getItem(key);
+            if (item == null) {
+                throw new QuestException("Magic item not found: '" + key + "'");
+            }
+            return item;
+        };
+    }
+
+    @Override
+    public QuestItemWrapper parseInstruction(final Instruction instruction) throws QuestException {
+        final Argument<ItemData> itemData = instruction.string().map(itemDataMapper).get();
+        return profile -> {
+            final ItemData dataValue = itemData.getValue(profile);
+            final ItemStack itemStack = dataValue.getItemStack();
+            if (itemStack == null) {
+                throw new QuestException("Magic item not found: '" + dataValue.getKey() + "'");
+            }
+            return new MagicItem(mageController, itemStack, itemData);
+        };
+    }
+
+    /**
+     * Implementation of {@link QuestItem} for Magic items.
+     *
+     * @param controller the MageController instance
+     * @param itemStack  the underlying Magic item
+     * @param itemData   the item data from the Magic API
+     */
+    private record MagicItem(MageController controller, ItemStack itemStack,
+                             Argument<ItemData> itemData) implements QuestItem {
+
+        @Override
+        public Component getName() {
+            return itemStack.displayName();
+        }
+
+        @Override
+        public List<Component> getLore() {
+            final List<Component> lore = itemStack.lore();
+            return lore == null ? List.of() : lore;
+        }
+
+        @Override
+        public ItemStack generate(final int stackSize, @Nullable final Profile profile) throws QuestException {
+            final ItemData value = itemData.getValue(profile);
+            final ItemStack itemStack = value.getItemStack();
+            if (itemStack == null) {
+                throw new QuestException("Magic item not found: '" + value.getKey() + "'");
+            }
+            return itemStack;
+        }
+
+        @Override
+        public boolean matches(@Nullable final ItemStack item) {
+            return controller.itemsAreEqual(item, itemStack);
+        }
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/MagicQuestItemSerializer.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/MagicQuestItemSerializer.java
@@ -1,0 +1,31 @@
+package org.betonquest.betonquest.compatibility.magic.item;
+
+import com.elmakers.mine.bukkit.api.magic.MageController;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.item.QuestItemSerializer;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Serializes {@link ItemStack}s to their Magic IDs.
+ */
+public class MagicQuestItemSerializer implements QuestItemSerializer {
+
+    /**
+     * The MageController instance to use.
+     */
+    private final MageController mageController;
+
+    /**
+     * Create a new QuestItemSerializer for the Magic integration.
+     *
+     * @param mageController the MageController instance retrieved from the Magic API
+     */
+    public MagicQuestItemSerializer(final MageController mageController) {
+        this.mageController = mageController;
+    }
+
+    @Override
+    public String serialize(final ItemStack itemStack) throws QuestException {
+        return mageController.getItemKey(itemStack);
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/package-info.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/magic/item/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Magic item support.
+ */
+package org.betonquest.betonquest.compatibility.magic.item;

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/Magic.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/Magic.md
@@ -1,0 +1,25 @@
+# [Magic](http://dev.bukkit.org/bukkit-plugins/magic/)
+
+@snippet:versions:minimum@ _10.2_
+
+!!! info
+    Magic integration supports other features as well.
+    For those, please visit the [Magic](../MMO/Magic.md) MMO page.
+
+## Items
+
+### `Magic`
+
+Magic items are integrated to the [BetonQuest Items](../Items/index.md) system.
+
+In addition, you can also add `quest-item` argument to tag them as "QuestItem".
+
+```YAML title="Example"
+items:
+  crown: "magic KingsCrown"
+  sword: "magic SkeletonKingSword quest-item"
+conditions:
+  hasCrown: "armor crown"
+actions:
+  giveSword: "give sword"
+```

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/index.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/Items/index.md
@@ -18,6 +18,7 @@ BetonQuest provides integrations for the following items plugins:
 - [Brewery & BreweryX](./Brewery.md)
 - [CraftEngine](./CraftEngine.md)
 - [ItemsAdder](./ItemsAdder.md)
+- [Magic](./Magic.md)
 - [MMOItems](./MMOItems.md)
 - [MythicMobs](./MythicMobs.md)
 - [Nexo](./Nexo.md)

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/MMO/Magic.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/MMO/Magic.md
@@ -2,6 +2,10 @@
 
 @snippet:versions:minimum@ _10.2_
 
+!!! info
+    Magic integration supports [BetonQuest Item](../Items/index.md) features as well.
+    For those, please visit the [Magic](../Items/Magic.md) Item page.
+
 ## Conditions
 
 ### `Wand`

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/index.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/index.md
@@ -26,6 +26,7 @@ The categories are just to make it easier for you to find the plugins you're loo
     - [Brewery & BreweryX](./Items/Brewery.md)
     - [CraftEngine](./Items/CraftEngine.md)
     - [ItemsAdder](./Items/ItemsAdder.md)
+    - [Magic](./Items/Magic.md)
     - [MMOItems](./Items/MMOItems.md)
     - [MythicMobs](./Items/MythicMobs.md)
     - [Nexo](./Items/Nexo.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
                   - 'Brewery & BreweryX': Documentation/Scripting/Building-Blocks/Integrations-List/Items/Brewery.md
                   - 'CraftEngine': Documentation/Scripting/Building-Blocks/Integrations-List/Items/CraftEngine.md
                   - 'ItemsAdder': Documentation/Scripting/Building-Blocks/Integrations-List/Items/ItemsAdder.md
+                  - 'Magic': Documentation/Scripting/Building-Blocks/Integrations-List/Items/Magic.md
                   - 'MMOItems': Documentation/Scripting/Building-Blocks/Integrations-List/Items/MMOItems.md
                   - 'MythicMobs': Documentation/Scripting/Building-Blocks/Integrations-List/Items/MythicMobs.md
                   - 'Nexo': Documentation/Scripting/Building-Blocks/Integrations-List/Items/Nexo.md


### PR DESCRIPTION
Add MagicItemFactory and MagicQuestItemSerializer for Magic integration to allow magic items to be used in BetonQuest

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
