### PR TITLE
Add Error-Tracking with FastStats

### DIFF
--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -27,7 +27,7 @@
 
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
     <bstats-bukkit.version>3.0.2</bstats-bukkit.version>
-    <faststats-bukkit.version>0.22.0</faststats-bukkit.version>
+    <faststats-bukkit.version>0.22.1</faststats-bukkit.version>
     <log4j-api.version>3.0.0-beta2</log4j-api.version>
     <log4j-core.version>3.0.0-beta2</log4j-core.version>
     <cron-utils.version>9.2.1</cron-utils.version>

--- a/code/core/src/main/java/org/betonquest/betonquest/faststats/FastStatsMetrics.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/faststats/FastStatsMetrics.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.faststats;
 
 import dev.faststats.bukkit.BukkitMetrics;
+import dev.faststats.core.ErrorTracker;
 import dev.faststats.core.Token;
 import dev.faststats.core.data.Metric;
 import org.bukkit.plugin.Plugin;
@@ -11,6 +12,11 @@ import java.util.Set;
  * The metrics handler implementation for FastStats.
  */
 public class FastStatsMetrics {
+
+    /**
+     * The error tracker to use for faststats error tracking.
+     */
+    private final ErrorTracker errorTracker;
 
     /**
      * The metrics instance to send metrics to FastStats.
@@ -29,9 +35,20 @@ public class FastStatsMetrics {
         for (final FastStatsMetricsProvider provider : metricsProviders) {
             final Set<Metric<?>> providerMetrics = provider.getMetrics();
             providerMetrics.forEach(metricsFactory::addMetric);
-            metricsFactory.onFlush(provider::metricsFlushed);
         }
-        this.metrics = metricsFactory.token(token).create(plugin);
+        metricsFactory.onFlush(() -> metricsProviders.forEach(FastStatsMetricsProvider::metricsFlushed));
+        this.errorTracker = ErrorTracker.contextAware();
+        configureErrorTracker();
+        this.metrics = metricsFactory
+                .errorTracker(errorTracker)
+                .token(token)
+                .create(plugin);
+    }
+
+    private void configureErrorTracker() {
+        errorTracker
+                .anonymize("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$", "[[E-MAIL]]")
+                .anonymize("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "[[UUID]]");
     }
 
     /**


### PR DESCRIPTION
Error tracking allows for better insights on user errors even before reporting them. They are contextualized with metrics data to allow for impact evaluation, but include no privacy breaking information due to regex-filtering.

Also update FastStats to 0.22.1.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
