### PR TITLE
Check in ChestPutObjective if there is a Chest/InventoryHolder only if the location matches

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/AbstractChestAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/AbstractChestAction.java
@@ -38,7 +38,7 @@ public abstract class AbstractChestAction implements NullableAction {
     protected InventoryHolder getChest(@Nullable final Profile profile) throws QuestException {
         final Block block = location.getValue(profile).getBlock();
         try {
-            return (InventoryHolder) block.getState();
+            return (InventoryHolder) block.getState(false);
         } catch (final ClassCastException e) {
             throw new QuestException("No chest found at location: X"
                     + block.getX() + " Y" + block.getY() + " Z" + block.getZ(), e);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveAction.java
@@ -47,7 +47,7 @@ public class ChestGiveAction implements NullableAction {
         final Block block = location.getValue(profile).getBlock();
         final InventoryHolder chest;
         try {
-            chest = (InventoryHolder) block.getState();
+            chest = (InventoryHolder) block.getState(false);
         } catch (final ClassCastException e) {
             throw new QuestException("Trying to put items in chest, but there's no chest! Location: X"
                     + block.getX() + " Y" + block.getY() + " Z" + block.getZ(), e);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/lever/LeverAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/lever/LeverAction.java
@@ -62,7 +62,7 @@ public class LeverAction implements NullableAction {
         };
         final Block relative = block.getRelative(attachedTo);
 
-        final BlockState relativeState = relative.getState();
+        final BlockState relativeState = relative.getState(true);
         if (relativeState instanceof final Container container) {
             container.getInventory().clear();
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/chest/ChestItemCondition.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/chest/ChestItemCondition.java
@@ -44,7 +44,7 @@ public class ChestItemCondition implements NullableCondition {
         final Block block = loc.getValue(profile).getBlock();
         final InventoryHolder chest;
         try {
-            chest = (InventoryHolder) block.getState();
+            chest = (InventoryHolder) block.getState(false);
         } catch (final ClassCastException e) {
             throw new QuestException("Trying to check items in a chest, but there's no chest! Location: X" + block.getX() + " Y"
                     + block.getY() + " Z" + block.getZ(), e);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -116,7 +116,7 @@ public class ChestPutObjective extends DefaultObjective {
             checkItems(onlineProfile);
             return;
         }
-        final InventoryHolder holder = event.getInventory().getHolder();
+        final InventoryHolder holder = event.getInventory().getHolder(false);
         if (holder instanceof final DoubleChest doubleChest) {
             final Chest leftChest = (Chest) doubleChest.getLeftSide();
             final Chest rightChest = (Chest) doubleChest.getRightSide();
@@ -141,10 +141,10 @@ public class ChestPutObjective extends DefaultObjective {
 
     private void checkIsInventory(final Location targetChestLocation) throws QuestException {
         final Block block = targetChestLocation.getBlock();
-        if (!(block.getState() instanceof InventoryHolder)) {
+        if (!(block.getState(false) instanceof InventoryHolder)) {
             final World world = targetChestLocation.getWorld();
             throw new QuestException(
-                    String.format("Block at location x:%d y:%d z:%d in world '%s' isn't a chest!",
+                    "Block at location x:%d y:%d z:%d in world '%s' isn't a chest!".formatted(
                             targetChestLocation.getBlockX(),
                             targetChestLocation.getBlockY(),
                             targetChestLocation.getBlockZ(),

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -61,12 +61,11 @@ public class ChestPutObjective extends DefaultObjective {
      * @param loc                the location of the chest
      * @param occupiedSender     the sender to notify the player if the chest is occupied
      * @param multipleAccess     manages the chest access for one or multiple players
-     * @throws QuestException if there is an error in the instruction
      */
     public ChestPutObjective(final ObjectiveService service,
                              final NullableCondition chestItemCondition, @Nullable final ChestTakeAction chestTakeAction,
                              final Argument<Location> loc, final IngameNotificationSender occupiedSender,
-                             final boolean multipleAccess) throws QuestException {
+                             final boolean multipleAccess) {
         super(service);
         this.chestItemCondition = chestItemCondition;
         this.chestTakeAction = chestTakeAction;
@@ -83,8 +82,8 @@ public class ChestPutObjective extends DefaultObjective {
      * @throws QuestException if argument resolving for the profile fails
      */
     public void onChestOpen(final InventoryOpenEvent event, final OnlineProfile onlineProfile) throws QuestException {
-        checkIsInventory(loc.getValue(onlineProfile));
         if (!multipleAccess && !checkForNoOtherPlayer(event)) {
+            checkIsInventory(loc.getValue(onlineProfile));
             occupiedSender.sendNotification(onlineProfile);
             event.setCancelled(true);
         }
@@ -109,13 +108,14 @@ public class ChestPutObjective extends DefaultObjective {
      */
     public void onChestClose(final InventoryCloseEvent event, final OnlineProfile onlineProfile) throws QuestException {
         final Location targetLocation = loc.getValue(onlineProfile);
-        checkIsInventory(targetLocation);
 
         final Location invLocation = event.getInventory().getLocation();
         if (invLocation != null && targetLocation.equals(invLocation.getBlock().getLocation())) {
+            checkIsInventory(targetLocation);
             checkItems(onlineProfile);
             return;
         }
+
         final InventoryHolder holder = event.getInventory().getHolder(false);
         if (holder instanceof final DoubleChest doubleChest) {
             final Chest leftChest = (Chest) doubleChest.getLeftSide();

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -14,6 +14,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
@@ -93,8 +94,10 @@ public class ChestPutObjective extends DefaultObjective {
      * @throws QuestException if argument resolving for the profile fails
      */
     public void onChestOpen(final InventoryOpenEvent event, final OnlineProfile onlineProfile) throws QuestException {
-        if (!multipleAccess && !checkForNoOtherPlayer(event)) {
-            checkIsInventory(loc.getValue(onlineProfile));
+        if (multipleAccess || IGNORED_TYPES.contains(event.getInventory().getType())) {
+            return;
+        }
+        if (!checkForNoOtherPlayer(event) && isRelevantBlock(event, onlineProfile)) {
             occupiedSender.sendNotification(onlineProfile);
             event.setCancelled(true);
         }
@@ -121,13 +124,18 @@ public class ChestPutObjective extends DefaultObjective {
         if (IGNORED_TYPES.contains(event.getInventory().getType())) {
             return;
         }
+        if (isRelevantBlock(event, onlineProfile)) {
+            checkItems(onlineProfile);
+        }
+    }
+
+    private boolean isRelevantBlock(final InventoryEvent event, final OnlineProfile onlineProfile) throws QuestException {
         final Location targetLocation = loc.getValue(onlineProfile);
 
         final Location invLocation = event.getInventory().getLocation();
         if (invLocation != null && targetLocation.equals(invLocation.getBlock().getLocation())) {
             checkIsInventory(targetLocation);
-            checkItems(onlineProfile);
-            return;
+            return true;
         }
 
         final InventoryHolder holder = event.getInventory().getHolder(false);
@@ -135,13 +143,12 @@ public class ChestPutObjective extends DefaultObjective {
             final Chest leftChest = (Chest) doubleChest.getLeftSide();
             final Chest rightChest = (Chest) doubleChest.getRightSide();
             if (leftChest == null || rightChest == null) {
-                return;
+                return false;
             }
-            if (leftChest.getLocation().getBlock().getLocation().equals(targetLocation)
-                    || rightChest.getLocation().getBlock().getLocation().equals(targetLocation)) {
-                checkItems(onlineProfile);
-            }
+            return leftChest.getLocation().getBlock().getLocation().equals(targetLocation)
+                    || rightChest.getLocation().getBlock().getLocation().equals(targetLocation);
         }
+        return false;
     }
 
     private void checkItems(final OnlineProfile onlineProfile) throws QuestException {

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/chestput/ChestPutObjective.java
@@ -15,16 +15,27 @@ import org.bukkit.block.Chest;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Requires the player to put items in the chest. Items can optionally NOT
  * disappear once the chest is closed.
  */
 public class ChestPutObjective extends DefaultObjective {
+
+    /**
+     * Inventory types without a persistent inventory.
+     */
+    private static final Set<InventoryType> IGNORED_TYPES = EnumSet.of(InventoryType.WORKBENCH, InventoryType.CRAFTING,
+            InventoryType.ENCHANTING, InventoryType.PLAYER, InventoryType.CREATIVE, InventoryType.MERCHANT, InventoryType.ANVIL,
+            InventoryType.SMITHING, InventoryType.BEACON, InventoryType.LOOM, InventoryType.CARTOGRAPHY, InventoryType.GRINDSTONE,
+            InventoryType.STONECUTTER, InventoryType.COMPOSTER);
 
     /**
      * Condition to check if the items are in the chest.
@@ -107,6 +118,9 @@ public class ChestPutObjective extends DefaultObjective {
      * @throws QuestException if argument resolving for the profile fails
      */
     public void onChestClose(final InventoryCloseEvent event, final OnlineProfile onlineProfile) throws QuestException {
+        if (IGNORED_TYPES.contains(event.getInventory().getType())) {
+            return;
+        }
         final Location targetLocation = loc.getValue(onlineProfile);
 
         final Location invLocation = event.getInventory().getLocation();

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -137,7 +137,7 @@ objectives:
 ## `ChestPut`
 
 __Context__: @snippet:objective-meta:online@  
-__Syntax__: `chestput <location> <items> [items-stay]`  
+__Syntax__: `chestput <location> <items> [items-stay] [multipleaccess]`  
 __Description__: The player has to put the specified items into the specified chest.
 
 First argument is a location of the chest, second argument is a list of items (from _items_ section),
@@ -146,6 +146,8 @@ You can also add amount of items after a colon.
 The items will be removed upon completing the objective unless you add `items-stay` optional argument.
 By default, only one player can look into the chest at the same time. You can change it by adding the key 
 `multipleaccess`.
+
+Note that the access to double chests can't be blocked and multiple players can open it even without `multipleaccess`.
 
 ```YAML title="Example"
 objectives:


### PR DESCRIPTION
<!-- Please describe your changes here. -->
and don't use block state snapshots when we don't use them - the inventories are live objects anways.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
