### PR TITLE
Update `faststats-bukkit.version` to 0.25.2

### DIFF
--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -27,7 +27,7 @@
 
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
     <bstats-bukkit.version>3.0.2</bstats-bukkit.version>
-    <faststats-bukkit.version>0.25.1</faststats-bukkit.version>
+    <faststats-bukkit.version>0.25.2</faststats-bukkit.version>
     <log4j-api.version>3.0.0-beta2</log4j-api.version>
     <log4j-core.version>3.0.0-beta2</log4j-core.version>
     <cron-utils.version>9.2.1</cron-utils.version>


### PR DESCRIPTION
Update `faststats-bukkit.version` to 0.25.2 in pom.xml fixing a severe bug in their implementation

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
