### PR TITLE
Fix concurrency issues on CachingBetonQuestLoggerFactory when used through PlayerDataFactory

### DIFF
--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/logger/CachingBetonQuestLoggerFactory.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/logger/CachingBetonQuestLoggerFactory.java
@@ -5,7 +5,6 @@ import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -36,11 +35,11 @@ public class CachingBetonQuestLoggerFactory implements BetonQuestLoggerFactory {
 
     @Override
     public BetonQuestLogger create(final Class<?> clazz, @Nullable final String topic) {
-        return loggers.computeIfAbsent(clazz, k -> new HashMap<>()).computeIfAbsent(topic, t -> loggerFactory.create(clazz, t));
+        return loggers.computeIfAbsent(clazz, k -> new ConcurrentHashMap<>()).computeIfAbsent(topic, t -> loggerFactory.create(clazz, t));
     }
 
     @Override
     public BetonQuestLogger create(final Plugin plugin, @Nullable final String topic) {
-        return loggers.computeIfAbsent(plugin.getClass(), k -> new HashMap<>()).computeIfAbsent(topic, t -> loggerFactory.create(plugin, t));
+        return loggers.computeIfAbsent(plugin.getClass(), k -> new ConcurrentHashMap<>()).computeIfAbsent(topic, t -> loggerFactory.create(plugin, t));
     }
 }


### PR DESCRIPTION
Fix concurrency issues on join with the logger causing `java.util.ConcurrentModificationException`s

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!

<img width="848" height="487" alt="image" src="https://github.com/user-attachments/assets/49f915fa-2478-4be0-b93b-249dfcb00081" />
