### PR TITLE
Fix concurrency issues by decoupling source collections

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/util/MetricsUtils.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/util/MetricsUtils.java
@@ -7,7 +7,6 @@ import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.service.instruction.Instructions;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +34,8 @@ public final class MetricsUtils {
      */
     public static Map<String, Integer> typeCountMetrics(final Collection<? extends ReadableIdentifier> identifiers,
                                                         final Collection<String> validTypes, final Instructions instructionApi) {
-        final List<String> types = new ArrayList<>(validTypes);
-        return new ArrayList<>(identifiers).stream()
+        final List<String> types = List.copyOf(validTypes);
+        return List.copyOf(identifiers).stream()
                 .map(identifier -> typeFromId(identifier, instructionApi))
                 .filter(types::contains)
                 .collect(Collectors.toConcurrentMap(Function.identity(), key -> 1, Integer::sum));


### PR DESCRIPTION
Optimize `typeCountMetrics` method by replacing `ArrayList` instantiations with `List.copyOf` for improved immutability and to prevent concurrency issues

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
