### PR TITLE
Fix version parsing for policies

### DIFF
--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/BetonQuestPolicy.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/BetonQuestPolicy.java
@@ -20,8 +20,7 @@ public record BetonQuestPolicy(Version version, VersionCompareStrategy versionCo
 
     @Override
     public boolean validate() {
-        return pluginProvider().withVersionType(BetonQuestVersion.BETONQUEST_VERSION_TYPE)
-                .version().map(actual -> versionCompareStrategy.test(actual, version)).orElse(false);
+        return pluginProvider().version().map(actual -> versionCompareStrategy.test(actual, version)).orElse(false);
     }
 
     @Override
@@ -31,6 +30,6 @@ public record BetonQuestPolicy(Version version, VersionCompareStrategy versionCo
 
     @Override
     public PluginProvider pluginProvider() {
-        return PluginProvider.forName(name());
+        return PluginProvider.forName(name()).withVersionType(BetonQuestVersion.BETONQUEST_VERSION_TYPE);
     }
 }

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/UnversionedPluginPolicy.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/UnversionedPluginPolicy.java
@@ -1,6 +1,7 @@
 package org.betonquest.betonquest.lib.integration.policy;
 
 import org.betonquest.betonquest.lib.integration.PluginProvider;
+import org.betonquest.betonquest.lib.version.DefaultVersionType;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -17,5 +18,10 @@ public record UnversionedPluginPolicy(PluginProvider pluginProvider, String desc
     @Override
     public boolean validate() {
         return pluginProvider.plugin().map(Plugin::isEnabled).orElse(false);
+    }
+
+    @Override
+    public PluginProvider pluginProvider() {
+        return pluginProvider.withVersionType(DefaultVersionType.UNDEFINED_VERSION);
     }
 }

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/VersionedPluginPolicy.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/integration/policy/VersionedPluginPolicy.java
@@ -23,13 +23,18 @@ public record VersionedPluginPolicy(PluginProvider pluginProvider, Version versi
 
     @Override
     public boolean validate() {
-        return pluginProvider.plugin().map(Plugin::isEnabled).orElse(false)
-                && pluginProvider.withVersionType(version.type()).version()
-                .map(actual -> versionCompareStrategy.test(actual, version)).orElse(false);
+        final PluginProvider provider = pluginProvider();
+        return provider.plugin().map(Plugin::isEnabled).orElse(false)
+                && provider.version().map(actual -> versionCompareStrategy.test(actual, version)).orElse(false);
     }
 
     @Override
     public String name() {
         return pluginProvider.name().orElse("unknown plugin");
+    }
+
+    @Override
+    public PluginProvider pluginProvider() {
+        return pluginProvider.withVersionType(version.type());
     }
 }

--- a/code/lib/src/main/java/org/betonquest/betonquest/lib/version/DefaultVersionType.java
+++ b/code/lib/src/main/java/org/betonquest/betonquest/lib/version/DefaultVersionType.java
@@ -34,6 +34,13 @@ public record DefaultVersionType(List<VersionToken> tokens) implements VersionTy
             .build();
 
     /**
+     * Accepts any version string.
+     */
+    public static final DefaultVersionType UNDEFINED_VERSION = builder()
+            .finite().any("version")
+            .build();
+
+    /**
      * Create a new {@link VersionTypeBuilder} instance.
      *
      * @return a new {@link VersionTypeBuilder} instance

--- a/code/lib/src/test/java/org/betonquest/betonquest/lib/version/UnspecifiedVersionTest.java
+++ b/code/lib/src/test/java/org/betonquest/betonquest/lib/version/UnspecifiedVersionTest.java
@@ -1,0 +1,40 @@
+package org.betonquest.betonquest.lib.version;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class UnspecifiedVersionTest {
+
+    private static final Set<String> ANY_STRING = Set.of(
+            "1.0", "2.0-dev", "2.2-asdasz77+45", "literally anything", "123i?´d#+as",
+            "1.0.", "3.0.0-dev-1.1", "1.0.0b", "3.0.0-dev.1",
+            "1.2.5-DEV-1.1", "2.2.a", "2.2.0-SNAPSHOT", "2.2.0-SNAPSHOT-1", "2.2.0-alpha.1", "1.1.1.1", "1.0.0+dev-55",
+            "1.0.0-DEV", "1.2.5-DEV", "2.0.0-DEV", "2.2.0-DEV", "3.0.0-DEV", "1.0.0-dev-", "2.2.0-rc.1",
+            "3.0.0-UNOFFICIAL", "2.2.-DEV-50", "2.2.0-dev-1", "1.0.0-DEV-ARTIFACT-Wolf2323/Betonquest-55",
+            "1.10", "1.0.0", "1.2.5", "2.0.0", "2.2.0", "3.0.0",
+            "1.0.0-DEV-55", "1.2.5-DEV-23", "2.0.0-DEV-334", "2.2.0-DEV-918", "3.0.0-DEV-1",
+            "5.0.0-DEV-UNOFFICIAL", "1.0.0-DEV-ARTIFACT-34541", "1.0.0-DEV-ARTIFACT-Wolf2323-Betonquest-55");
+
+    private static Stream<Arguments> anyVersion() {
+        return ANY_STRING.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("anyVersion")
+    void any_non_empty_string_is_valid_for_unspecified_version(final String versionString) {
+        assertDoesNotThrow(() -> VersionParser.parse(DefaultVersionType.UNDEFINED_VERSION, versionString));
+    }
+
+    @Test
+    void empty_string_is_invalid_for_unspecified_version() {
+        assertThrows(IllegalArgumentException.class, () -> VersionParser.parse(DefaultVersionType.UNDEFINED_VERSION, ""));
+    }
+}


### PR DESCRIPTION
Fix bug where version parsing failed even if no explicit version type was set and an undefined version policy was used.
By displaying via the version reader in PluginProvider, some policies assumed the wrong version format.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
