### PR TITLE
[DOCS] Small typo as pointed out by a user

### DIFF
--- a/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
+++ b/docs/Documentation/Scripting/Building-Blocks/Objectives-List.md
@@ -566,7 +566,7 @@ objectives:
 ## `NpcRange`
 
 __Context__: @snippet:objective-meta:online@  
-__Syntax__: `npcrange <npc <action> <range>`  
+__Syntax__: `npcrange <npc> <action> <range>`  
 __Description__: The player has to enter or leave the specified area around the NPC.
 
 It is also possible to define multiple NPCs separated with `,`.


### PR DESCRIPTION
Add missing closing `>` in docs for `npcrange` objective

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
