### PR TITLE
Escape quotes in simple item serializing

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
@@ -410,9 +410,9 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
                  "a" -> completeActions(args);
             case "items",
                  "item",
-                 "i" -> completeItems(false, args);
+                 "i" -> completeItems(true, args);
             case "give",
-                 "g" -> completeItems(true, args);
+                 "g" -> completeItems(false, args);
             case "objectives",
                  "objective",
                  "o" -> completeObjectives(args);
@@ -909,11 +909,11 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
      * Returns a list including all possible options for tab complete of the
      * /betonquest item and /betonquest give commands.
      */
-    private Optional<List<String>> completeItems(final boolean give, final String... args) {
+    private Optional<List<String>> completeItems(final boolean suggestSerializers, final String... args) {
         if (args.length == 2) {
             return completeId(args, AccessorType.ITEMS);
         }
-        if (give && args.length == 3) {
+        if (suggestSerializers && args.length == 3) {
             return Optional.of(List.copyOf(itemTypeRegistry.serializerKeySet()));
         }
         return Optional.of(new ArrayList<>());

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BookHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BookHandler.java
@@ -107,9 +107,12 @@ public class BookHandler implements ItemMetaHandler<BookMeta> {
         if (bookMeta.hasPages()) {
             final StringBuilder builder = new StringBuilder();
             for (final Component page : bookMeta.pages()) {
-                builder.append(MiniMessage.miniMessage().serialize(page).replace("|", "\\|")).append('|');
+                builder.append('|').append(MiniMessage.miniMessage().serialize(page)
+                        .replace("|", "\\|")
+                        .replace("\"", "\\\"")
+                );
             }
-            return " \"text:@[minimessage]" + builder.substring(0, builder.length() - 1) + "\"";
+            return " \"text:@[minimessage]" + builder.substring(1) + "\"";
         }
         return "";
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/HandlerUtil.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/HandlerUtil.java
@@ -94,13 +94,15 @@ public final class HandlerUtil {
      * <p>
      * It will be serialized into MiniMessage format and prefixed with {@code @[minimessage]}
      * as used in the DecidingMessageParser standard implementation.
+     * <p>
+     * In addition, all quotes will be escaped as parsed in the standard tokenizer.
      *
      * @param key   the instruction key
      * @param value the component to serialize
      * @return the ready to parse key value pair
      */
     public static String toKeyValue(final String key, final Component value) {
-        return "\"" + key + ":@[minimessage]" + MiniMessage.miniMessage().serialize(value) + "\"";
+        return "\"" + key + ":@[minimessage]" + MiniMessage.miniMessage().serialize(value).replace("\"", "\\\"") + "\"";
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/LoreHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/LoreHandler.java
@@ -1,7 +1,6 @@
 package org.betonquest.betonquest.item.typehandler;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.text.TextParser;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -68,11 +67,10 @@ public class LoreHandler implements ItemMetaHandler<ItemMeta> {
     public String serializeToString(final ItemMeta meta) {
         if (meta.hasLore()) {
             final StringBuilder string = new StringBuilder(22);
-            final MiniMessage miniMessage = MiniMessage.miniMessage();
             for (final Component line : meta.lore()) {
-                string.append("\"lore:@[minimessage]").append(miniMessage.serialize(line)).append("\" ");
+                string.append(' ').append(HandlerUtil.toKeyValue("lore", line));
             }
-            return string.substring(0, string.length() - 1);
+            return string.substring(1);
         }
         return null;
     }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
so it can be parsed from the tokenizer.

I also found a _thing_ with that the Quest Item lore gets added to the item, but that has to be removed manually in my opinion.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #4007

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
