### PR TITLE
Allow to set base speed to not "zoom"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `functions` section to define mathematical functions
 - `function` condition to evaluate a function as a condition
 - `TheBrewingProject` integration as modern alternative to Brewery
+- `base_speed` option to menu conv io to avoid zooming effect at risk of permanent modification
 ### Changed
 - `language` config option is now a section; the default language moved to `language.default`
 - `burn` action to no longer require its duration argument to specify its name `duration`

--- a/code/core/src/main/resources/config.patch.yml
+++ b/code/core/src/main/resources/config.patch.yml
@@ -1,4 +1,8 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.1.0.3:
+  - type: SET
+    key: conversation.io.menu.base_speed
+    value: false
 3.1.0.2:
   - type: SET
     key: hook.thebrewingproject
@@ -9,7 +13,7 @@
     newKey: language.default
   - type: SET
     key: language.questlang_whitelist
-    value: []
+    value: [ ]
 3.0.0.26:
   - type: SET
     key: conversation.io.menu.bottom_margin

--- a/code/core/src/main/resources/config.yml
+++ b/code/core/src/main/resources/config.yml
@@ -27,7 +27,7 @@ profile:
   initial_name: 'default'
 language:
   default: en-US
-  questlang_whitelist: []
+  questlang_whitelist: [ ]
 conversation:
   default_io: menu,packetevents,tellraw
   block_item_transfer: true
@@ -59,6 +59,7 @@ conversation:
       refresh_delay: 180
       rate_limit: 10
       set_speed: true
