### PR TITLE
Improve release script (SSH auth)

### DIFF
--- a/.github/scripts/release_utils.sh
+++ b/.github/scripts/release_utils.sh
@@ -9,64 +9,26 @@ printNewSection() {
 
 checkRequirements() {
   echo 'Requirements'
-  findSshKey
   checkSsh
   checkGit
   checkMaven
   checkGitHubCLI
 }
 
-findSshKey() {
-  keys=()
-  for k in ~/.ssh/*;
-  do
-    if [[ -f "$k" && "${k##*/}" != *.* && "${k##*/}" != "known_hosts" ]];
-    then
-      keys+=("$k")
-    fi
-  done
-
-  if [ ${#keys[@]} -eq 0 ];
+checkSsh() {
+  if ! ssh-add -l >/dev/null 2>&1
   then
-    echo "    SSH: failed [no keys found]"
+    echo '    SSH: failed [ssh authentication]'
     exit 1
   fi
-
-  if [ ${#keys[@]} -eq 1 ];
+  set +o pipefail
+  if ! ssh -o BatchMode=yes -T git@github.com 2>&1 | grep -q "successfully authenticated";
   then
-      SSH_KEY="${keys[0]}"
-  else
-    echo "    Select SSH key:"
-    select SSH_KEY in "${keys[@]}";
-    do
-      if [[ -n "$SSH_KEY" ]];
-      then
-        break
-      fi
-    done
-    deletePreviousLines 2
-    deletePreviousLines "${#keys[@]}"
+      echo '    SSH: failed [github authentication]'
+      exit 1
   fi
-}
-
-checkSsh() {
-  if ssh-add "$SSH_KEY" &> /dev/null;
-  then
-    echo '    SSH: ok'
-    return 0
-  fi
-  if [ -z "${SSH_AUTH_SOCK:-}" ];
-  then
-    eval "$(ssh-agent -s)" > /dev/null
-    trap 'ssh-agent -k >/dev/null' EXIT
-    if ssh-add "$SSH_KEY" &> /dev/null;
-    then
-        echo '    SSH: ok [local ssh-agent]'
-        return 0
-    fi
-  fi
-  echo '    SSH: failed [not authenticated]'
-  exit 1
+  set -o pipefail
+  echo '    SSH: ok'
 }
 
 checkGit() {


### PR DESCRIPTION
Simplify SSH authentication logic in release utility script for improved reliability.

Now all steps to enable ssh and allow access to github are required to do by the user.
The release script is just not the correct file to do that sort of environmental stuff.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
