### PR TITLE
Remove redundant data from data collection

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
@@ -193,9 +193,11 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
     public Set<Metric<?>> getMetrics() {
         return Set.of(
                 Metric.number("profiles_personal_lang_count", () -> playerDataMap.values().stream()
-                        .filter(data -> data.getLanguage().isPresent()).count()),
+                        .filter(data -> data.getLanguage().isPresent()
+                                && !"default".equalsIgnoreCase(data.getLanguage().get())).count()),
                 Metric.stringArray("profiles_personal_lang", () -> playerDataMap.values().stream()
                         .map(data -> data.getLanguage().orElse(null)).filter(Objects::nonNull)
+                        .filter(lang -> !"default".equalsIgnoreCase(lang))
                         .toList().toArray(new String[0]))
         );
     }


### PR DESCRIPTION
Remove `default` as valid value from per-profile set languages to reduce the amount of unnecessary data sent to the statistics backend that potentially scales with the amount of players without providing useful information

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
