### PR TITLE
Refactor game-versions to dynamically use `>=${{ env.PLUGIN_API_VERSION }}` in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -489,9 +489,4 @@ jobs:
           loaders: 'paper'
           changelog: ${{ env.RELEASE_DESCRIPTION }}
           files: 'target/code/BetonQuest-${{ env.VERSION }}.jar'
-          game-versions: |
-            1.18.x
-            1.19.x
-            1.20.x
-            1.21.x
-            26.1.x
+          game-versions: ">=${{ env.PLUGIN_API_VERSION }}"


### PR DESCRIPTION
Wait for new release [here](https://github.com/cloudnode-pro/modrinth-publish) until PR can be merged.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
