### PR TITLE
Avoid concurrent modification exceptions

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/util/MetricsUtils.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/util/MetricsUtils.java
@@ -36,7 +36,7 @@ public final class MetricsUtils {
         return identifiers.stream()
                 .map(identifier -> typeFromId(identifier, instructionApi))
                 .filter(validTypes::contains)
-                .collect(Collectors.toMap(Function.identity(), key -> 1, Integer::sum));
+                .collect(Collectors.toConcurrentMap(Function.identity(), key -> 1, Integer::sum));
     }
 
     @Nullable


### PR DESCRIPTION
Refactor `typeCountMetrics` method to use `HashSet` for identifiers and valid types filtering to avoid concurrent modification exceptions

---


### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
