### PR TITLE
Downgrade WorldGuard integration requirement to version 7.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `language` config option is now a section; the default language moved to `language.default`
 - `burn` action to no longer require its duration argument to specify its name `duration`
 - `mmoitem` now checks for soulbound when set
-- `worldguard` integration version requirement to 7.0.17
+- `worldguard` integration version requirement to 7.0.16
 - `worldedit` integration version requirement to 7.3.19
 ### Deprecated
 ### Removed

--- a/code/compatibility/pom.xml
+++ b/code/compatibility/pom.xml
@@ -25,8 +25,8 @@
 
     <!-- dependency versions -->
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
-    <worldguard-bukkit.version>7.0.17</worldguard-bukkit.version>
-    <worldguard-core.version>7.0.17</worldguard-core.version>
+    <worldguard-bukkit.version>7.0.16</worldguard-bukkit.version>
+    <worldguard-core.version>7.0.16</worldguard-core.version>
     <worldedit-bukkit.version>7.3.19</worldedit-bukkit.version>
     <worldedit-core.version>7.3.19</worldedit-core.version>
     <Heroes.version>1.10.7-RELEASE</Heroes.version>

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/WorldGuardIntegrator.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/worldguard/WorldGuardIntegrator.java
@@ -19,7 +19,7 @@ public class WorldGuardIntegrator implements Integration {
     /**
      * The minimum required version of WorldGuard.
      */
-    public static final String REQUIRED_VERSION = "7.0.17";
+    public static final String REQUIRED_VERSION = "7.0.16";
 
     /**
      * The default constructor.

--- a/docs/Documentation/Reference/Integrations-List/Administration/WorldGuard.md
+++ b/docs/Documentation/Reference/Integrations-List/Administration/WorldGuard.md
@@ -1,6 +1,6 @@
 # [WorldGuard](http://dev.bukkit.org/bukkit-plugins/worldguard/)
 
-@snippet:versions:minimum@ _7.0.17_
+@snippet:versions:minimum@ _7.0.16_
 
 ## Objectives
 


### PR DESCRIPTION
Fix errors from incorrect versions, WorldGuard uses an odd version format

Reaction to #4127

Error message that showed the initial error:
``[BetonQuest] Integration provided by 'BetonQuest' is not compatible due to policy: Plugin 'WorldGuard' version '7.0.17' and above is required.``

This happened due to WorldGuard not being '7.0.17' but something like '7.0.17+234-sadasd' instead -> interpreted as lower than the release.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
