### PR TITLE
Correctly de-/serialize firework colors in simple item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `QuestItem`s and `Journal`s could be put into bundles (MC 1.21.4+)
 - hologram integration with the lowest priority was selected instead with the highest
 - broken Conversation states no longer trap players
+- `firework` colors de-/serializing in `simple` item when there is no color
 ### Security
 
 ## [2.2.1] - 2025-01-12

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkEffectHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkEffectHandler.java
@@ -69,7 +69,7 @@ public class FireworkEffectHandler {
      * @param string the serialized firework effect data
      * @throws QuestException if the data is malformed
      */
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.AvoidLiteralsInIfCondition", "PMD.CognitiveComplexity"})
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidLiteralsInIfCondition", "PMD.CognitiveComplexity"})
     public void set(final String string) throws QuestException {
         final String[] parts = HandlerUtil.getSplit(string, "Effect is missing!", ":");
         // if "whatever" then all type checking is unnecessary
@@ -91,30 +91,8 @@ public class FireworkEffectHandler {
         if (parts.length != 5) {
             throw new QuestException("Incorrect effect format: " + string);
         }
-        if (Existence.NONE_KEY.equalsIgnoreCase(parts[1])) {
-            mainE = Existence.FORBIDDEN;
-        } else if ("?".equals(parts[1])) {
-            mainE = Existence.WHATEVER;
-        } else {
-            mainE = Existence.REQUIRED;
-            for (final String color : parts[1].split(";")) {
-                final Color regularColor = HandlerUtil.getColor(color);
-                final DyeColor fireworkColor = DyeColor.getByColor(regularColor);
-                mainColors.add(fireworkColor == null ? regularColor : fireworkColor.getFireworkColor());
-            }
-        }
-        if (Existence.NONE_KEY.equalsIgnoreCase(parts[2])) {
-            fadeE = Existence.FORBIDDEN;
-        } else if ("?".equals(parts[2])) {
-            fadeE = Existence.WHATEVER;
-        } else {
-            fadeE = Existence.REQUIRED;
-            for (final String color : parts[2].split(";")) {
-                final Color regularColor = HandlerUtil.getColor(color);
-                final DyeColor fireworkColor = DyeColor.getByColor(regularColor);
-                fadeColors.add(fireworkColor == null ? regularColor : fireworkColor.getFireworkColor());
-            }
-        }
+        mainE = colors(parts[1], mainColors);
+        fadeE = colors(parts[2], fadeColors);
         final BooleanParser booleanParser = new BooleanParser();
         if ("?".equals(parts[3])) {
             trail = Existence.WHATEVER;
@@ -126,6 +104,22 @@ public class FireworkEffectHandler {
         } else {
             flicker = booleanParser.apply(parts[4]) ? Existence.REQUIRED : Existence.FORBIDDEN;
         }
+    }
+
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
+    private Existence colors(final String part, final List<Color> colors) throws QuestException {
+        if (Existence.NONE_KEY.equalsIgnoreCase(part)) {
+            return Existence.FORBIDDEN;
+        }
+        if ("?".equals(part)) {
+            return Existence.WHATEVER;
+        }
+        for (final String color : part.split(";")) {
+            final Color regularColor = HandlerUtil.getColor(color);
+            final DyeColor fireworkColor = DyeColor.getByColor(regularColor);
+            colors.add(fireworkColor == null ? regularColor : fireworkColor.getFireworkColor());
+        }
+        return Existence.REQUIRED;
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkEffectHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkEffectHandler.java
@@ -114,10 +114,12 @@ public class FireworkEffectHandler {
         if ("?".equals(part)) {
             return Existence.WHATEVER;
         }
-        for (final String color : part.split(";")) {
-            final Color regularColor = HandlerUtil.getColor(color);
-            final DyeColor fireworkColor = DyeColor.getByColor(regularColor);
-            colors.add(fireworkColor == null ? regularColor : fireworkColor.getFireworkColor());
+        if (!part.isEmpty()) {
+            for (final String color : part.split(";")) {
+                final Color regularColor = HandlerUtil.getColor(color);
+                final DyeColor fireworkColor = DyeColor.getByColor(regularColor);
+                colors.add(fireworkColor == null ? regularColor : fireworkColor.getFireworkColor());
+            }
         }
         return Existence.REQUIRED;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/FireworkHandler.java
@@ -116,14 +116,17 @@ public class FireworkHandler implements ItemMetaHandler<FireworkMeta> {
             final DyeColor dye = DyeColor.getByFireworkColor(color);
             builder.append(dye == null ? '#' + Integer.toHexString(color.asRGB()) : dye).append(';');
         }
-        // remove last semicolon
-        builder.setLength(Math.max(builder.length() - 1, 0));
+        if (!effect.getColors().isEmpty()) {
+            builder.deleteCharAt(builder.length() - 1);
+        }
         builder.append(':');
         for (final Color color : effect.getFadeColors()) {
             final DyeColor dye = DyeColor.getByFireworkColor(color);
             builder.append(dye == null ? '#' + Integer.toHexString(color.asRGB()) : dye).append(';');
         }
-        builder.setLength(Math.max(builder.length() - 1, 0));
+        if (!effect.getFadeColors().isEmpty()) {
+            builder.deleteCharAt(builder.length() - 1);
+        }
         builder.append(':').append(effect.hasTrail()).append(':').append(effect.hasFlicker());
     }
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
There were both assumption for loading and saving the item that there must be at least one (fading) color.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
