### PR TITLE
Enhance GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Request
-    about: Suggest new features to help us improve the plugin.
+  - name: Share your ideas
+    about: Share your ideas with us that aren't precise enough for a feature request yet!
     url: https://github.com/BetonQuest/BetonQuest/discussions/new?category=ideas
   - name: BetonQuest Support
-    about: Quick, chat-based support for any usage questions.
+    about: Quick, chat-based support for any usage questions on discord.
     url: https://discord.gg/rK6mfHq

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -2,7 +2,6 @@ name: "Docs Feedback"
 title: "[Docs] "
 description: "Report wrong or unclear documentation."
 labels: [ "Documentation" ]
-projects: [ "BetonQuest/BetonQuest" ]
 body:
   - type: input
     id: "version"
@@ -12,6 +11,7 @@ body:
       placeholder: "3.0"
     validations:
       required: true
+
   - type: input
     id: "url"
     attributes:
@@ -20,6 +20,7 @@ body:
       placeholder: "https://betonquest.org/RELEASE/"
     validations:
       required: true
+
   - type: textarea
     id: "description"
     attributes:
@@ -27,6 +28,7 @@ body:
       description: "What can be improved?"
     validations:
       required: true
+
   - type: upload
     id: "screenshots"
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,77 @@
+name: "Feature Request"
+description: "Describe a new feature for this project."
+type: "Feature Request"
+body:
+  - type: markdown
+    attributes:
+      value: "## Thanks for filling out this feature request!"
+  - type: markdown
+    attributes:
+      value: |
+        Please read _carefully_ and fill out the following sections as **detailed as possible**.
+        If you provide sufficient information, your feature request will be considered more likely.
+
+  - type: checkboxes
+    attributes:
+      label: "Checklist before submitting a feature request"
+      description: "Please make sure you've checked these boxes truthfully before submitting your feature request."
+      options:
+        - label: "I have checked that this feature hasn't already been implemented."
+          required: true
+        - label: "I have checked that this feature hasn't already been suggested."
+          required: true
+
+  - type: input
+    id: "version"
+    attributes:
+      label: "Which is the current version of the project? (latest release or development build)"
+      description: |
+        Please specify the version of the project. It provides context.
+        This is important for us to know the age of the request as well as if it
+        might be already implemented/still not implemented.
+      placeholder: "3.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: "problem"
+    attributes:
+      label: "Describe the problem you're trying to solve"
+      description: "Describing the problem you're trying to solve will help us understand the context of this feature."
+      placeholder: |
+        Suggestions:
+        - I'm always frustrated when [...]
+        - I would like to be able to [...]
+        - This is currently difficult/impossible because [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: "solution"
+    attributes:
+      label: "Describe the solution you'd like"
+      description: "A clear and concise description of what you want to happen."
+      placeholder: |
+        Suggestions:
+        - This should be possible to do by [...]
+        - It could be done by [...]
+        - A solution might look like [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: "alternatives"
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered and your reasoning behind discarding them."
+      placeholder: |
+        Suggestions:
+        - There is also [...], but [...]
+        - I've considered [...], but [...]
+        - This is also possible to do by [...], but [...]
+
+  - type: textarea
+    id: "additional"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context or just any information about the feature request here."

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,64 @@
+name: "Task"
+description: "Create a new task."
+type: "Task"
+body:
+  - type: markdown
+    attributes:
+      value: "# Only useful for maintainers"
+
+  - type: markdown
+    attributes:
+      value: |
+        This form should streamline the process of creating a new task and provide a consistent format.
+        It should also ensure that the task is properly defined and considered to be complete.
+
+  - type: textarea
+    id: "short"
+    attributes:
+      label: "Short introduction"
+      description: "A clear, concise and short description of what the task is."
+      placeholder: "Create X that does Y by using Z"
+    validations:
+      required: true
+
+  - type: textarea
+    id: "related"
+    attributes:
+      label: "Related"
+      description: "List any related (parent) issues, discussions, etc."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: "requirements"
+    attributes:
+      label: "Which common steps are required? This task requires..."
+      options:
+        - label: "Changes to the code"
+        - label: "Changes to the database"
+        - label: "Changes to the documentation"
+        - label: "Updating changelog"
+        - label: "Additional unit testing"
+        - label: "Creating a migration"
+        - label: "Bumping the version of the api or library module"
+    validations:
+      required: true
+
+  - type: textarea
+    id: "steps"
+    attributes:
+      label: "Steps to complete"
+      description: "Describe the steps required to complete the task."
+      placeholder: |
+        1. Create A
+        2. Use B to complete C
+        3. Change X
+        4. Implement Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: "notes"
+    attributes:
+      label: "Additional context"
+      description: "Any additional notes, description or context."


### PR DESCRIPTION
Enhance GitHub issues templates.

- Add templates for `task` and `feature request` issue types
- Adjust github issue config.yml to no longer link feature request to the discussions

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
