### PR TITLE
Update suppression rules for PMD warnings and migrate `AsyncSaver` to…

### DIFF
--- a/code/api/pom.xml
+++ b/code/api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest API</name>

--- a/code/build/pom.xml
+++ b/code/build/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Build</name>

--- a/code/compatibility/pom.xml
+++ b/code/compatibility/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Compatibility</name>

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Core</name>

--- a/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 @SuppressWarnings({"PMD.DoNotUseThreads", "PMD.AvoidSynchronizedStatement"})
 @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
-public class AsyncSaver extends Thread implements Saver {
+public class AsyncSaver implements Runnable, Saver {
 
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
@@ -46,7 +46,6 @@ public class AsyncSaver extends Thread implements Saver {
      * @param connector         the connector for database access
      */
     public AsyncSaver(final BetonQuestLogger log, final long reconnectInterval, final Connector connector) {
-        super();
         this.log = log;
         this.reconnectInterval = reconnectInterval;
         this.con = connector;
@@ -81,7 +80,7 @@ public class AsyncSaver extends Thread implements Saver {
                     log.warn("Failed to re-establish connection with the database! Trying again in %s second(s)..."
                             .formatted(reconnectInterval / 1000), illegalStateException);
                     try {
-                        sleep(reconnectInterval);
+                        Thread.sleep(reconnectInterval);
                     } catch (final InterruptedException interruptedException) {
                         log.warn("AsyncSaver got interrupted!", interruptedException);
                         return;

--- a/code/core/src/main/java/org/betonquest/betonquest/feature/Backpack.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/feature/Backpack.java
@@ -41,7 +41,6 @@ import java.util.Map;
 /**
  * Represents a chest GUI for the backpack displayed to the player.
  */
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class Backpack implements Listener {
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
@@ -44,7 +44,7 @@ public class AsyncSaverComponent extends AbstractCoreComponent {
         final Connector connector = getDependency(Connector.class);
 
         final AsyncSaver saver = new AsyncSaver(loggerFactory.create(AsyncSaver.class, "Database"), config.getLong("mysql.reconnect_interval"), connector);
-        saver.start();
+        new Thread(saver).start();
         new Backup(loggerFactory, loggerFactory.create(Backup.class), configAccessorFactory, plugin.getDataFolder(), connector)
                 .loadDatabaseFromBackup();
 

--- a/code/core/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/schedule/CronRebootScheduleTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.*;
 /**
  * Test for {@link CronSchedule} that support reboot and custom nicknames.
  */
-@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
+@SuppressWarnings("PMD.JUnitJupiterTestShouldBePackagePrivate")
 public class CronRebootScheduleTest extends CronScheduleBaseTest {
 
     @Override

--- a/code/core/src/test/java/org/betonquest/betonquest/api/schedule/CronScheduleBaseTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/schedule/CronScheduleBaseTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.*;
 /**
  * These tests should ensure that the parsing of cron schedules works properly.
  */
-@SuppressWarnings({"PMD.TooManyStaticImports", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings("PMD.JUnitJupiterTestShouldBePackagePrivate")
 public class CronScheduleBaseTest extends ScheduleBaseTest {
 
     @Override

--- a/code/core/src/test/java/org/betonquest/betonquest/api/schedule/ScheduleBaseTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/api/schedule/ScheduleBaseTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.*;
 /**
  * These tests should ensure that the basic parsing of schedules works properly.
  */
-@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
+@SuppressWarnings("PMD.JUnitJupiterTestShouldBePackagePrivate")
 @ExtendWith(BetonQuestLoggerExtension.class)
 public class ScheduleBaseTest extends AbstractScheduleTest {
 

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/ScheduleTypeTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/ScheduleTypeTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.*;
 /**
  * Tests for {@link ActionScheduling.ScheduleType}.
  */
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 @ExtendWith({MockitoExtension.class, BetonQuestLoggerExtension.class})
 class ScheduleTypeTest {
 

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/realtime/cron/RealtimeCronScheduleTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/realtime/cron/RealtimeCronScheduleTest.java
@@ -7,7 +7,7 @@ import org.betonquest.betonquest.api.schedule.CronSchedule;
 /**
  * Tests for realtime cron schedule.
  */
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class RealtimeCronScheduleTest extends CronRebootScheduleTest {
 
     @Override

--- a/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/realtime/daily/RealtimeDailyScheduleTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/schedule/impl/realtime/daily/RealtimeDailyScheduleTest.java
@@ -40,7 +40,7 @@ class RealtimeDailyScheduleTest extends ScheduleBaseTest {
 
     @Test
     @Override
-    @SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
+    @SuppressWarnings("PMD.JUnitJupiterTestShouldBePackagePrivate")
     public void testScheduleValidLoad() throws QuestException {
         final RealtimeDailySchedule schedule = createSchedule();
         assertEquals(LocalTime.of(22, 0), schedule.getTimeToRun(), "Returned time should be correct");

--- a/code/lib/pom.xml
+++ b/code/lib/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Library</name>

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/ConfigurationSectionDecoratorTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/ConfigurationSectionDecoratorTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for the {@link ConfigurationSectionDecorator}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class ConfigurationSectionDecoratorTest extends ConfigurationSectionBaseTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationEmptyOriginalTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationEmptyOriginalTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfigurationSection} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationEmptyOriginalTest extends FallbackConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationNestedTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationNestedTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfiguration} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationNestedTest extends FallbackConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationNonFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationNonFallbackTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Tag;
  * Tests the {@link FallbackConfiguration} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationNonFallbackTest extends ConfigurationBaseTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionEdgeCaseTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionEdgeCaseTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This class tests edge cases of the {@link FallbackConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
+@SuppressWarnings("PMD.JUnitJupiterTestShouldBePackagePrivate")
 public class FallbackConfigurationSectionEdgeCaseTest {
 
     @Test

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionEmptyOriginalTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionEmptyOriginalTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfigurationSection} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionEmptyOriginalTest extends FallbackConfigurationSectionTest {
 
     protected Configuration original;

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionNestedTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionNestedTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfigurationSection} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionNestedTest extends FallbackConfigurationSectionTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionNonFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionNonFallbackTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Tag;
  * Tests the {@link FallbackConfigurationSection} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionNonFallbackTest extends ConfigurationSectionBaseTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationSectionTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfigurationSection} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionTest extends ConfigurationSectionBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/fallback/FallbackConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the {@link FallbackConfiguration} class.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationTest extends ConfigurationBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationSectionTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationSectionTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link HandleModificationConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestShouldIncludeAssert", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestShouldIncludeAssert", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class HandleModificationConfigurationSectionTest extends ConfigurationSectionBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationSectionWithConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationSectionWithConfigurationTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for the {@link HandleModificationConfigurationSection} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class HandleModificationConfigurationSectionWithConfigurationTest extends HandleModificationConfigurationSectionTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/handle/HandleModificationConfigurationTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for {@link HandleModificationConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestShouldIncludeAssert", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestShouldIncludeAssert", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class HandleModificationConfigurationTest extends ConfigurationBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/lazy/LazyConfigurationSectionTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/lazy/LazyConfigurationSectionTest.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.JUnit5TestShouldBePackagePrivate", "PMD.UnitTestAssertionsShouldIncludeMessage"})
+@SuppressWarnings({"PMD.JUnitJupiterTestShouldBePackagePrivate", "PMD.UnitTestAssertionsShouldIncludeMessage"})
 class LazyConfigurationSectionTest extends ConfigurationSectionBaseTest {
 
     private MemoryConfiguration root;

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationModificationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationModificationTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for modifications of the {@link MultiSectionConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.UnitTestContainsTooManyAsserts", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.UnitTestContainsTooManyAsserts", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationModificationTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSectionSplitWithConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSectionSplitWithConfigurationTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for {@link MultiSectionConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSectionSplitWithConfigurationTest extends MultiSectionConfigurationSectionWithConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSectionWithConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSectionWithConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for {@link MultiSectionConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.UnitTestAssertionsShouldIncludeMessage"})
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSectionWithConfigurationTest extends ConfigurationSectionBaseTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSplitTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationSplitTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link MultiSectionConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSplitTest extends MultiSectionConfigurationTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/MultiSectionConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link MultiSectionConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationTest extends ConfigurationBaseTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationEmptyOriginalWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationEmptyOriginalWithMultiFallbackTest.java
@@ -13,7 +13,7 @@ import java.util.List;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationEmptyOriginalWithMultiFallbackTest extends FallbackConfigurationEmptyOriginalTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionEmptyOriginalWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionEmptyOriginalWithMultiFallbackTest.java
@@ -13,7 +13,7 @@ import java.util.List;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionEmptyOriginalWithMultiFallbackTest extends FallbackConfigurationSectionEmptyOriginalTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionNestedWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionNestedWithMultiFallbackTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionNestedWithMultiFallbackTest extends FallbackConfigurationSectionNestedTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionNonFallbackWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionNonFallbackWithMultiFallbackTest.java
@@ -12,7 +12,7 @@ import java.util.List;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionNonFallbackWithMultiFallbackTest extends FallbackConfigurationSectionNonFallbackTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationSectionWithMultiFallbackTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationSectionWithMultiFallbackTest extends FallbackConfigurationSectionTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/FallbackConfigurationWithMultiFallbackTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class FallbackConfigurationWithMultiFallbackTest extends FallbackConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSectionSplitWithConfigurationWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSectionSplitWithConfigurationWithMultiFallbackTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for {@link MultiFallbackConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSectionSplitWithConfigurationWithMultiFallbackTest extends MultiSectionConfigurationSectionSplitWithConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSectionWithConfigurationWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSectionWithConfigurationWithMultiFallbackTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for {@link MultiFallbackConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSectionWithConfigurationWithMultiFallbackTest extends MultiSectionConfigurationSectionWithConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSplitWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationSplitWithMultiFallbackTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationSplitWithMultiFallbackTest extends MultiSectionConfigurationSplitTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationWithMultiFallbackTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/multi/fallback/MultiSectionConfigurationWithMultiFallbackTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for the {@link MultiFallbackConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class MultiSectionConfigurationWithMultiFallbackTest extends MultiSectionConfigurationTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationSectionTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationSectionTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link UnmodifiableConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class UnmodifiableConfigurationSectionTest extends ConfigurationSectionBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationSectionWithConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationSectionWithConfigurationTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Tag;
  * This is a test for {@link UnmodifiableConfiguration} as a {@link ConfigurationSection}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class UnmodifiableConfigurationSectionWithConfigurationTest extends UnmodifiableConfigurationSectionTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/section/unmodifiable/UnmodifiableConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This is a test for the {@link UnmodifiableConfiguration}.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class UnmodifiableConfigurationTest extends ConfigurationBaseTest {
 
     /**

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/util/ConfigurationBaseTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/util/ConfigurationBaseTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * You only need to override methods with behaviours that differ from the default one.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate"})
+@SuppressWarnings({"PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate"})
 public class ConfigurationBaseTest extends AbstractConfigBaseTest<Configuration> implements ConfigurationInterfaceTest {
 
     @Override

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/config/util/ConfigurationSectionBaseTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/config/util/ConfigurationSectionBaseTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.*;
  * You only need to override methods with behaviours that differ from the default one.
  */
 @Tag("ConfigurationSection")
-@SuppressWarnings({"PMD.GodClass", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnit5TestShouldBePackagePrivate",
+@SuppressWarnings({"PMD.GodClass", "PMD.UnitTestAssertionsShouldIncludeMessage", "PMD.JUnitJupiterTestShouldBePackagePrivate",
         "PMD.CyclomaticComplexity", "PMD.ExcessivePublicCount"})
 public class ConfigurationSectionBaseTest extends AbstractConfigBaseTest<ConfigurationSection> implements ConfigurationSectionInterfaceTest {
 

--- a/code/mc_1_20_6/pom.xml
+++ b/code/mc_1_20_6/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Minecraft 1.20.6</name>

--- a/code/mc_1_21_4/pom.xml
+++ b/code/mc_1_21_4/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest</groupId>
     <artifactId>parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Minecraft 1.21.4</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.betonquest.parent</groupId>
     <artifactId>versions</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0</version>
   </parent>
 
   <name>BetonQuest Reactor</name>


### PR DESCRIPTION
… use `Runnable` interface

- Updated all test classes to align with the suppression rule `PMD.JUnitJupiterTestShouldBePackagePrivate`.
- Migrated `AsyncSaver` from extending `Thread` to implementing `Runnable`. Adjusted associated logic to use `Thread` objects for execution.
- Updated project POM files to use parent version `2.10.0`.

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Requires https://github.com/BetonQuest/MavenSetup/pull/128

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
