### PR TITLE
Add QuestPredicate interface

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/common/function/QuestPredicate.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/common/function/QuestPredicate.java
@@ -37,9 +37,8 @@ public interface QuestPredicate<T> {
      * @return a composed predicate that represents the short-circuiting logical
      * AND of this predicate and the {@code other} predicate
      * @throws NullPointerException if other is null
-     * @throws QuestException       when the method execution fails
      */
-    default QuestPredicate<T> and(final QuestPredicate<? super T> other) throws QuestException {
+    default QuestPredicate<T> and(final QuestPredicate<? super T> other) {
         Objects.requireNonNull(other);
         return (T t) -> test(t) && other.test(t);
     }
@@ -50,9 +49,8 @@ public interface QuestPredicate<T> {
      *
      * @return a predicate that represents the logical negation of this
      * predicate
-     * @throws QuestException when the method execution fails
      */
-    default QuestPredicate<T> negate() throws QuestException {
+    default QuestPredicate<T> negate() {
         return (T t) -> !test(t);
     }
 
@@ -71,10 +69,9 @@ public interface QuestPredicate<T> {
      * @return a composed predicate that represents the short-circuiting logical
      * OR of this predicate and the {@code other} predicate
      * @throws NullPointerException if other is null
-     * @throws QuestException       when the method execution fails
      */
     @SuppressWarnings("PMD.ShortMethodName")
-    default QuestPredicate<T> or(final QuestPredicate<? super T> other) throws QuestException {
+    default QuestPredicate<T> or(final QuestPredicate<? super T> other) {
         Objects.requireNonNull(other);
         return (T t) -> test(t) || other.test(t);
     }

--- a/code/api/src/main/java/org/betonquest/betonquest/api/common/function/QuestPredicate.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/common/function/QuestPredicate.java
@@ -1,0 +1,81 @@
+package org.betonquest.betonquest.api.common.function;
+
+import org.betonquest.betonquest.api.QuestException;
+
+import java.util.Objects;
+
+/**
+ * A {@link java.util.function.Predicate} that may throw a {@link QuestException}
+ *
+ * @param <T> The type of the input argument
+ */
+@FunctionalInterface
+public interface QuestPredicate<T> {
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param value the argument to test
+     * @return {@code true} if the input argument match the predicate,
+     * otherwise {@code false}
+     * @throws QuestException when the method execution fails
+     */
+    boolean test(T value) throws QuestException;
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * AND of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code false}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ANDed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * AND of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     * @throws QuestException       when the method execution fails
+     */
+    default QuestPredicate<T> and(final QuestPredicate<? super T> other) throws QuestException {
+        Objects.requireNonNull(other);
+        return (T t) -> test(t) && other.test(t);
+    }
+
+    /**
+     * Returns a predicate that represents the logical negation of this
+     * predicate.
+     *
+     * @return a predicate that represents the logical negation of this
+     * predicate
+     * @throws QuestException when the method execution fails
+     */
+    default QuestPredicate<T> negate() throws QuestException {
+        return (T t) -> !test(t);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * OR of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code true}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ORed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * OR of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     * @throws QuestException       when the method execution fails
+     */
+    @SuppressWarnings("PMD.ShortMethodName")
+    default QuestPredicate<T> or(final QuestPredicate<? super T> other) throws QuestException {
+        Objects.requireNonNull(other);
+        return (T t) -> test(t) || other.test(t);
+    }
+}


### PR DESCRIPTION
I found the use for this functional interface in #4025 - I think it has more uses for at least integrations.

---

### Related Issues

None

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
