### PR TITLE
Add questlang language whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- `language.questlang_whitelist` to restrict which languages players can select via `/questlang`
 ### Changed
+- `language` config option is now a section; the default language moved to `language.default`
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/core/src/main/java/org/betonquest/betonquest/command/LangCommand.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/command/LangCommand.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import org.betonquest.betonquest.api.LanguageProvider;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.common.component.VariableReplacement;
+import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.api.config.Localizations;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
@@ -21,7 +22,6 @@ import org.bukkit.entity.Player;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Changes the default language for the player.
@@ -60,6 +60,11 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
     private final IngameNotificationSender languageChangedSender;
 
     /**
+     * The plugin configuration, used to read the questlang whitelist.
+     */
+    private final ConfigAccessor config;
+
+    /**
      * Creates a new executor for the /questlang command.
      *
      * @param log              the logger that will be used for logging
@@ -67,10 +72,11 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
      * @param localizations    the {@link Localizations} instance
      * @param profileProvider  the profile provider instance
      * @param languageProvider the language provider instance
+     * @param config           the {@link ConfigAccessor} used to read the language whitelist
      */
     public LangCommand(final BetonQuestLogger log, final PlayerDataStorage dataStorage,
                        final Localizations localizations, final ProfileProvider profileProvider,
-                       final LanguageProvider languageProvider) {
+                       final LanguageProvider languageProvider, final ConfigAccessor config) {
         this.log = log;
         this.dataStorage = dataStorage;
         this.localizations = localizations;
@@ -78,6 +84,23 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
         this.languageProvider = languageProvider;
         this.languageChangedSender = new IngameNotificationSender(log, localizations, null,
                 "LanguageCommand", NotificationLevel.INFO, "language_changed");
+        this.config = config;
+    }
+
+    /**
+     * Resolves the languages a player is allowed to select via {@code /questlang}.
+     * <p>
+     * An empty {@code language.questlang_whitelist} allows every loaded language; a non-empty
+     * whitelist restricts the result to the loaded languages that are also whitelisted.
+     *
+     * @return the list of selectable language keys
+     */
+    private List<String> allowedLanguages() {
+        final List<String> whitelist = config.getStringList("language.questlang_whitelist");
+        if (whitelist.isEmpty()) {
+            return localizations.getLanguages().stream().toList();
+        }
+        return localizations.getLanguages().stream().filter(whitelist::contains).toList();
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")
@@ -98,7 +121,7 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
             }
             return true;
         }
