### PR TITLE
Update WorldGuard and WorldEdit compatibility to newer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `language` config option is now a section; the default language moved to `language.default`
 - `burn` action to no longer require its duration argument to specify its name `duration`
 - `mmoitem` now checks for soulbound when set
+- `worldguard` integration version requirement to 7.0.17
+- `worldedit` integration version requirement to 7.3.19
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/compatibility/pom.xml
+++ b/code/compatibility/pom.xml
@@ -25,10 +25,10 @@
 
     <!-- dependency versions -->
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
-    <worldguard-bukkit.version>7.0.9</worldguard-bukkit.version>
-    <worldguard-core.version>7.0.9</worldguard-core.version>
-    <worldedit-bukkit.version>7.3.0</worldedit-bukkit.version>
-    <worldedit-core.version>7.3.0</worldedit-core.version>
+    <worldguard-bukkit.version>7.0.17</worldguard-bukkit.version>
+    <worldguard-core.version>7.0.17</worldguard-core.version>
+    <worldedit-bukkit.version>7.3.19</worldedit-bukkit.version>
+    <worldedit-core.version>7.3.19</worldedit-core.version>
     <Heroes.version>1.10.7-RELEASE</Heroes.version>
     <Mythic-Dist.version>5.7.2</Mythic-Dist.version>
     <MythicLib-dist.version>1.7.1-SNAPSHOT</MythicLib-dist.version>

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldedit/WorldEditIntegrator.java
@@ -19,7 +19,7 @@ public class WorldEditIntegrator implements Integration {
     /**
      * The minimum required version of WorldEdit.
      */
-    public static final String WE_REQUIRED_VERSION = "7.3.0";
+    public static final String WE_REQUIRED_VERSION = "7.3.19";
 
     /**
      * The minimum required version of FastAsyncWorldEdit.

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/WorldGuardIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/WorldGuardIntegrator.java
@@ -19,7 +19,7 @@ public class WorldGuardIntegrator implements Integration {
     /**
      * The minimum required version of WorldGuard.
      */
-    public static final String REQUIRED_VERSION = "7.0.9";
+    public static final String REQUIRED_VERSION = "7.0.17";
 
     /**
      * The default constructor.

--- a/docs/Documentation/Reference/Integrations-List/Administration/WorldEdit.md
+++ b/docs/Documentation/Reference/Integrations-List/Administration/WorldEdit.md
@@ -1,6 +1,6 @@
 # [WorldEdit](http://dev.bukkit.org/bukkit-plugins/worldedit/) or [FastAsyncWorldEdit](https://www.spigotmc.org/resources/13932/)
 
-@snippet:versions:minimum@ _7.3.0_
+@snippet:versions:minimum@ WorldEdit _7.3.19_ / FastAsyncWorldEdit _2.10.0_
 
 ## Actions
 

--- a/docs/Documentation/Reference/Integrations-List/Administration/WorldGuard.md
+++ b/docs/Documentation/Reference/Integrations-List/Administration/WorldGuard.md
@@ -1,6 +1,6 @@
 # [WorldGuard](http://dev.bukkit.org/bukkit-plugins/worldguard/)
 
-@snippet:versions:minimum@ _7.0.9_
+@snippet:versions:minimum@ _7.0.17_
 
 ## Objectives
 


### PR DESCRIPTION
Update WorldGuard and WorldEdit compatibility to newer versions (7.017, 7.3.19) and update documentation accordingly

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
