### PR TITLE
Add option to parse a map of named arguments

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/ChainableInstruction.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/ChainableInstruction.java
@@ -6,7 +6,9 @@ import org.betonquest.betonquest.api.instruction.FlagArgument;
 import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentParser;
 import org.jetbrains.annotations.Contract;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * An instruction that can be parsed in parts using chained calls.
@@ -77,4 +79,16 @@ public interface ChainableInstruction {
      */
     @Contract("!null, !null, !null -> new")
     <T> FlagArgument<T> getFlag(String argumentKey, InstructionArgumentParser<T> argumentParser, T presenceDefault) throws QuestException;
+
+    /**
+     * Get all named arguments in the instruction filtered by the given {@link Predicate} for their keys.
+     *
+     * @param argumentParser the argument parser to use
+     * @param keyFilter      the filter to apply to the keys
+     * @param <T>            the type of the argument
+     * @return a map of the named arguments
+     * @throws QuestException if an error occurs while parsing
+     */
+    @Contract("!null, !null -> new")
+    <T> Map<String, Argument<T>> getNamed(InstructionArgumentParser<T> argumentParser, Predicate<String> keyFilter) throws QuestException;
 }

--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/InstructionChainRetriever.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/chain/InstructionChainRetriever.java
@@ -6,7 +6,9 @@ import org.betonquest.betonquest.api.instruction.FlagArgument;
 import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentParser;
 import org.jetbrains.annotations.Contract;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * In the last step of the instruction chain, the argument is retrieved.
