### PR TITLE
Fix NPE in faulty objective data

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractData.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/interact/EntityInteractData.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.identifier.ObjectiveIdentifier;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -19,7 +20,10 @@ public class EntityInteractData extends CountingObjective.CountingData {
 
     /**
      * The set of entities that have been interacted with.
+     * This value is only nullable to a rare incident in which the super call
+     * in the instructor accesses the {@link #toString()} method.
      */
+    @Nullable
     private final Set<UUID> entities;
 
     /**
@@ -57,6 +61,6 @@ public class EntityInteractData extends CountingObjective.CountingData {
 
     @Override
     public String toString() {
-        return super.toString() + ";" + entities.stream().map(UUID::toString).collect(Collectors.joining("/"));
+        return super.toString() + ";" + (entities == null ? "" : entities.stream().map(UUID::toString).collect(Collectors.joining("/")));
     }
 }


### PR DESCRIPTION
Handle nullable `entities` field in `EntityInteractData` and update `toString` method to avoid null pointer exceptions

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