-        final Set<String> languages = localizations.getLanguages();
+        final List<String> languages = allowedLanguages();
         if (!languages.contains(args[0]) && !"default".equalsIgnoreCase(args[0])) {
             final StringBuilder builder = new StringBuilder();
             builder.append("default (").append(languageProvider.getDefaultLanguage()).append("), ").append(String.join(", ", languages));
@@ -127,7 +150,7 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
     @Override
     public Optional<List<String>> simpleTabComplete(final CommandSender sender, final Command command, final String alias, final String[] args) {
         if (args.length == 1) {
-            return Optional.of(localizations.getLanguages().stream().toList());
+            return Optional.of(allowedLanguages());
         }
         return Optional.of(Collections.emptyList());
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/CommandsComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/CommandsComponent.java
@@ -114,7 +114,7 @@ public class CommandsComponent extends AbstractCoreComponent {
         javaPlugin.getCommand("compass").setExecutor(new CompassCommand(javaPlugin, loggerFactory,
                 config, localizations, profileProvider, playerDataStorage, cancelerProcessor,
                 compassManager, itemManager, identifiers));
-        final LangCommand langCommand = new LangCommand(loggerFactory.create(LangCommand.class), playerDataStorage, localizations, profileProvider, languageProvider);
+        final LangCommand langCommand = new LangCommand(loggerFactory.create(LangCommand.class), playerDataStorage, localizations, profileProvider, languageProvider, config);
         javaPlugin.getCommand("questlang").setExecutor(langCommand);
         javaPlugin.getCommand("questlang").setTabCompleter(langCommand);
         javaPlugin.getCommand("betonquestanswer").setTabCompleter((sender, command, label, args) -> List.of());

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/ConfigComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/ConfigComponent.java
@@ -82,7 +82,7 @@ public class ConfigComponent extends AbstractCoreComponent {
         @Override
         public Set<Metric<?>> getMetrics() {
             return Set.of(
-                    Metric.string("c_server_language", () -> fileConfigAccessor.getString("language")),
+                    Metric.string("c_server_language", () -> fileConfigAccessor.getString("language.default")),
                     Metric.string("c_conversation_default_io", () -> fileConfigAccessor.getString("conversation.default_io")),
                     Metric.string("c_conversation_interceptor_default", () -> fileConfigAccessor.getString("conversation.interceptor.default")),
                     Metric.number("c_npc_interaction_limit", () -> fileConfigAccessor.getInt("npc.interaction_limit")),

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/LanguageProviderComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/LanguageProviderComponent.java
@@ -33,7 +33,7 @@ public class LanguageProviderComponent extends AbstractCoreComponent {
     protected void load(final DependencyProvider dependencyProvider) {
         final ConfigAccessor config = getDependency(ConfigAccessor.class);
 
-        final LanguageProvider languageProvider = () -> config.getString("language", "en-US");
+        final LanguageProvider languageProvider = () -> config.getString("language.default", "en-US");
 
         dependencyProvider.take(LanguageProvider.class, languageProvider);
     }

--- a/code/core/src/main/resources/config.patch.yml
+++ b/code/core/src/main/resources/config.patch.yml
@@ -1,4 +1,11 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.1.0.1:
+  - type: KEY_RENAME
+    oldKey: language
+    newKey: language.default
+  - type: SET
+    key: language.questlang_whitelist
+    value: []
 3.0.0.26:
   - type: SET
     key: conversation.io.menu.bottom_margin

--- a/code/core/src/main/resources/config.yml
+++ b/code/core/src/main/resources/config.yml
@@ -1,5 +1,4 @@
 configVersion: ""
-language: en-US
 text_parser: legacyminimessage
 date_format: dd.MM.yyyy HH:mm
 default_notify_io: chat
@@ -26,6 +25,9 @@ mysql:
   reconnect_interval: 1000
 profile:
   initial_name: 'default'
+language:
+  default: en-US
+  questlang_whitelist: []
 conversation:
   default_io: menu,packetevents,tellraw
   block_item_transfer: true

--- a/docs/Documentation/Reference/Plugin-Config.md
+++ b/docs/Documentation/Reference/Plugin-Config.md
@@ -5,13 +5,6 @@ icon: octicons/tasklist-16
 The configuration of BetonQuest is mainly done in the "_config.yml_" file. All of its options are described on this page.
 There is also additional information about backups, updates, and database transfers. 
 
-## `language` - Default plugin language
-The language option sets the default language of BetonQuest.  
-It is used for all players that do not have a specific language set or as fallback language just in case.  
-You can see all available languages in the `lang` folder, and you can add your own language files there.
-The language consists of a 2 to 3 character language key (a-z in lowercase), followed by a dash and at least
-2 characters from a-z, A-Z, numbers and dashes. 
-
 ## `text_parser` - Default text parser
 Set the default parser used to format all text in betonquest.
 For more information, see the [Text Formatting](../Advanced/Text-Formatting.md) page.
@@ -108,6 +101,21 @@ Profiles allow players to have different progress/data active.
 Currently, there is no way to switch between profiles, as the feature is still in development.
 
 * `initial_name` - The name of the profile that is created when a player joins for the first time.
+
+## `language` - Language settings
+`language` section controls the languages BetonQuest uses.
+
+### `language.default` - Default plugin language
+Sets the default language of BetonQuest.  
+It is used for all players that do not have a specific language set, or as a fallback language just in case.  
+You can see all available languages in the `lang` folder, and you can add your own language files there.
+The language consists of a 2 to 3 character language key (a-z in lowercase), followed by a dash and at least
+2 characters from a-z, A-Z, numbers and dashes.
+
+### `language.questlang_whitelist` - Selectable languages
+A list of languages that players are allowed to choose with the `/questlang` command.  
+Leave it empty (`[]`) to allow every loaded language. If the list is not empty, only the listed languages
+are offered as tab-completions and can be selected; any other language is treated as if it does not exist.
 
 ## `conversation` - Conversation settings
 All conversation related settings.


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Add a `language.questlang_whitelist` config option that limits which languages players can select via the /questlang command. An empty list (the default) allows all loaded languages, preserving current behaviour; a non-empty list restricts both tab-completion and selection to the listed languages. A non-whitelisted language is treated as non-existent and reuses the existing `language_not_exist` message.

The `language` config option is now a section, with the default moved to `language.default`. A config patch (3.1.0.1) migrates existing configs, and the default-language reads were updated accordingly.

How I tested:
- ConfigPatcherIT passes (old baseline config patches cleanly to the new structure).
- Full ./mvnw clean verify is green, including Checkstyle/PMD/SpotBugs.
- In-game: with questlang_whitelist: [en-US, de-DE], only those two tab-complete and are selectable; /questlang fr-FR is rejected with language_not_exist; an empty list restores all languages; a fresh player gets language.default.
- Migration: a config with the old flat `language: en` is rewritten to the nested structure on startup.
---

### Related Issues

<!-- Issue number if existing. -->
Closes #4066 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