@@ -59,5 +61,29 @@ public interface InstructionChainRetriever<T> {
      * @see org.betonquest.betonquest.api.instruction.FlagState
      * @see ChainableInstruction#getFlag(String, InstructionArgumentParser, Object)
      */
+    @Contract("!null, !null -> new")
     FlagArgument<T> getFlag(String argumentKey, T presenceDefaultValue) throws QuestException;
+
+    /**
+     * Retrieves all named arguments of the chain as {@link Argument}s with their key as name in a {@link Map}.
+     *
+     * @return a map of named arguments
+     * @throws QuestException an argument could not be resolved
+     * @see ChainableInstruction#getNamed(InstructionArgumentParser, Predicate)
+     */
+    @Contract("-> new")
+    Map<String, Argument<T>> getNamed() throws QuestException;
+
+    /**
+     * Retrieves all targeted named arguments of the chain as {@link Argument}s with their key as name in a {@link Map}.
+     * The arguments are filtered by the given {@link Predicate}
+     * and only those argument keys that match the filter are returned.
+     *
+     * @param keyFilter a filter for the keys of the arguments
+     * @return a map of named arguments
+     * @throws QuestException an argument could not be resolved
+     * @see ChainableInstruction#getNamed(InstructionArgumentParser, Predicate)
+     */
+    @Contract("!null -> new")
+    Map<String, Argument<T>> getNamed(Predicate<String> keyFilter) throws QuestException;
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/instruction/DefaultInstruction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/instruction/DefaultInstruction.java
@@ -35,6 +35,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * The Instruction. Primary object for input parsing.
@@ -125,7 +127,7 @@ public class DefaultInstruction implements Instruction {
             throw new QuestException("Could not tokenize instruction '" + instruction + "': " + e.getMessage(), e);
         }
         this.chainableInstruction = new DefaultChainableInstruction(placeholders, packManager, pack,
-                this.instructionParts::nextElement, this::getValue, this::getFlag);
+                this.instructionParts::nextElement, this::getValue, this::getFlag, this::getNamedValues);
     }
 
     /**
@@ -143,7 +145,7 @@ public class DefaultInstruction implements Instruction {
         this.instructionParts = new InstructionPartsArray(instruction.instructionParts);
         this.argumentParsers = instruction.argumentParsers;
         this.chainableInstruction = new DefaultChainableInstruction(placeholders, packManager, pack,
-                this.instructionParts::nextElement, this::getValue, this::getFlag);
+                this.instructionParts::nextElement, this::getValue, this::getFlag, this::getNamedValues);
     }
 
     private static Identifier useFallbackIdIfNecessary(final QuestPackage pack, @Nullable final Identifier identifier) {
@@ -227,6 +229,19 @@ public class DefaultInstruction implements Instruction {
                 .orElse(Map.entry(FlagState.ABSENT, ""));
     }
 
+    private Map<String, String> getNamedValues(final Predicate<String> keyFilter) {
+        return instructionParts.getParts().stream()
+                .filter(part -> part.startsWith("+"))
+                .map(part -> part.substring(1))
+                .filter(part -> part.indexOf(':') > 0)
+                .map(part -> {
+                    final int colonIndex = part.indexOf(':');
+                    return Map.entry(part.substring(0, colonIndex), part.substring(colonIndex + 1));
+                })
+                .filter(argument -> keyFilter.test(argument.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     @Override
     public DefaultInstruction copy() {
         return copy(identifier);
@@ -240,7 +255,8 @@ public class DefaultInstruction implements Instruction {
     @Override
     public InstructionChainParser chainForArgument(final QuestSupplier<String> rawArgumentSupplier) {
         final ChainableInstruction instruction = new DefaultChainableInstruction(placeholders, packManager, pack,
-                rawArgumentSupplier, key -> rawArgumentSupplier.get(), key -> Map.entry(FlagState.DEFINED, key));
+                rawArgumentSupplier, key -> rawArgumentSupplier.get(), key -> Map.entry(FlagState.DEFINED, key),
+                this::getNamedValues);
         return new DefaultInstructionChainParser(instruction, argumentParsers);
     }
 
@@ -262,6 +278,11 @@ public class DefaultInstruction implements Instruction {
     @Override
     public <T> FlagArgument<T> getFlag(final String argumentKey, final InstructionArgumentParser<T> argumentParser, final T presenceDefault) throws QuestException {
         return chainableInstruction.getFlag(argumentKey, argumentParser, presenceDefault);
+    }
+
+    @Override
+    public <T> Map<String, Argument<T>> getNamed(final InstructionArgumentParser<T> argumentParser, final Predicate<String> keyFilter) throws QuestException {
+        return chainableInstruction.getNamed(argumentParser, keyFilter);
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/api/service/DefaultInstructions.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/service/DefaultInstructions.java
@@ -74,7 +74,7 @@ public class DefaultInstructions implements Instructions {
     @Override
     public InstructionChainParser createForArgument(final QuestPackage questPackage, final QuestSupplier<String> argument) {
         final ChainableInstruction instruction = new DefaultChainableInstruction(placeholders.get(), packageManager, questPackage,
-                argument, key -> argument.get(), key -> Map.entry(FlagState.DEFINED, key));
+                argument, key -> argument.get(), key -> Map.entry(FlagState.DEFINED, key), predicate -> Map.of("", argument.get()));
         return new DefaultInstructionChainParser(instruction, argumentParsers.get());
     }
 

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/argument/DefaultChainableInstruction.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/argument/DefaultChainableInstruction.java
@@ -13,12 +13,15 @@ import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentPar
 import org.betonquest.betonquest.api.instruction.chain.ChainableInstruction;
 import org.betonquest.betonquest.api.service.placeholder.PlaceholderManager;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * The default implementation for {@link ChainableInstruction}.
  */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class DefaultChainableInstruction implements ChainableInstruction {
 
     /**
@@ -52,25 +55,33 @@ public class DefaultChainableInstruction implements ChainableInstruction {
     private final QuestFunction<String, Map.Entry<FlagState, String>> nextFlagFunction;
 
     /**
+     * The function to retrieve the next named elements by a key filter.
+     */
+    private final QuestFunction<Predicate<String>, Map<String, String>> namedElementsFunction;
+
+    /**
      * Sole constructor.
      *
-     * @param placeholders         the {@link PlaceholderManager} to create and resolve placeholders
-     * @param packManager          the package manager
-     * @param pack                 the related package
-     * @param nextElementSupplier  the provider for the next element
-     * @param nextOptionalFunction the provider for the next element by key
-     * @param nextFlagFunction     the provider for the next flag by key
+     * @param placeholders          the {@link PlaceholderManager} to create and resolve placeholders
+     * @param packManager           the package manager
+     * @param pack                  the related package
+     * @param nextElementSupplier   the provider for the next element
+     * @param nextOptionalFunction  the provider for the next element by key
+     * @param nextFlagFunction      the provider for the next flag by key
+     * @param namedElementsFunction the provider for the next named elements by a key filter
      */
     public DefaultChainableInstruction(final PlaceholderManager placeholders, final QuestPackageManager packManager,
                                        final QuestPackage pack, final QuestSupplier<String> nextElementSupplier,
                                        final QuestFunction<String, String> nextOptionalFunction,
-                                       final QuestFunction<String, Map.Entry<FlagState, String>> nextFlagFunction) {
+                                       final QuestFunction<String, Map.Entry<FlagState, String>> nextFlagFunction,
+                                       final QuestFunction<Predicate<String>, Map<String, String>> namedElementsFunction) {
         this.placeholders = placeholders;
         this.packManager = packManager;
         this.pack = pack;
         this.nextElementSupplier = nextElementSupplier;
         this.nextOptionalFunction = nextOptionalFunction;
         this.nextFlagFunction = nextFlagFunction;
+        this.namedElementsFunction = namedElementsFunction;
     }
 
     @Override
@@ -108,5 +119,16 @@ public class DefaultChainableInstruction implements ChainableInstruction {
             case DEFINED -> new DefaultFlagArgument<>(placeholders, pack, flag.getValue(),
                     value -> Optional.of(argumentParser.apply(placeholders, packManager, pack, value)));
         };
+    }
+
+    @Override
+    public <T> Map<String, Argument<T>> getNamed(final InstructionArgumentParser<T> argumentParser, final Predicate<String> keyFilter) throws QuestException {
+        final Map<String, String> map = namedElementsFunction.apply(keyFilter);
+        final Map<String, Argument<T>> result = new HashMap<>();
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
+            result.put(entry.getKey(), new DefaultArgument<>(placeholders, pack, entry.getValue(),
+                    value -> argumentParser.apply(placeholders, packManager, pack, value)));
+        }
+        return result;
     }
 }

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/chain/DefaultInstructionChainRetriever.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/chain/DefaultInstructionChainRetriever.java
@@ -7,7 +7,9 @@ import org.betonquest.betonquest.api.instruction.argument.InstructionArgumentPar
 import org.betonquest.betonquest.api.instruction.chain.ChainableInstruction;
 import org.betonquest.betonquest.api.instruction.chain.InstructionChainRetriever;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * A default implementation of {@link InstructionChainRetriever}.
