### PR TITLE
Update integration versions

### DIFF
--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
@@ -132,8 +132,7 @@ public final class BundledCompatibility {
         register("Vault", () -> new VaultIntegrator(servicesManager), VaultIntegrator.REQUIRED_VERSION);
         register("Skript", () -> new SkriptIntegrator(), SkriptIntegrator.REQUIRED_VERSION);
         register("WorldGuard", () -> new WorldGuardIntegrator(), WorldGuardIntegrator.REQUIRED_VERSION);
-        register("WorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.WE_REQUIRED_VERSION);
-        register("FastAsyncWorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.FAWE_REQUIRED_VERSION);
+        register("WorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.getPolicies());
         register("mcMMO", () -> new McMMOIntegrator(), McMMOIntegrator.REQUIRED_VERSION);
         register("MythicLib", () -> new MythicLibIntegrator(), MythicLibIntegrator.REQUIRED_VERSION);
         register("MMOCore", () -> new MMOCoreIntegrator(), MMOCoreIntegrator.REQUIRED_VERSION);

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/BundledCompatibility.java
@@ -132,8 +132,8 @@ public final class BundledCompatibility {
         register("Vault", () -> new VaultIntegrator(servicesManager), VaultIntegrator.REQUIRED_VERSION);
         register("Skript", () -> new SkriptIntegrator(), SkriptIntegrator.REQUIRED_VERSION);
         register("WorldGuard", () -> new WorldGuardIntegrator(), WorldGuardIntegrator.REQUIRED_VERSION);
-        register("WorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.REQUIRED_VERSION);
-        register("FastAsyncWorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.REQUIRED_VERSION);
+        register("WorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.WE_REQUIRED_VERSION);
+        register("FastAsyncWorldEdit", () -> new WorldEditIntegrator(), WorldEditIntegrator.FAWE_REQUIRED_VERSION);
         register("mcMMO", () -> new McMMOIntegrator(), McMMOIntegrator.REQUIRED_VERSION);
         register("MythicLib", () -> new MythicLibIntegrator(), MythicLibIntegrator.REQUIRED_VERSION);
         register("MMOCore", () -> new MMOCoreIntegrator(), MMOCoreIntegrator.REQUIRED_VERSION);

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptIntegrator.java
@@ -12,7 +12,7 @@ public class SkriptIntegrator implements Integration {
     /**
      * The minimum required version of Skript.
      */
-    public static final String REQUIRED_VERSION = "5.0.0";
+    public static final String REQUIRED_VERSION = "2.9.1";
 
     /**
      * The default constructor.

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
@@ -3,6 +3,10 @@ package org.betonquest.betonquest.compatibility.worldedit;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import org.betonquest.betonquest.api.BetonQuestApi;
 import org.betonquest.betonquest.api.integration.Integration;
+import org.betonquest.betonquest.api.integration.policy.Policy;
+import org.betonquest.betonquest.lib.integration.policy.Policies;
+import org.betonquest.betonquest.lib.version.DefaultVersionType;
+import org.betonquest.betonquest.lib.version.VersionParser;
 import org.bukkit.Bukkit;
 
 import java.io.File;
@@ -23,10 +27,34 @@ public class WorldEditIntegrator implements Integration {
     public static final String FAWE_REQUIRED_VERSION = "2.10.0";
 
     /**
+     * The name of the WorldEdit plugin.
+     */
+    private static final String WE_NAME = "WorldEdit";
+
+    /**
+     * The name of the FastAsyncWorldEdit plugin.
+     */
+    private static final String FAWE_NAME = "FastAsyncWorldEdit";
+
+    /**
      * The default constructor.
      */
     public WorldEditIntegrator() {
 
+    }
+
+    /**
+     * Provides the valid policies of the 'WorldEdit' plugin.
+     *
+     * @return policies to check whether the correct version is installed or not
+     */
+    public static Policy[] getPolicies() {
+        final Policy weVersionPolicy = Policies.minimalPluginVersion(WE_NAME, VersionParser.parse(DefaultVersionType.SIMPLE_SEMANTIC_VERSION, WE_REQUIRED_VERSION));
+        final Policy faweVersionPolicy = Policies.minimalPluginVersion(FAWE_NAME, VersionParser.parse(DefaultVersionType.SIMPLE_SEMANTIC_VERSION, FAWE_REQUIRED_VERSION));
+        return new Policy[]{
+                Policies.simpleCondition(() -> weVersionPolicy.validate() || faweVersionPolicy.validate(),
+                        "WorldEdit version '%s' or above is required (or FastAsyncWorldEdit '%s' or above).".formatted(WE_REQUIRED_VERSION, FAWE_REQUIRED_VERSION))
+        };
     }
 
     @Override

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
@@ -15,7 +15,12 @@ public class WorldEditIntegrator implements Integration {
     /**
      * The minimum required version of WorldEdit.
      */
-    public static final String REQUIRED_VERSION = "7.3.0";
+    public static final String WE_REQUIRED_VERSION = "7.3.0";
+
+    /**
+     * The minimum required version of FastAsyncWorldEdit.
+     */
+    public static final String FAWE_REQUIRED_VERSION = "2.10.0";
 
     /**
      * The default constructor.


### PR DESCRIPTION
- WorldEdit and FastAsyncWorldEdit actually have separate versioning - FAWE version guessed by release timing of WorldEdit to be around 2.10.0 with some overshooting buffer for safety
- Skript version was just wrong - adjusted to version stated in pom.xml

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
