### PR TITLE
Remove footnote

### DIFF
--- a/docs/API/Concepts/Objectives.md
+++ b/docs/API/Concepts/Objectives.md
@@ -357,7 +357,6 @@ Each request must fulfill certain requirements to be registered successfully.
 
     | Method                       | Description                                                | Info               |
     |:-----------------------------|:-----------------------------------------------------------|:-------------------|
-    | `source(Id)`                 | Sets the objective's id for the event request.             | :information: [^1] |
     | `handler(NonProfileHandler)` | Define how the event is handled.                           |                    |
     | `handler(ProfileHandler)`    | Define how the event is handled.                           |                    |
     | `onlinehandler(Handler)`     | Define how the event is handled.                           |                    |
@@ -369,8 +368,6 @@ Each request must fulfill certain requirements to be registered successfully.
     | `priority(EventPriority)`    | Sets the priority for the event request.                   | def: `NORMAL`      |
     | `ignoreConditions()`         | Ignores conditions set for the objective for this event.   | def: unset         |
     | `subscribe(boolean)`         | Finalize event subscription and define `ignoreCancelled`   |                    |
-
-    [^1]: The id is required, but usually already set before provided to the factory.
 
 The following examples show how to subscribe to an event with the request builder:
 

--- a/docs/API/Concepts/Objectives.md
+++ b/docs/API/Concepts/Objectives.md
@@ -355,19 +355,19 @@ Each request must fulfill certain requirements to be registered successfully.
 
 ??? abstract "Event subscription methods"
 
-    | Method                       | Description                                                | Info               |
-    |:-----------------------------|:-----------------------------------------------------------|:-------------------|
-    | `handler(NonProfileHandler)` | Define how the event is handled.                           |                    |
-    | `handler(ProfileHandler)`    | Define how the event is handled.                           |                    |
-    | `onlinehandler(Handler)`     | Define how the event is handled.                           |                    |
-    | `uuid(Extractor)`            | Extract a players `UUID` from the event.                   |                    |
-    | `offlinePlayer(Extractor)`   | Extract an `OfflinePlayer` from the event.                 |                    |
-    | `player(Extractor)`          | Extract a `Player` from the event.                         |                    |
-    | `entity(Extractor)`          | Extract an `Entity` from the event that may be a `Player`. |                    |
-    | `profile(Extractor)`         | Extract a `Profile` from the event.                        |                    |
-    | `priority(EventPriority)`    | Sets the priority for the event request.                   | def: `NORMAL`      |
-    | `ignoreConditions()`         | Ignores conditions set for the objective for this event.   | def: unset         |
-    | `subscribe(boolean)`         | Finalize event subscription and define `ignoreCancelled`   |                    |
+    | Method                       | Description                                                | Info          |
+    |:-----------------------------|:-----------------------------------------------------------|:--------------|
+    | `handler(NonProfileHandler)` | Define how the event is handled.                           |               |
+    | `handler(ProfileHandler)`    | Define how the event is handled.                           |               |
+    | `onlinehandler(Handler)`     | Define how the event is handled.                           |               |
+    | `uuid(Extractor)`            | Extract a players `UUID` from the event.                   |               |
+    | `offlinePlayer(Extractor)`   | Extract an `OfflinePlayer` from the event.                 |               |
+    | `player(Extractor)`          | Extract a `Player` from the event.                         |               |
+    | `entity(Extractor)`          | Extract an `Entity` from the event that may be a `Player`. |               |
+    | `profile(Extractor)`         | Extract a `Profile` from the event.                        |               |
+    | `priority(EventPriority)`    | Sets the priority for the event request.                   | def: `NORMAL` |
+    | `ignoreConditions()`         | Ignores conditions set for the objective for this event.   | def: unset    |
+    | `subscribe(boolean)`         | Finalize event subscription and define `ignoreCancelled`   |               |
 
 The following examples show how to subscribe to an event with the request builder:
 


### PR DESCRIPTION
Remove unnecessary info from event subscription handler methods since source method is not required to be called anyway

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