@@ -55,5 +57,15 @@ public class DefaultInstructionChainRetriever<T> implements InstructionChainRetr
     @Override
     public FlagArgument<T> getFlag(final String argumentKey, final T presenceDefaultValue) throws QuestException {
         return instruction.getFlag(argumentKey, argument, presenceDefaultValue);
+    }
+
+    @Override
+    public Map<String, Argument<T>> getNamed() throws QuestException {
+        return getNamed(key -> true);
+    }
+
+    @Override
+    public Map<String, Argument<T>> getNamed(final Predicate<String> keyFilter) throws QuestException {
+        return instruction.getNamed(argument, keyFilter);
     }
 }

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/section/DefaultSectionInstruction.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/instruction/section/DefaultSectionInstruction.java
@@ -130,7 +130,7 @@ public class DefaultSectionInstruction implements SectionInstruction {
     @Override
     public InstructionChainParser chainForArgument(final String argument) {
         final DefaultChainableInstruction instruction = new DefaultChainableInstruction(placeholders, packageManager, questPackage,
-                () -> argument, val -> argument, val -> Map.entry(FlagState.DEFINED, val));
+                () -> argument, val -> argument, val -> Map.entry(FlagState.DEFINED, val), predicate -> Map.of("", argument));
         return new DefaultInstructionChainParser(instruction, parsers);
     }
 

--- a/docs/API/Tools/Instruction.md
+++ b/docs/API/Tools/Instruction.md
@@ -113,12 +113,14 @@ The argument retrieval step is required after the argument parsing and represent
 instance to be carried on into actions, conditions and objectives.
 To have valid calls the `Number` parser is used as an example, but naturally any parser will do.
 
