### PR TITLE
Fix missing deprecation

### DIFF
--- a/code/api/src/main/java/org/betonquest/betonquest/api/instruction/InstructionParts.java
+++ b/code/api/src/main/java/org/betonquest/betonquest/api/instruction/InstructionParts.java
@@ -1,12 +1,16 @@
 package org.betonquest.betonquest.api.instruction;
 
 import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.chain.InstructionChainParser;
 
 import java.util.List;
 
 /**
  * Represents the parts of an instruction.
+ *
+ * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
  */
+@Deprecated
 public interface InstructionParts {
 
     /**
@@ -14,28 +18,36 @@ public interface InstructionParts {
      *
      * @return The next part of the instruction.
      * @throws QuestException If there are no parts left.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     String nextElement() throws QuestException;
 
     /**
      * Gets the current part of the instruction.
      *
      * @return The current part of the instruction.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     String current();
 
     /**
      * Checks if there are more parts left.
      *
      * @return True if there are more parts left, false otherwise.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     boolean hasNext();
 
     /**
      * Gets the number of parts.
      *
      * @return The number of parts.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     int size();
 
     /**
@@ -44,21 +56,27 @@ public interface InstructionParts {
      * @param index The index of the part to get.
      * @return The part at the given index.
      * @throws QuestException If the index is out of bounds.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     String getPart(int index) throws QuestException;
 
     /**
      * Gets all parts of the instruction as a list.
      *
      * @return The parts of the instruction as a list.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     List<String> getParts();
 
     /**
      * Gets the parts of the instruction excluding the first part.
      *
      * @return The parts of the instruction.
+     * @deprecated Use {@link Instruction} and {@link InstructionChainParser} instead.
      */
+    @Deprecated
     default List<String> getValueParts() {
         return getParts().subList(1, size());
     }


### PR DESCRIPTION
Mark `InstructionParts` interface and its methods as deprecated, suggesting the use of `Instruction` and `InstructionChainParser`.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
