### PR TITLE
[DOCS] Add explanation for nested paths in placeholders

### DIFF
--- a/docs/Documentation/Basics/Packages-&-Templates.md
+++ b/docs/Documentation/Basics/Packages-&-Templates.md
@@ -169,6 +169,57 @@ to match the current location, relative paths will still work.
         zombieObjective: "mobkill ZOMBIE 50 actions:{==-weeklyQuestTwo-subQuest>startQuest==}"
         ````
     
+#### Nested Package paths
+
+In some places, like the [`eval` placeholder](../Reference/Placeholders-List.md#eval), you may need
+to write package paths inside nested placeholders. In order to do so you need to escape the grater
+than (`>`) of the inner paths with a level of backslash (`\`).
+
+Note that in some cases you may need to escape the backslash too (`\\`) for a single level of
+escaping. For example, when you are in a double-quoted YAML string (`" "`).
+
+??? example
+
+    === "`eval` placeholder"
+        Let's assume you have two packages: The second one called `OtherPackage` in which there is just
+        a simple constant `shape`.
+        ```YAML
+        constants:
+          shape: triangle
+        ```
+        Usually you could use this with `%OtherPackage>constant.shape%` when accessing from other
+        packages.
+
+        However, in this example, you want to use this `shape` as the name for another constant
+        inside your first package using the [`eval` placeholder](../Reference/Placeholders-List.md#eval).
+        ```YAML
+        constants:
+          red_triangle: This works!
+          red_circle: Not this shape.
+          blue_square: Also not this one.
+        
+        actions:
+          printShape: notify %eval.constant.red_\%OtherPackage\>constant.shape\%%
+        ```
+
+    === "`math` placeholder"
+        Let's assume the same base: A package called `OtherPackage` in which there is just
+        a simple constant `amount`.
+        ```YAML
+        constants:
+          amount: 7
+        ```
+
+        Now, in this example, you want to work with this `amount` inside your first package in the 
+        [`math` placeholder](../Reference/Placeholders-List.md#math) and set its result as the `answer` globalpoint.
+        ```YAML
+        constants:
+          factor: 6
+        
+        actions:
+          setAnswer: globalpoint answer %math.calc:{constant.factor}*{OtherPackage\>constant.amount}% action:set
+        ```
+
 ### Disabling Packages
 
 Packages are enabled by default, you can disable a package if you don't want it to be loaded.

--- a/docs/Documentation/Reference/Placeholders-List.md
+++ b/docs/Documentation/Reference/Placeholders-List.md
@@ -63,9 +63,13 @@ You can nest multiple evals, but this leads you to an escape hell.
 If you do so, you need to add one escape level with each nesting level,
 this means normally you write `\%` and in the next level you need to write `\\\%`.
 
+When using a cross package reference, remember to escape the `>` of a nested placeholder too. More
+on this in the [nested package paths](../Basics/Packages-&-Templates.md#nested-package-paths) article.
+
 ```scss title="Example"
 %eval.player.\%objective.placeholderStore.displayType\%%
 %eval.player.\%eval.objective.\\\%objective.otherStore.targetStore\\\%.displayType\%%
+%eval.player.\%OtherPackage\>objective.placeholderStore.displayType\%%
 ```
 
 ## `GlobalPoint`
@@ -191,11 +195,16 @@ When the calculation fails `0` will be returned and the reason logged.
     If you don't want to escape the percentage and actually want to write a backslash you can use `\\%`.
     Don't forget to escape the backslash itself with another backslash if you are inside a double-quoted string `"`.
 
+    When using a cross package reference, remember to escape the `>` of a nested placeholder too.
+    More on this in the [nested package paths](../Basics/Packages-&-Templates.md#nested-package-paths)
+    article.
+
 ```scss title="Example"
 %math.calc:100*(15-point.reputation.amount)%
 %math.calc:objective.kill_zombies.left/objective.kill_zombies.total*100~2%
 %math.calc:-{ph.myplugin_stragee+placeholder}%
 %math.calc:64\%32%
+%math.calc:3*OtherPackage\>globalpoint.factor.amount%
 ```
 
 ## `Npc`


### PR DESCRIPTION
<!-- Please describe your changes here. -->
When I was migrating from an older DEV build of 3.0 to the full release of 3.0, I ran into an issue which I could not read anything about in the docs.

Across package communication, but nested inside `eval` and `math.calc`. The clue was to also escape the `>` now.

These are the places I tried to look for when I was searching for this.
I don't know, if there are more cases where an `>` needs escaping.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... wrote a Migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