+      base_speed: false
       npc_name_type: chat
       npc_name_align: center
       npc_name_separator: true

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/BundledMC_1_21_4.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/BundledMC_1_21_4.java
@@ -54,7 +54,7 @@ public class BundledMC_1_21_4 implements Integration {
         item.registerSerializer("simple", new UpdatedSimpleQuestItemSerializer(textParser, bookPageWrapper));
 
         final TriFunction<Player, ConversationAction, Boolean, ConversationSession> inputFunction = (player, control, setSpeed)
-                -> new InputEventSession(betonQuest, player, control, setSpeed, true);
+                -> new InputEventSession(betonQuest, player, control, setSpeed, betonQuest.getPluginConfig().getBoolean("conversation.io.menu.base_speed"));
         componentLoader.get(ConversationIORegistry.class).register("menu", new MenuConvIOFactory(
                 api.loggerFactory(), betonQuest.getPluginConfig(), betonQuest,
                 api.localizations(), inputFunction, textParser,

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/BundledMC_1_21_4.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/BundledMC_1_21_4.java
@@ -54,7 +54,7 @@ public class BundledMC_1_21_4 implements Integration {
         item.registerSerializer("simple", new UpdatedSimpleQuestItemSerializer(textParser, bookPageWrapper));
 
         final TriFunction<Player, ConversationAction, Boolean, ConversationSession> inputFunction = (player, control, setSpeed)
-                -> new InputEventSession(betonQuest, player, control, setSpeed);
+                -> new InputEventSession(betonQuest, player, control, setSpeed, true);
         componentLoader.get(ConversationIORegistry.class).register("menu", new MenuConvIOFactory(
                 api.loggerFactory(), betonQuest.getPluginConfig(), betonQuest,
                 api.localizations(), inputFunction, textParser,

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/conversation/InputEventSession.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/conversation/InputEventSession.java
@@ -139,29 +139,35 @@ public class InputEventSession implements ConversationSession, Listener {
 
     @Override
     public void end() {
-        Bukkit.getScheduler().runTask(plugin, () -> {
-            if (baseSpeed) {
-                player.setWalkSpeed(oldWalkSpeed);
-                player.setFlySpeed(oldFlySpeed);
+        if (Bukkit.isPrimaryThread()) {
+            endReset();
+        } else {
+            Bukkit.getScheduler().runTask(plugin, this::endReset);
+        }
+        HandlerList.unregisterAll(this);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> HandlerList.unregisterAll(unmount), 20);
+    }
+
+    private void endReset() {
+        if (baseSpeed) {
+            player.setWalkSpeed(oldWalkSpeed);
+            player.setFlySpeed(oldFlySpeed);
+        }
+        for (final Attribute attribute : ATTRIBUTES) {
+            final AttributeInstance attributeInstance = player.getAttribute(attribute);
+            if (attributeInstance != null) {
+                attributeInstance.removeModifier(ATTRIBUTE_KEY);
             }
+        }
+
+        if (player.getVehicle() instanceof final Attributable vehicle) {
             for (final Attribute attribute : ATTRIBUTES) {
-                final AttributeInstance attributeInstance = player.getAttribute(attribute);
+                final AttributeInstance attributeInstance = vehicle.getAttribute(attribute);
                 if (attributeInstance != null) {
                     attributeInstance.removeModifier(ATTRIBUTE_KEY);
                 }
             }
-
-            if (player.getVehicle() instanceof final Attributable vehicle) {
-                for (final Attribute attribute : ATTRIBUTES) {
-                    final AttributeInstance attributeInstance = vehicle.getAttribute(attribute);
-                    if (attributeInstance != null) {
-                        attributeInstance.removeModifier(ATTRIBUTE_KEY);
-                    }
-                }
-            }
-        });
-        HandlerList.unregisterAll(this);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> HandlerList.unregisterAll(unmount), 20);
+        }
     }
 
     /**

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/conversation/InputEventSession.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/conversation/InputEventSession.java
@@ -21,8 +21,6 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.plugin.Plugin;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -39,7 +37,7 @@ public class InputEventSession implements ConversationSession, Listener {
     /**
      * Attributes to set to 0 while in the conversation.
      */
-    private static final Set<Attribute> ATTRIBUTES = new HashSet<>(Arrays.asList(Attribute.MOVEMENT_SPEED, Attribute.JUMP_STRENGTH));
+    private static final Set<Attribute> ATTRIBUTES = Set.of(Attribute.MOVEMENT_SPEED, Attribute.JUMP_STRENGTH);
 
     /**
      * Attribute Modifier that multiplies the total value with 0.
@@ -68,30 +66,57 @@ public class InputEventSession implements ConversationSession, Listener {
     private final boolean setSpeed;
 
     /**
+     * If the {@link Player#getWalkSpeed()} and {@link Player#getFlySpeed()} should set instead when {@link #setSpeed}.
+     */
+    private final boolean baseSpeed;
+
+    /**
      * Separate listener to prevent unmounting.
      */
     private final Listener unmount;
 
     /**
+     * Walk speed to reset to.
+     */
+    private float oldWalkSpeed;
+
+    /**
+     * Fly speed to reset to.
+     */
+    private float oldFlySpeed;
+
+    /**
      * Creates a new Conversation Input Session based on the {@link PlayerInputEvent}.
      *
-     * @param plugin   the plugin to start tasks
-     * @param player   the player of the session
-     * @param action   the conversation action to call on input
-     * @param setSpeed the player should get their speed set to 0 instead just cancelling moves
+     * @param plugin    the plugin to start tasks
+     * @param player    the player of the session
+     * @param action    the conversation action to call on input
+     * @param setSpeed  the player should get their speed set to 0 instead just cancelling moves
+     * @param baseSpeed whether the {@link Player#getWalkSpeed()} and {@link Player#getFlySpeed()} should be set
+     *                  instead of modifying the {@link Attribute#MOVEMENT_SPEED}
      */
-    public InputEventSession(final Plugin plugin, final Player player, final ConversationAction action, final boolean setSpeed) {
+    public InputEventSession(final Plugin plugin, final Player player, final ConversationAction action, final boolean setSpeed,
+                             final boolean baseSpeed) {
         this.plugin = plugin;
         this.player = player;
         this.action = action;
         this.setSpeed = setSpeed;
+        this.baseSpeed = baseSpeed;
         this.unmount = new Unmount();
     }
 
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.CyclomaticComplexity"})
     @Override
     public void begin() {
         if (setSpeed) {
             for (final Attribute attribute : ATTRIBUTES) {
+                if (baseSpeed && attribute == Attribute.MOVEMENT_SPEED) {
+                    oldWalkSpeed = player.getWalkSpeed();
+                    oldFlySpeed = player.getFlySpeed();
+                    player.setWalkSpeed(0);
+                    player.setFlySpeed(0);
+                    continue;
+                }
                 final AttributeInstance attributeInstance = player.getAttribute(attribute);
                 if (attributeInstance != null && attributeInstance.getModifier(ATTRIBUTE_KEY) == null) {
                     attributeInstance.addTransientModifier(TO_ZERO_MODIFIER);
@@ -115,6 +140,10 @@ public class InputEventSession implements ConversationSession, Listener {
     @Override
     public void end() {
         Bukkit.getScheduler().runTask(plugin, () -> {
+            if (baseSpeed) {
+                player.setWalkSpeed(oldWalkSpeed);
+                player.setFlySpeed(oldFlySpeed);
+            }
             for (final Attribute attribute : ATTRIBUTES) {
                 final AttributeInstance attributeInstance = player.getAttribute(attribute);
                 if (attributeInstance != null) {

--- a/docs/Documentation/Reference/Plugin-Config.md
+++ b/docs/Documentation/Reference/Plugin-Config.md
@@ -171,6 +171,7 @@ Every io has its own settings that can be configured in the `io` section.
       refresh_delay: 180    #(5)!
       rate_limit: 10        #(6)!
       set_speed: true       #(7)!
+      base_speed: false     #(24)!
   
       npc_name_type: chat              #(8)!
       npc_name_align: center           #(9)!
@@ -216,6 +217,8 @@ Every io has its own settings that can be configured in the `io` section.
     21. A prefix that gets applied to the start of a new line if the actual text is too long.
     22. The arrow format to scroll up.
     23. The arrow format to scroll down.
+    24. Requires `set_speed: true`. If set to `true`, the base movement speed is directly reduced to 0 instead using a
+        temporary modifier for that. However, in case of a server crash during a conversation, this change might persist.
   
 
 * `chest`  


### PR DESCRIPTION
<!-- Please describe your changes here. -->
When applying a modification to the speed the player gets a "zoom" effect. The great negative point in setting the base speed is that it persistent on the server and will remain after a crash or unexpected conversation break.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
