### PR TITLE
Prevent getting stuck in conversation

### DIFF
--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/packetevents/passenger/FakeArmorStandPassengerController.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/packetevents/passenger/FakeArmorStandPassengerController.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.PacketEventsAPI;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerInput;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientSteerVehicle;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
@@ -62,13 +63,17 @@ public class FakeArmorStandPassengerController extends FakeArmorStandPassenger i
         }
     }
 
+    @SuppressWarnings("ConstantConditions")
     private void sendSpeed(final double speed) {
         if (!setSpeed) {
             return;
         }
         final WrapperPlayServerUpdateAttributes attributes = new WrapperPlayServerUpdateAttributes(player.getEntityId(),
                 List.of(new WrapperPlayServerUpdateAttributes.Property(Attributes.MOVEMENT_SPEED, speed, List.of())));
-        packetEventsAPI.getPlayerManager().getUser(player).sendPacket(attributes);
+        final User user = packetEventsAPI.getPlayerManager().getUser(player);
+        if (user != null) {
+            user.sendPacket(attributes);
+        }
     }
 
     @Override


### PR DESCRIPTION
Catch exceptions to prevent players from getting stuck in conversations after disconnects.
For now this seems to be AdvancedSlimePaper specific; however we cannot be sure of that.

Fix has been tested by the user reporting the error.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
