### PR TITLE
Add MythicLibStatAction to allow changing player stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `abort` flag and `fail` actions to (chest) take action
 - item support for the integration `magic`
 - FastStats integration to provide better statistics for BetonQuest
+- `mmostat` action to modify the player's stats using the MythicLib (MmoLib) integration
 ### Changed
 - Spigot is no longer supported, paper is now required 
 - message.yml file was deleted and instead the lang folder now contains all translations

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibIntegrator.java
@@ -25,6 +25,7 @@ public class MythicLibIntegrator extends IntegrationTemplate {
     public void enable(final BetonQuestApi api) {
         playerCondition("stat", new MythicLibStatConditionFactory());
         objective("skill", new MythicLibSkillObjectiveFactory());
+        playerAction("stat", new MythicLibStatActionFactory());
 
         registerFeatures(api, "mmo");
     }

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibStatAction.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibStatAction.java
@@ -1,0 +1,134 @@
+package org.betonquest.betonquest.compatibility.mmogroup.mmolib;
+
+import io.lumine.mythic.lib.api.player.EquipmentSlot;
+import io.lumine.mythic.lib.api.player.MMOPlayerData;
+import io.lumine.mythic.lib.api.stat.StatInstance;
+import io.lumine.mythic.lib.api.stat.modifier.StatModifier;
+import io.lumine.mythic.lib.player.modifier.ModifierSource;
+import io.lumine.mythic.lib.player.modifier.ModifierType;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.action.PlayerAction;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Action to change a stat of a player.
+ */
+public class MythicLibStatAction implements PlayerAction {
+
+    /**
+     * The name of the stat to change.
+     */
+    @Nullable
+    private final Argument<String> statName;
+
+    /**
+     * The value to set the stat to.
+     */
+    private final Argument<Number> value;
+
+    /**
+     * The key of the stat modifier.
+     */
+    private final Argument<String> modifierKey;
+
+    /**
+     * The type of the stat modifier.
+     */
+    private final Argument<ModifierType> type;
+
+    /**
+     * The slot of the stat modifier.
+     */
+    private final Argument<EquipmentSlot> slot;
+
+    /**
+     * The source of the stat modifier.
+     */
+    private final Argument<ModifierSource> source;
+
+    /**
+     * Flag to determine whether to add the stat modifier.
+     */
+    private final FlagArgument<Boolean> add;
+
+    /**
+     * Flag to determine whether to remove the stat modifier.
+     */
+    private final FlagArgument<Boolean> remove;
+
+    /**
+     * Flag to determine whether to clear all stat modifiers by the key.
+     */
+    private final FlagArgument<Boolean> clear;
+
+    /**
+     * Constructor for the MythicLibStatAction.
+     *
+     * @param statName    the name of the stat to change
+     * @param value       the value to set the stat to
+     * @param modifierKey the key of the stat modifier
+     * @param type        the type of the stat modifier
+     * @param slot        the slot of the stat modifier
+     * @param source      the source of the stat modifier
+     * @param add         the add flag
+     * @param remove      the remove flag
+     * @param clear       the clear flag
+     */
+    public MythicLibStatAction(@Nullable final Argument<String> statName, final Argument<Number> value, final Argument<String> modifierKey,
+                               final Argument<ModifierType> type, final Argument<EquipmentSlot> slot,
+                               final Argument<ModifierSource> source, final FlagArgument<Boolean> add,
+                               final FlagArgument<Boolean> remove, final FlagArgument<Boolean> clear) {
+        this.statName = statName;
+        this.value = value;
+        this.modifierKey = modifierKey;
+        this.type = type;
+        this.slot = slot;
+        this.source = source;
+        this.add = add;
+        this.remove = remove;
+        this.clear = clear;
+    }
+
+    @Override
+    public void execute(final Profile profile) throws QuestException {
+        final MMOPlayerData data = MMOPlayerData.get(profile.getPlayerUUID());
+        final String key = modifierKey.getValue(profile);
+        if (clear.getValue(profile).orElse(false)) {
+            clearModifiers(data, key);
+        }
+
+        if (statName == null) {
+            return;
+        }
+        final String stat = statName.getValue(profile);
+        if (remove.getValue(profile).orElse(false)) {
+            removeModifier(data, key, stat);
+        }
+
+        final double statValue = value.getValue(profile).doubleValue();
+        final ModifierType modifierType = type.getValue(profile);
+        final EquipmentSlot equipmentSlot = slot.getValue(profile);
+        final ModifierSource modifierSource = source.getValue(profile);
+        if (add.getValue(profile).orElse(false)) {
+            addModifier(modifierType, key, stat, statValue, data, modifierSource, equipmentSlot);
+        }
+    }
+
+    private void removeModifier(final MMOPlayerData playerData, final String key, final String stat) {
+        playerData.getStatMap().getInstance(stat).removeIf(key::equals);
+    }
+
+    private void clearModifiers(final MMOPlayerData playerData, final String key) {
+        for (final StatInstance instance : playerData.getStatMap().getInstances()) {
+            instance.removeIf(key::equals);
+        }
+    }
+
+    private void addModifier(final ModifierType modifierType, final String key, final String stat, final double statValue,
+                             final MMOPlayerData data, final ModifierSource modifierSource, final EquipmentSlot equipmentSlot) {
+        new StatModifier(key, stat, statValue, modifierType, equipmentSlot, modifierSource).register(data);
+    }
+}

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibStatActionFactory.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mmogroup/mmolib/MythicLibStatActionFactory.java
@@ -1,0 +1,50 @@
+package org.betonquest.betonquest.compatibility.mmogroup.mmolib;
+
+import io.lumine.mythic.lib.api.player.EquipmentSlot;
+import io.lumine.mythic.lib.player.modifier.ModifierSource;
+import io.lumine.mythic.lib.player.modifier.ModifierType;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.instruction.FlagState;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.quest.action.PlayerAction;
+import org.betonquest.betonquest.api.quest.action.PlayerActionFactory;
+
+import java.util.Optional;
+
+/**
+ * Factory to create {@link MythicLibStatAction}s from {@link Instruction}s.
+ */
+public class MythicLibStatActionFactory implements PlayerActionFactory {
+
+    /**
+     * Create a new factory for the Mythic Lib Action.
+     */
+    public MythicLibStatActionFactory() {
+    }
+
+    @Override
+    public PlayerAction parsePlayer(final Instruction instruction) throws QuestException {
+        final Optional<Argument<String>> statName = instruction.string().get("stat");
+        final Argument<Number> value = instruction.number().get("value", 0);
+        final Argument<String> key = instruction.string().get("key", io.lumine.mythic.lib.command.argument.Argument.DEFAULT_MODIFIER_KEY);
+        final Argument<ModifierType> type = instruction.enumeration(ModifierType.class).get("type", ModifierType.FLAT);
+        final Argument<EquipmentSlot> slot = instruction.enumeration(EquipmentSlot.class).get("slot", EquipmentSlot.OTHER);
+        final Argument<ModifierSource> source = instruction.enumeration(ModifierSource.class).get("source", ModifierSource.OTHER);
+        final FlagArgument<Boolean> add = instruction.bool().getFlag("add", true);
+        final FlagArgument<Boolean> remove = instruction.bool().getFlag("remove", true);
+        final FlagArgument<Boolean> clear = instruction.bool().getFlag("clear", true);
+
+        if (add.getState() == FlagState.ABSENT && remove.getState() == FlagState.ABSENT && clear.getState() == FlagState.ABSENT) {
+            throw new QuestException("At least one of the flags 'add', 'remove' or 'clear' must be set.");
+        }
+
+        if (statName.isEmpty() && clear.getState() == FlagState.ABSENT) {
+            throw new QuestException("The stat name must be set if not clearing");
+        }
+
+        return new MythicLibStatAction(statName.orElse(null), value, key, type, slot, source,
+                add, remove, clear);
+    }
+}

--- a/docs/Documentation/Scripting/Building-Blocks/Integrations-List/MMO/MMOLib.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Integrations-List/MMO/MMOLib.md
@@ -2,6 +2,75 @@
 
 @snippet:versions:minimum@ _1.7.1-SNAPSHOT_
 
+## Actions
+
+### `MmoStat`
+
+__Context__: @snippet:action-meta:online-offline@  
+__Syntax__: `mmostat [stat] [value] [key] [type] [slot] [source] [add] [remove] [clear]`  
+__Description__: Modifies a stat of a player.
+
+Modify values that combine all sorts of stats from MMOCore and MMOItems.
+The functional flags `add`, `remove` and `clear` can be used to modify the stat and may even be combined.
+They follow a strict order of priority in their execution:
+
+1. `clear`
+2. `remove`
+3. `add`
+
+| Parameter | Syntax         | Default Value          | Explanation                                                      |
+|-----------|----------------|------------------------|------------------------------------------------------------------|
+| _stat_    | Name           | :octicons-x-circle-16: | The stat to modify.                                              |
+| _value_   | Number         | 0                      | The value to add the stat. Only used if `add` is set to true.    |
+| _key_     | Name           | `default`              | The key to modify.                                               |
+| _type_    | ModifierType   | `FLAT`                 | The type of the modification.                                    |
+| _slot_    | EquipmentSlot  | `OTHER`                | The slot of the modification.                                    |
+| _source_  | ModifierSource | `OTHER`                | The source of the modification.                                  |
+| _add_     | Boolean Flag   | `false`                | Whether to add a new modifier for the stat with the given value. |
+| _remove_  | Boolean Flag   | `false`                | Whether to remove a modifier for the given key and stat.         |
+| _clear_   | Boolean Flag   | `false`                | Whether to clear all modifiers for the key.                      |
+
+??? abstract "ModifierType values"
+
+    - `FLAT`
+    - `ADDITIVE_MULTIPLIER`
+    - `RELATIVE`
+
+
+??? abstract "EquipmentSlot values"
+
+    - `ARMOR`
+    - `HEAD`
+    - `CHEST`
+    - `LEGS`
+    - `FEET`
+    - `ACCESSORY`
+    - `INVENTORY`
+    - `OFF_HAND`
+    - `MAIN_HAND`
+    - `OTHER`
+    
+??? abstract "ModifierSource values"
+
+    - `MELEE_WEAPON`
+    - `RANGED_WEAPON`
+    - `OFFHAND_ITEM`
+    - `MAINHAND_ITEM`
+    - `HAND_ITEM`
+    - `ARMOR`
+    - `ACCESSORY`
+    - `ORNAMENT`
+    - `OTHER`
+    - `VOID`
+
+```YAML title="Example"
+actions:
+  damageReduction3: "mmostat add stat:DAMAGE_REDUCTION value:3"
+  damageReductionRemove: "mmostat remove stat:DAMAGE_REDUCTION"
+  armorToughnessReplace: "mmostat add remove stat:ARMOR_TOUGHNESS value:5 key:default type:ADDITIVE_MULTIPLIER slot:CHEST source:ACCESSORY"
+  statClear: "mmostat clear"
+```
+
 ## Objectives
 
 ### `MmoSkill`


### PR DESCRIPTION
Add MythicLibStatAction to allow changing player stats as requested by a user in discord

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