-| Call                                                                  |                Type                | Description                                                                                                                                           |
-|:----------------------------------------------------------------------|:----------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `.get()`                                                              |         `Argument<Number>`         | Retrieves an argument of the next value in order from the instruction                                                                                 |
-| `.get("amount")`                                                      |    `Optional<Argument<Number>>`    | Retrieves an optional argument of the value with the key `amount` from the instruction                                                                |
-| `.get("amount", 10)`                                                  |         `Argument<Number>`         | Retrieves an optional argument of the value with the key `amount` from the instruction or gets an argument with default value                         |
-| `.getFlag("repeat", 10)`                                              |       `FlagArgument<Number>`       | Retrieves an optional flag argument of the value with the key `repeat` from the instruction using the default value for its undefined state           |
+| Call                                |              Type               | Description                                                                                                                                                      |
+|:------------------------------------|:-------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.get()`                            |       `Argument<Number>`        | Retrieves an argument of the next value in order from the instruction                                                                                            |
+| `.get("amount")`                    |  `Optional<Argument<Number>>`   | Retrieves an optional argument of the value with the key `amount` from the instruction                                                                           |
+| `.get("amount", 10)`                |       `Argument<Number>`        | Retrieves an optional argument of the value with the key `amount` from the instruction or gets an argument with default value                                    |
+| `.getFlag("repeat", 10)`            |     `FlagArgument<Number>`      | Retrieves an optional flag argument of the value with the key `repeat` from the instruction using the default value for its undefined state                      |
+| `.getNamed()`                       | `Map<String, Argument<Number>>` | Retrieves all named arguments from the instruction as a map of key-value pairs. Named arguments are prefixed with `+` in the script.                             |
+| `.getNamed(p -> p.startsWith("a"))` | `Map<String, Argument<Number>>` | Retrieves all named arguments with keys starting with `a` from the instruction as a map of key-value pairs. Named arguments are prefixed with `+` in the script. |
 
 ### Advanced Argument Parsing
 Parsers via the chain offer more functionality than just parsing a string into a specific type.

--- a/docs/Participate/Process/Docs/Style-Definitions.md
+++ b/docs/Participate/Process/Docs/Style-Definitions.md
@@ -15,7 +15,7 @@ To simplify the process of maintaining these lists, we use the following style d
     ## `Example`
     
     __Context__: @snippet:action-meta:online-offline-independent@  
-    __Syntax__: `example <param1> [param2] {param3}`  
+    __Syntax__: `example <param1> [param2] {param3} +[...]`  
     __Description__: An example action.
     
     This description is used to provide a brief explanation of the action if it is not obvious from short description
@@ -26,6 +26,7 @@ To simplify the process of maintaining these lists, we use the following style d
     | param1 <br>[Number]  | Required               | What does this parameter do? |
     | param2 <br>[String]  | Optional <br>[Null]    | What does this parameter do? |
     | param3 <br>[Boolean] | Flag <br>[false, true] | What does this parameter do? |
+    | +[...] <br>[String]  | Additionals            | What do these parameters do? |
     
     ```YAML title="Examples"
     actions:
@@ -34,6 +35,7 @@ To simplify the process of maintaining these lists, we use the following style d
       exapl3: "example 55 param2:Test"
       exapl4: "example 55 param3"
       exapl5: "example 55"
+      exapl6: "example 55 param2:Test param3:false +myAdditionalParam:AnyValue"
     ```
     
 Make sure the style matches using the following checklists:

--- a/docs/_glossary/instruction-datatypes.md
+++ b/docs/_glossary/instruction-datatypes.md
@@ -4,4 +4,5 @@
 *[Flag]: A flag can be either absent or undefined with separate default values [absent, undefined] or explicitly defined with a value.
 *[Optional]: An optional value can be either absent with a default value or explicitly defined with a value.
 *[Required]: A required value must be defined at the correct position and without its name. It must not be absent or undefined.
+*[Additionals]: Additional values are prefixed with a + symbol and allow for key-value pairs to be added to the element.
 *[Null]: A null value has no value.


### PR DESCRIPTION
Add option to parse a map of named arguments whose keys match a given predicate instead of having known names

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
