### PR TITLE
Fix FastStats to no longer stop BQ from enabling

### DIFF
--- a/code/build/src/main/java/org/betonquest/betonquest/BetonQuestPlugin.java
+++ b/code/build/src/main/java/org/betonquest/betonquest/BetonQuestPlugin.java
@@ -43,8 +43,8 @@ public class BetonQuestPlugin extends BetonQuest {
             super.onEnable();
         } catch (final IllegalStateException exception) {
             log.error("Disabling BetonQuest due to an error: " + exception.getMessage(), exception);
-            getComponentLoader().getOptional(FastStatsMetrics.class)
-                    .ifPresent(metrics -> metrics.getErrorTracker().trackError(exception).handled(true));
+            getComponentLoader().getOptional(FastStatsMetrics.class).flatMap(FastStatsMetrics::getErrorTracker)
+                    .ifPresent(tracker -> tracker.trackError(exception).handled(true));
             getServer().getPluginManager().disablePlugin(this);
             return;
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/faststats/FastStatsMetrics.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/faststats/FastStatsMetrics.java
@@ -5,7 +5,9 @@ import dev.faststats.Token;
 import dev.faststats.bukkit.BukkitContext;
 import dev.faststats.data.Metric;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -16,6 +18,7 @@ public class FastStatsMetrics {
     /**
      * The error tracker to use for faststats error tracking.
      */
+    @Nullable
     private final ErrorTracker errorTracker;
 
     /**
@@ -33,8 +36,6 @@ public class FastStatsMetrics {
      */
     public FastStatsMetrics(final Plugin plugin, @Token final String token, final Set<FastStatsMetricsProvider> metricsProviders,
                             final boolean logErrors) {
-        this.errorTracker = ErrorTracker.contextAware();
-        configureErrorTracker();
         final BukkitContext.Factory context = new BukkitContext.Factory(plugin, token);
         context.metrics(factory -> {
             for (final FastStatsMetricsProvider provider : metricsProviders) {
@@ -45,12 +46,19 @@ public class FastStatsMetrics {
             return factory.create();
         });
         if (logErrors) {
+            this.errorTracker = ErrorTracker.contextAware();
+            configureErrorTracker();
             context.errorTrackerService(this.errorTracker);
+        } else {
+            this.errorTracker = null;
         }
         this.context = context.create();
     }
 
     private void configureErrorTracker() {
+        if (errorTracker == null) {
+            return;
+        }
         errorTracker
                 .anonymize("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$", "[[E-MAIL]]")
                 .anonymize("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "[[UUID]]");
@@ -61,8 +69,8 @@ public class FastStatsMetrics {
      *
      * @return the error tracker
      */
-    public ErrorTracker getErrorTracker() {
-        return errorTracker;
+    public Optional<ErrorTracker> getErrorTracker() {
+        return Optional.ofNullable(errorTracker);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/FastStatsMetricsComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/FastStatsMetricsComponent.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.kernel.component;
 
 import org.betonquest.betonquest.api.dependency.DependencyProvider;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.version.Version;
 import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.faststats.FastStatsMetrics;
@@ -34,7 +35,7 @@ public class FastStatsMetricsComponent extends AbstractCoreComponent {
 
     @Override
     public Set<Class<?>> requires() {
-        return Set.of(JavaPlugin.class, Compatibility.class, PluginDescriptionFile.class);
+        return Set.of(JavaPlugin.class, Compatibility.class, PluginDescriptionFile.class, BetonQuestLoggerFactory.class);
     }
 
     @Override
@@ -48,9 +49,11 @@ public class FastStatsMetricsComponent extends AbstractCoreComponent {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     protected void load(final DependencyProvider dependencyProvider) {
         final JavaPlugin plugin = getDependency(JavaPlugin.class);
         final PluginDescriptionFile descriptionFile = getDependency(PluginDescriptionFile.class);
+        final BetonQuestLoggerFactory loggerFactory = getDependency(BetonQuestLoggerFactory.class);
 
         final Version version = BetonQuestVersion.parse(descriptionFile.getVersion());
         final Optional<String> typeElement = version.getNamedElement("type");
@@ -60,9 +63,12 @@ public class FastStatsMetricsComponent extends AbstractCoreComponent {
                 .filter(injectedDependency -> FastStatsMetricsProvider.class.isAssignableFrom(injectedDependency.type()))
                 .map(injectedDependency -> (FastStatsMetricsProvider) injectedDependency.dependency())
                 .collect(Collectors.toSet());
-        final FastStatsMetrics fastStatsMetrics = new FastStatsMetrics(plugin, TOKEN, fastStatsMetricsProviders, fastStatsErrorTrackingEnabled);
-        fastStatsMetrics.enable();
-
-        dependencyProvider.take(FastStatsMetrics.class, fastStatsMetrics);
+        try {
+            final FastStatsMetrics fastStatsMetrics = new FastStatsMetrics(plugin, TOKEN, fastStatsMetricsProviders, fastStatsErrorTrackingEnabled);
+            fastStatsMetrics.enable();
+            dependencyProvider.take(FastStatsMetrics.class, fastStatsMetrics);
+        } catch (final Exception e) {
+            loggerFactory.create(FastStatsMetrics.class).error("Could not enable FastStats metrics!", e);
+        }
     }
 }


### PR DESCRIPTION
Add error handling for FastStatsMetrics initialization and make error tracker optional

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [ ]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... wrote a Migration?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
