### PR TITLE
Fix questlang command error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Deprecated
 ### Removed
 ### Fixed
+- `/questlang` command error message listing the available languages incorrectly
 ### Security
 
 ## [3.0.2] - 2026-06-24

--- a/code/core/src/main/java/org/betonquest/betonquest/command/LangCommand.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/command/LangCommand.java
@@ -129,7 +129,7 @@ public class LangCommand implements CommandExecutor, SimpleTabCompleter {
                 log.warn("No localizations loaded, somethings wrong!");
                 return false;
             }
-            final String finalMessage = builder.substring(0, builder.length() - 2) + ".";
+            final String finalMessage = builder.append('.').toString();
             try {
                 sender.sendMessage(localizations.getMessage(onlineProfile, "language_not_exist",
                         new VariableReplacement("languages", Component.text(finalMessage))));


### PR DESCRIPTION
Fix string concatenation in LangCommand to no longer chop off the last 2 characters

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
