### PR TITLE
feat(objective): implement DamageObjective and factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- `damage` objective to track dealt and taken damage
 - `haspoint` and `hasglobalpoint` conditions to check if a point is set
 - counting objective related translations in the lang files can now use all counting objective related placeholders
 - `fallback` argument to point conditions to use a default value when category has no value at all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
-- `damage` objective to track dealt and taken damage
 - `haspoint` and `hasglobalpoint` conditions to check if a point is set
 - counting objective related translations in the lang files can now use all counting objective related placeholders
 - `fallback` argument to point conditions to use a default value when category has no value at all
 - `section` (and implicit `section`) condition to allow usage of subsections as list of (conjugated) conditions
+- `damage` objective to track dealt and taken damage
 ### Changed
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
@@ -92,6 +92,7 @@ public class ObjectiveTypeComponent extends AbstractCoreComponent {
         objectiveTypes.register("command", new CommandObjectiveFactory(actionManager));
         objectiveTypes.register("consume", new ConsumeObjectiveFactory());
         objectiveTypes.register("craft", new CraftingObjectiveFactory());
+        objectiveTypes.register("damage", new DamageObjectiveFactory());
         objectiveTypes.register("delay", new DelayObjectiveFactory());
         objectiveTypes.register("die", new DieObjectiveFactory());
         objectiveTypes.register("enchant", new EnchantObjectiveFactory());
@@ -120,6 +121,5 @@ public class ObjectiveTypeComponent extends AbstractCoreComponent {
         objectiveTypes.register("equip", new EquipItemObjectiveFactory());
         objectiveTypes.register("jump", new JumpObjectiveFactory());
         objectiveTypes.register("resourcepack", new ResourcepackObjectiveFactory());
-        objectiveTypes.register("damage", new DamageObjectiveFactory());
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
@@ -92,7 +92,7 @@ public class ObjectiveTypeComponent extends AbstractCoreComponent {
         objectiveTypes.register("command", new CommandObjectiveFactory(actionManager));
         objectiveTypes.register("consume", new ConsumeObjectiveFactory());
         objectiveTypes.register("craft", new CraftingObjectiveFactory());
-        objectiveTypes.register("damage", new DamageObjectiveFactory());
+        objectiveTypes.register("damage", new DamageObjectiveFactory(plugin));
         objectiveTypes.register("delay", new DelayObjectiveFactory());
         objectiveTypes.register("die", new DieObjectiveFactory());
         objectiveTypes.register("enchant", new EnchantObjectiveFactory());

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ObjectiveTypeComponent.java
@@ -19,6 +19,7 @@ import org.betonquest.betonquest.quest.objective.chestput.ChestPutObjectiveFacto
 import org.betonquest.betonquest.quest.objective.command.CommandObjectiveFactory;
 import org.betonquest.betonquest.quest.objective.consume.ConsumeObjectiveFactory;
 import org.betonquest.betonquest.quest.objective.crafting.CraftingObjectiveFactory;
+import org.betonquest.betonquest.quest.objective.damage.DamageObjectiveFactory;
 import org.betonquest.betonquest.quest.objective.data.PointObjectiveFactory;
 import org.betonquest.betonquest.quest.objective.data.TagObjectiveFactory;
 import org.betonquest.betonquest.quest.objective.delay.DelayObjectiveFactory;
@@ -119,5 +120,6 @@ public class ObjectiveTypeComponent extends AbstractCoreComponent {
         objectiveTypes.register("equip", new EquipItemObjectiveFactory());
         objectiveTypes.register("jump", new JumpObjectiveFactory());
         objectiveTypes.register("resourcepack", new ResourcepackObjectiveFactory());
+        objectiveTypes.register("damage", new DamageObjectiveFactory());
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageAction.java
@@ -13,5 +13,10 @@ public enum DamageAction {
     /**
      * The player must deal damage to the entity.
      */
-    DEAL
+    DEAL,
+
+    /**
+     * The player must take/deal damage.
+     */
+    BOTH
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageAction.java
@@ -1,0 +1,17 @@
+package org.betonquest.betonquest.quest.objective.damage;
+
+/**
+ * Specifies whether the player deals or takes damage.
+ */
+public enum DamageAction {
+
+    /**
+     * The player must take damage from the entity.
+     */
+    TAKE,
+
+    /**
+     * The player must deal damage to the entity.
+     */
+    DEAL
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -6,12 +6,10 @@ import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
 import org.betonquest.betonquest.lib.argument.type.TimeUnit;
-import org.bukkit.Bukkit;
+import org.betonquest.betonquest.lib.profile.ProfileKeyMap;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -47,7 +45,7 @@ public class DamageObjective extends CountingObjective {
     /**
      * Stores the last damage event timestamp in milliseconds for each profile.
      */
-    private final Map<UUID, Long> intervalTimes = new ConcurrentHashMap<>();
+    private final ProfileKeyMap<Long> intervalTimes;
 
     /**
      * Constructs a new {@code DamageObjective} for the given {@code Instruction}.
@@ -71,6 +69,10 @@ public class DamageObjective extends CountingObjective {
         this.minAmount = minAmount;
         this.interval = interval;
         this.timeUnit = timeUnit;
+        this.intervalTimes = new ProfileKeyMap<>(
+                service.getProfileProvider(),
+                new ConcurrentHashMap<>()
+        );
     }
 
     /**
@@ -107,7 +109,8 @@ public class DamageObjective extends CountingObjective {
             return;
         }
 
-        getCountingData(profile).progress();
+        final int dmg = (int) Math.round(event.getDamage());
+        getCountingData(profile).progress(dmg);
         completeIfDoneOrNotify(profile);
     }
 
@@ -123,23 +126,21 @@ public class DamageObjective extends CountingObjective {
     }
 
     private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
-        final Long expirationTime = intervalTimes.get(profile.getProfileUUID());
-        if (expirationTime != null && Bukkit.getCurrentTick() < expirationTime) {
+        final Long expirationTimeMillis = intervalTimes.get(profile);
+        if (expirationTimeMillis != null && System.currentTimeMillis() < expirationTimeMillis) {
             return true;
         }
 
         final long rawAmount = interval.getValue(profile).longValue();
         final TimeUnit unit = timeUnit.getValue(profile);
-        final long requiredInterval = unit.getTicks(rawAmount);
+        final long requiredIntervalMillis = unit.getTicks(rawAmount) * 50;
 
-        if (requiredInterval <= 0) {
+        if (requiredIntervalMillis <= 0) {
             return false;
         }
 
-        final long currentTick = Bukkit.getCurrentTick();
-        final UUID profileId = profile.getProfileUUID();
-
-        intervalTimes.put(profileId, currentTick + requiredInterval);
+        final long currentTimeMillis = System.currentTimeMillis();
+        intervalTimes.put(profile, currentTimeMillis + requiredIntervalMillis);
         return false;
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -1,21 +1,30 @@
 package org.betonquest.betonquest.quest.objective.damage;
 
-import org.betonquest.betonquest.api.CountingObjective;
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.BetonQuestApi;
+import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.objective.service.ObjectiveProperties;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
 import org.betonquest.betonquest.lib.argument.type.TimeUnit;
 import org.betonquest.betonquest.lib.profile.ProfileKeyMap;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 /**
  * The player must deal or take a specific amount of damage.
  */
-public class DamageObjective extends CountingObjective {
+public class DamageObjective extends DefaultObjective {
+
+    /**
+     * The target amount of damage to be received or dealt.
+     */
+    private final Argument<Number> targetAmount;
 
     /**
      * The action specifying whether the player deals or takes damage.
@@ -45,34 +54,44 @@ public class DamageObjective extends CountingObjective {
     /**
      * Stores the last damage event timestamp in milliseconds for each profile.
      */
-    private final ProfileKeyMap<Long> intervalTimes;
+    private final Map<Profile, Long> intervalTimes;
 
     /**
-     * Constructs a new {@code DamageObjective} for the given {@code Instruction}.
+     * BetonQuest API instance used to interact with the stored data.
+     */
+    private final BetonQuestApi api;
+
+    /**
+     * Constructs a new {@code DamageObjective}.
      *
-     * @param service      the objective service.
-     * @param targetAmount the target amount of damage required.
-     * @param action       the action specifying whether the player deals or takes damage.
-     * @param type         the list of damage types or causes allowed.
-     * @param minAmount    the minimum amount of damage required per event.
-     * @param interval     the time interval in milliseconds between valid damage events.
+     * @param service      the objective service
+     * @param targetAmount the target amount of damage required
+     * @param action       the action specifying whether the player deals or takes damage
+     * @param type         the list of damage types or causes allowed
+     * @param minAmount    the minimum amount of damage required per event
+     * @param interval     the time interval in milliseconds between valid damage events
      * @param timeUnit     the unit of time used to convert the interval duration
-     * @throws QuestException if the instruction is invalid.
+     * @throws QuestException if the instruction is invalid
      */
     public DamageObjective(final ObjectiveService service, final Argument<Number> targetAmount,
                            final Argument<DamageAction> action, final Argument<List<EntityDamageEvent.DamageCause>> type,
                            final Argument<Number> minAmount, final Argument<Number> interval,
                            final Argument<TimeUnit> timeUnit) throws QuestException {
-        super(service, targetAmount, null);
+        super(service);
+        this.targetAmount = targetAmount;
         this.action = action;
         this.type = type;
         this.minAmount = minAmount;
         this.interval = interval;
         this.timeUnit = timeUnit;
-        this.intervalTimes = new ProfileKeyMap<>(
-                service.getProfileProvider(),
-                new ConcurrentHashMap<>()
-        );
+        this.intervalTimes = new ProfileKeyMap<>(service.getProfileProvider());
+
+        this.api = BetonQuest.getInstance().getBetonQuestApi();
+
+        final ObjectiveProperties properties = service.getProperties();
+        properties.setProperty("amount", profile -> String.valueOf(getCurrentDamage(profile)));
+        properties.setProperty("left", profile -> String.valueOf(getRemainingDamage(profile)));
+        properties.setProperty("total", profile -> String.valueOf(targetAmount.getValue(profile)));
     }
 
     /**
@@ -99,19 +118,26 @@ public class DamageObjective extends CountingObjective {
 
     private void processDamageEvent(final EntityDamageEvent event, final OnlineProfile profile, final DamageAction expectedAction)
             throws QuestException {
-        if (action.getValue(profile) != expectedAction && action.getValue(profile) != DamageAction.BOTH) {
+
+        final DamageAction action = this.action.getValue(profile);
+        if (action != expectedAction && action != DamageAction.BOTH) {
             return;
         }
 
+        final double finalDmg = event.getFinalDamage();
         if (checkIsInvalidType(profile, event.getCause())
-                || checkIsInvalidMin(profile, event.getFinalDamage())
+                || checkIsInvalidMin(profile, finalDmg)
                 || checkIsOnCooldown(profile)) {
             return;
         }
 
-        final int dmg = (int) Math.round(event.getDamage());
-        getCountingData(profile).progress(dmg);
-        completeIfDoneOrNotify(profile);
+        final int dmgToAdd = (int) Math.round(finalDmg * 100);
+
+        api.persistence().of(profile).points().add("damage_progress", dmgToAdd);
+
+        if (getCurrentDamage(profile) >= targetAmount.getValue(profile).doubleValue()) {
+            getService().complete(profile);
+        }
     }
 
     private boolean checkIsInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause currentCause)
@@ -142,5 +168,16 @@ public class DamageObjective extends CountingObjective {
         final long currentTimeMillis = System.currentTimeMillis();
         intervalTimes.put(profile, currentTimeMillis + requiredIntervalMillis);
         return false;
+    }
+
+    private double getCurrentDamage(final Profile profile) {
+        final int storedPoints = api.persistence().of(profile).points().get("damage_progress").orElse(0);
+        return storedPoints / 100.0;
+    }
+
+    private double getRemainingDamage(final Profile profile) throws QuestException {
+        final double target = targetAmount.getValue(profile).doubleValue();
+        final double current = getCurrentDamage(profile);
+        return Math.max(0.0, target - current);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -1,0 +1,150 @@
+package org.betonquest.betonquest.quest.objective.damage;
+
+import org.betonquest.betonquest.api.CountingObjective;
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The player must deal or take a specific amount of damage.
+ */
+public class DamageObjective extends CountingObjective {
+
+    /**
+     * Maximum duration in milliseconds to keep cache entries before removal (10 minutes).
+     */
+    private static final long CACHE_EXPIRATION_MS = 600_000L;
+
+    /**
+     * The action specifying whether the player deals or takes damage.
+     */
+    private final Argument<String> action;
+
+    /**
+     * The list of allowed damage types or causes.
+     */
+    private final Argument<List<String>> type;
+
+    /**
+     * The minimum amount of damage required per event.
+     */
+    private final Argument<Number> minAmount;
+
+    /**
+     * The minimum time interval in milliseconds between valid damage events.
+     */
+    private final Argument<Number> interval;
+
+    /**
+     * Stores the last damage event timestamp in milliseconds for each profile.
+     */
+    private final Map<UUID, Long> intervalTimes = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs a new {@code DamageObjective} for the given {@code Instruction}.
+     *
+     * @param service      the objective service.
+     * @param targetAmount the target amount of damage required.
+     * @param action       the action specifying whether the player deals or takes damage.
+     * @param type         the list of damage types or causes allowed.
+     * @param minAmount    the minimum amount of damage required per event.
+     * @param interval     the time interval in milliseconds between valid damage events.
+     * @throws QuestException if the instruction is invalid.
+     */
+    public DamageObjective(final ObjectiveService service, final Argument<Number> targetAmount,
+                           final Argument<String> action, final Argument<List<String>> type,
+                           final Argument<Number> minAmount, final Argument<Number> interval) throws QuestException {
+        super(service, targetAmount, null);
+        this.action = action;
+        this.type = type;
+        this.minAmount = minAmount;
+        this.interval = interval;
+    }
+
+    /**
+     * Handles when a player deals damage and updates objective progress.
+     *
+     * @param event         the Bukkit entity damage event
+     * @param onlineProfile the profile of the player dealing damage
+     * @throws QuestException if evaluating event arguments fails
+     */
+    public void onDamageDealt(final EntityDamageEvent event, final OnlineProfile onlineProfile) throws QuestException {
+        processDamageEvent(event, onlineProfile, "deal");
+    }
+
+    /**
+     * Handles when a player takes damage and updates objective progress.
+     *
+     * @param event         the Bukkit entity damage event
+     * @param onlineProfile the profile of the player taking damage
+     * @throws QuestException if evaluating event arguments fails
+     */
+    public void onDamageTaken(final EntityDamageEvent event, final OnlineProfile onlineProfile) throws QuestException {
+        processDamageEvent(event, onlineProfile, "take");
+    }
+
+    private void processDamageEvent(final EntityDamageEvent event, final OnlineProfile profile, final String expectedAction)
+            throws QuestException {
+        if (!action.getValue(profile).equalsIgnoreCase(expectedAction)) {
+            return;
+        }
+
+        if (checkIsInvalidType(profile, event.getCause())
+                || checkIsInvalidMin(profile, event.getFinalDamage())
+                || checkIsOnCooldown(profile)) {
+            return;
+        }
+
+        getCountingData(profile).progress();
+        completeIfDoneOrNotify(profile);
+    }
+
+    private boolean checkIsInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause cause)
+            throws QuestException {
+        final List<String> allowedTypes = type.getValue(profile);
+        final String currentCause = cause.name();
+
+        for (final String allowedType : allowedTypes) {
+            if (allowedType.equalsIgnoreCase(currentCause)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean checkIsInvalidMin(final OnlineProfile profile, final double damage) throws QuestException {
+        final double min = minAmount.getValue(profile).doubleValue();
+        return damage < min;
+    }
+
+    private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
+        final long requiredInterval = interval.getValue(profile).longValue();
+
+        if (requiredInterval <= 0) {
+            return false;
+        }
+
+        final UUID profileId = profile.getProfileUUID();
+        final long currentTime = System.currentTimeMillis();
+
+        intervalTimes.entrySet().removeIf(entry -> (currentTime - entry.getValue()) > CACHE_EXPIRATION_MS);
+
+        final Long lastTime = intervalTimes.get(profileId);
+        if (lastTime != null) {
+            final long timePassed = currentTime - lastTime;
+            if (timePassed < requiredInterval) {
+                return true;
+            }
+        }
+
+        intervalTimes.put(profileId, currentTime);
+        return false;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -8,7 +8,6 @@ import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
 import org.betonquest.betonquest.lib.argument.type.TimeUnit;
 import org.bukkit.Bukkit;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
 import java.util.Map;
@@ -63,7 +62,7 @@ public class DamageObjective extends CountingObjective {
      * @throws QuestException if the instruction is invalid.
      */
     public DamageObjective(final ObjectiveService service, final Argument<Number> targetAmount,
-                           final Argument<DamageAction> action, final @UnknownNullability Argument<List<EntityDamageEvent.DamageCause>> type,
+                           final Argument<DamageAction> action, final Argument<List<EntityDamageEvent.DamageCause>> type,
                            final Argument<Number> minAmount, final Argument<Number> interval,
                            final Argument<TimeUnit> timeUnit) throws QuestException {
         super(service, targetAmount, null);
@@ -98,7 +97,7 @@ public class DamageObjective extends CountingObjective {
 
     private void processDamageEvent(final EntityDamageEvent event, final OnlineProfile profile, final DamageAction expectedAction)
             throws QuestException {
-        if (action.getValue(profile) != expectedAction) {
+        if (action.getValue(profile) != expectedAction && action.getValue(profile) != DamageAction.BOTH) {
             return;
         }
 
@@ -124,9 +123,13 @@ public class DamageObjective extends CountingObjective {
     }
 
     private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
+        final Long expirationTime = intervalTimes.get(profile.getProfileUUID());
+        if (expirationTime != null && Bukkit.getCurrentTick() < expirationTime) {
+            return true;
+        }
+
         final long rawAmount = interval.getValue(profile).longValue();
         final TimeUnit unit = timeUnit.getValue(profile);
-
         final long requiredInterval = unit.getTicks(rawAmount);
 
         if (requiredInterval <= 0) {
@@ -135,11 +138,6 @@ public class DamageObjective extends CountingObjective {
 
         final long currentTick = Bukkit.getCurrentTick();
         final UUID profileId = profile.getProfileUUID();
-
-        final Long expirationTime = intervalTimes.get(profileId);
-        if (expirationTime != null && currentTick < expirationTime) {
-            return true;
-        }
 
         intervalTimes.put(profileId, currentTick + requiredInterval);
         return false;

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -127,9 +127,9 @@ public class DamageObjective extends DefaultObjective {
         }
 
         final double finalDmg = event.getFinalDamage();
-        if (checkIsInvalidType(profile, event.getCause())
-                || checkIsInvalidMin(profile, finalDmg)
-                || checkIsOnCooldown(profile)) {
+        if (isInvalidType(profile, event.getCause())
+                || isInvalidMin(profile, finalDmg)
+                || isOnCooldown(profile)) {
             return;
         }
 
@@ -140,18 +140,18 @@ public class DamageObjective extends DefaultObjective {
         }
     }
 
-    private boolean checkIsInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause currentCause)
+    private boolean isInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause currentCause)
             throws QuestException {
         final List<EntityDamageEvent.DamageCause> allowedTypes = type.getValue(profile);
         return !allowedTypes.contains(currentCause);
     }
 
-    private boolean checkIsInvalidMin(final OnlineProfile profile, final double damage) throws QuestException {
+    private boolean isInvalidMin(final OnlineProfile profile, final double damage) throws QuestException {
         final double min = minAmount.getValue(profile).doubleValue();
         return damage < min;
     }
 
-    private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
+    private boolean isOnCooldown(final OnlineProfile profile) throws QuestException {
         final Player player = profile.getPlayer();
 
         if (!selectionCooldowns.add(player)) {

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -1,10 +1,9 @@
 package org.betonquest.betonquest.quest.objective.damage;
 
-import org.betonquest.betonquest.BetonQuest;
-import org.betonquest.betonquest.api.BetonQuestApi;
 import org.betonquest.betonquest.api.DefaultObjective;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.argument.parser.NumberParser;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveProperties;
@@ -57,11 +56,6 @@ public class DamageObjective extends DefaultObjective {
     private final Map<Profile, Long> intervalTimes;
 
     /**
-     * BetonQuest API instance used to interact with the stored data.
-     */
-    private final BetonQuestApi api;
-
-    /**
      * Constructs a new {@code DamageObjective}.
      *
      * @param service      the objective service
@@ -86,12 +80,11 @@ public class DamageObjective extends DefaultObjective {
         this.timeUnit = timeUnit;
         this.intervalTimes = new ProfileKeyMap<>(service.getProfileProvider());
 
-        this.api = BetonQuest.getInstance().getBetonQuestApi();
-
+        service.setDefaultData(this::getDefaultDataInstruction);
         final ObjectiveProperties properties = service.getProperties();
-        properties.setProperty("amount", profile -> String.valueOf(getCurrentDamage(profile)));
+        properties.setProperty("amount", profile -> String.valueOf(getDamageAmount(profile).current));
         properties.setProperty("left", profile -> String.valueOf(getRemainingDamage(profile)));
-        properties.setProperty("total", profile -> String.valueOf(targetAmount.getValue(profile)));
+        properties.setProperty("total", profile -> String.valueOf(getDamageAmount(profile).target));
     }
 
     /**
@@ -131,11 +124,9 @@ public class DamageObjective extends DefaultObjective {
             return;
         }
 
-        final int dmgToAdd = (int) Math.round(finalDmg * 100);
+        add(profile, finalDmg);
 
-        api.persistence().of(profile).points().add("damage_progress", dmgToAdd);
-
-        if (getCurrentDamage(profile) >= targetAmount.getValue(profile).doubleValue()) {
+        if (isCompleted(profile)) {
             getService().complete(profile);
         }
     }
@@ -170,14 +161,54 @@ public class DamageObjective extends DefaultObjective {
         return false;
     }
 
-    private double getCurrentDamage(final Profile profile) {
-        final int storedPoints = api.persistence().of(profile).points().get("damage_progress").orElse(0);
-        return storedPoints / 100.0;
+    private String getDefaultDataInstruction(final Profile profile) throws QuestException {
+        return String.valueOf(targetAmount.getValue(profile).doubleValue());
     }
 
     private double getRemainingDamage(final Profile profile) throws QuestException {
-        final double target = targetAmount.getValue(profile).doubleValue();
-        final double current = getCurrentDamage(profile);
-        return Math.max(0.0, target - current);
+        final Amount amount = getDamageAmount(profile);
+        return amount.target - amount.current;
+    }
+
+    private boolean isCompleted(final Profile profile) throws QuestException {
+        final Amount amount = getDamageAmount(profile);
+        return amount.current >= amount.target;
+    }
+
+    private void add(final Profile profile, final double toAdd) throws QuestException {
+        final Amount amount = getDamageAmount(profile);
+        final double newAmount = amount.current + toAdd;
+        getService().getData().put(profile, newAmount + "/" + amount.target);
+        getService().updateData(profile);
+    }
+
+    private Amount getDamageAmount(final Profile profile) throws QuestException {
+        final String stringData = getService().getData().get(profile);
+        if (stringData == null) {
+            throw new QuestException("Profile should have data!");
+        }
+        final String[] split = stringData.split("/");
+        final double amount;
+        final double targetAmount;
+        final int initLength = 1;
+        if (split.length == initLength) {
+            amount = 0;
+            targetAmount = NumberParser.DEFAULT.apply(split[0]).doubleValue();
+        } else {
+            amount = NumberParser.DEFAULT.apply(split[0]).doubleValue();
+            targetAmount = NumberParser.DEFAULT.apply(split[1]).doubleValue();
+        }
+        return new Amount(amount, targetAmount);
+    }
+
+    /**
+     * Represents a numerical progress tracking structure containing the current value
+     * and the target objective value.
+     *
+     * @param current the current progress value achieved so far
+     * @param target  the final target value required to complete the objective
+     */
+    private record Amount(double current, double target) {
+
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -9,11 +9,14 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveProperties;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
 import org.betonquest.betonquest.lib.argument.type.TimeUnit;
-import org.betonquest.betonquest.lib.profile.ProfileKeyMap;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.plugin.Plugin;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The player must deal or take a specific amount of damage.
@@ -41,44 +44,50 @@ public class DamageObjective extends DefaultObjective {
     private final Argument<Number> minAmount;
 
     /**
-     * The minimum time interval in milliseconds between valid damage events.
+     * The minimum time interval amount between valid damage events.
      */
     private final Argument<Number> interval;
 
     /**
-     * The unit of time used to convert the interval duration.
+     * The unit of time used to interpret the time interval between valid damage events.
      */
     private final Argument<TimeUnit> timeUnit;
 
     /**
-     * Stores the last damage event timestamp in milliseconds for each profile.
+     * Stores the players currently on selection cooldown to prevent spam.
      */
-    private final Map<Profile, Long> intervalTimes;
+    private final Set<Player> selectionCooldowns = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Plugin instance to schedule tasks.
+     */
+    private final Plugin plugin;
 
     /**
      * Constructs a new {@code DamageObjective}.
      *
      * @param service      the objective service
+     * @param plugin       the plugin instance to run tasks
      * @param targetAmount the target amount of damage required
      * @param action       the action specifying whether the player deals or takes damage
      * @param type         the list of damage types or causes allowed
      * @param minAmount    the minimum amount of damage required per event
-     * @param interval     the time interval in milliseconds between valid damage events
+     * @param interval     the time interval amount between valid damage events
      * @param timeUnit     the unit of time used to convert the interval duration
      * @throws QuestException if the instruction is invalid
      */
-    public DamageObjective(final ObjectiveService service, final Argument<Number> targetAmount,
+    public DamageObjective(final ObjectiveService service, final Plugin plugin, final Argument<Number> targetAmount,
                            final Argument<DamageAction> action, final Argument<List<EntityDamageEvent.DamageCause>> type,
                            final Argument<Number> minAmount, final Argument<Number> interval,
                            final Argument<TimeUnit> timeUnit) throws QuestException {
         super(service);
+        this.plugin = plugin;
         this.targetAmount = targetAmount;
         this.action = action;
         this.type = type;
         this.minAmount = minAmount;
         this.interval = interval;
         this.timeUnit = timeUnit;
-        this.intervalTimes = new ProfileKeyMap<>(service.getProfileProvider());
 
         service.setDefaultData(this::getDefaultDataInstruction);
         final ObjectiveProperties properties = service.getProperties();
@@ -143,21 +152,17 @@ public class DamageObjective extends DefaultObjective {
     }
 
     private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
-        final Long expirationTimeMillis = intervalTimes.get(profile);
-        if (expirationTimeMillis != null && System.currentTimeMillis() < expirationTimeMillis) {
+        final Player player = profile.getPlayer();
+
+        if (!selectionCooldowns.add(player)) {
             return true;
         }
 
         final long rawAmount = interval.getValue(profile).longValue();
         final TimeUnit unit = timeUnit.getValue(profile);
-        final long requiredIntervalMillis = unit.getTicks(rawAmount) * 50;
+        final long requiredInterval = unit.getTicks(rawAmount);
 
-        if (requiredIntervalMillis <= 0) {
-            return false;
-        }
-
-        final long currentTimeMillis = System.currentTimeMillis();
-        intervalTimes.put(profile, currentTimeMillis + requiredIntervalMillis);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> selectionCooldowns.remove(player), requiredInterval);
         return false;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjective.java
@@ -5,7 +5,10 @@ import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
+import org.betonquest.betonquest.lib.argument.type.TimeUnit;
+import org.bukkit.Bukkit;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
 import java.util.Map;
@@ -18,19 +21,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DamageObjective extends CountingObjective {
 
     /**
-     * Maximum duration in milliseconds to keep cache entries before removal (10 minutes).
-     */
-    private static final long CACHE_EXPIRATION_MS = 600_000L;
-
-    /**
      * The action specifying whether the player deals or takes damage.
      */
-    private final Argument<String> action;
+    private final Argument<DamageAction> action;
 
     /**
      * The list of allowed damage types or causes.
      */
-    private final Argument<List<String>> type;
+    private final Argument<List<EntityDamageEvent.DamageCause>> type;
 
     /**
      * The minimum amount of damage required per event.
@@ -41,6 +39,11 @@ public class DamageObjective extends CountingObjective {
      * The minimum time interval in milliseconds between valid damage events.
      */
     private final Argument<Number> interval;
+
+    /**
+     * The unit of time used to convert the interval duration.
+     */
+    private final Argument<TimeUnit> timeUnit;
 
     /**
      * Stores the last damage event timestamp in milliseconds for each profile.
@@ -56,16 +59,19 @@ public class DamageObjective extends CountingObjective {
      * @param type         the list of damage types or causes allowed.
      * @param minAmount    the minimum amount of damage required per event.
      * @param interval     the time interval in milliseconds between valid damage events.
+     * @param timeUnit     the unit of time used to convert the interval duration
      * @throws QuestException if the instruction is invalid.
      */
     public DamageObjective(final ObjectiveService service, final Argument<Number> targetAmount,
-                           final Argument<String> action, final Argument<List<String>> type,
-                           final Argument<Number> minAmount, final Argument<Number> interval) throws QuestException {
+                           final Argument<DamageAction> action, final @UnknownNullability Argument<List<EntityDamageEvent.DamageCause>> type,
+                           final Argument<Number> minAmount, final Argument<Number> interval,
+                           final Argument<TimeUnit> timeUnit) throws QuestException {
         super(service, targetAmount, null);
         this.action = action;
         this.type = type;
         this.minAmount = minAmount;
         this.interval = interval;
+        this.timeUnit = timeUnit;
     }
 
     /**
@@ -76,7 +82,7 @@ public class DamageObjective extends CountingObjective {
      * @throws QuestException if evaluating event arguments fails
      */
     public void onDamageDealt(final EntityDamageEvent event, final OnlineProfile onlineProfile) throws QuestException {
-        processDamageEvent(event, onlineProfile, "deal");
+        processDamageEvent(event, onlineProfile, DamageAction.DEAL);
     }
 
     /**
@@ -87,12 +93,12 @@ public class DamageObjective extends CountingObjective {
      * @throws QuestException if evaluating event arguments fails
      */
     public void onDamageTaken(final EntityDamageEvent event, final OnlineProfile onlineProfile) throws QuestException {
-        processDamageEvent(event, onlineProfile, "take");
+        processDamageEvent(event, onlineProfile, DamageAction.TAKE);
     }
 
-    private void processDamageEvent(final EntityDamageEvent event, final OnlineProfile profile, final String expectedAction)
+    private void processDamageEvent(final EntityDamageEvent event, final OnlineProfile profile, final DamageAction expectedAction)
             throws QuestException {
-        if (!action.getValue(profile).equalsIgnoreCase(expectedAction)) {
+        if (action.getValue(profile) != expectedAction) {
             return;
         }
 
@@ -106,17 +112,10 @@ public class DamageObjective extends CountingObjective {
         completeIfDoneOrNotify(profile);
     }
 
-    private boolean checkIsInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause cause)
+    private boolean checkIsInvalidType(final OnlineProfile profile, final EntityDamageEvent.DamageCause currentCause)
             throws QuestException {
-        final List<String> allowedTypes = type.getValue(profile);
-        final String currentCause = cause.name();
-
-        for (final String allowedType : allowedTypes) {
-            if (allowedType.equalsIgnoreCase(currentCause)) {
-                return false;
-            }
-        }
-        return true;
+        final List<EntityDamageEvent.DamageCause> allowedTypes = type.getValue(profile);
+        return !allowedTypes.contains(currentCause);
     }
 
     private boolean checkIsInvalidMin(final OnlineProfile profile, final double damage) throws QuestException {
@@ -125,26 +124,24 @@ public class DamageObjective extends CountingObjective {
     }
 
     private boolean checkIsOnCooldown(final OnlineProfile profile) throws QuestException {
-        final long requiredInterval = interval.getValue(profile).longValue();
+        final long rawAmount = interval.getValue(profile).longValue();
+        final TimeUnit unit = timeUnit.getValue(profile);
+
+        final long requiredInterval = unit.getTicks(rawAmount);
 
         if (requiredInterval <= 0) {
             return false;
         }
 
+        final long currentTick = Bukkit.getCurrentTick();
         final UUID profileId = profile.getProfileUUID();
-        final long currentTime = System.currentTimeMillis();
 
-        intervalTimes.entrySet().removeIf(entry -> (currentTime - entry.getValue()) > CACHE_EXPIRATION_MS);
-
-        final Long lastTime = intervalTimes.get(profileId);
-        if (lastTime != null) {
-            final long timePassed = currentTime - lastTime;
-            if (timePassed < requiredInterval) {
-                return true;
-            }
+        final Long expirationTime = intervalTimes.get(profileId);
+        if (expirationTime != null && currentTick < expirationTime) {
+            return true;
         }
 
-        intervalTimes.put(profileId, currentTime);
+        intervalTimes.put(profileId, currentTick + requiredInterval);
         return false;
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -6,6 +6,7 @@ import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.quest.objective.Objective;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveFactory;
 import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
+import org.betonquest.betonquest.lib.argument.type.TimeUnit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -22,26 +23,6 @@ import java.util.List;
 public class DamageObjectiveFactory implements ObjectiveFactory {
 
     /**
-     * The name of the parameter that determines whether the player is the one attacking or taking damage.
-     */
-    public static final String ACTION_ARGUMENT = "action";
-
-    /**
-     * The name of the parameter that determines the type of damage to be dealt.
-     */
-    public static final String TYPE_ARGUMENT = "type";
-
-    /**
-     * The name of the parameter that defines the minimum amount of damage.
-     */
-    public static final String MIN_AMOUNT_ARGUMENT = "min";
-
-    /**
-     * The name of the parameter that defines the delay between each attack.
-     */
-    public static final String INTERVAL_ARGUMENT = "interval";
-
-    /**
      * Creates a new DamageObjectiveFactory instance.
      */
     public DamageObjectiveFactory() {
@@ -50,11 +31,13 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
     @Override
     public Objective parseInstruction(final Instruction instruction, final ObjectiveService service) throws QuestException {
         final Argument<Number> targetAmount = instruction.number().get();
-        final Argument<String> action = instruction.string().get(ACTION_ARGUMENT, "deal");
-        final Argument<List<String>> type = instruction.string().list().get(TYPE_ARGUMENT, List.of("entity_attack"));
-        final Argument<Number> minAmount = instruction.number().get(MIN_AMOUNT_ARGUMENT, 0.0);
-        final Argument<Number> interval = instruction.number().get(INTERVAL_ARGUMENT, 0L);
-        final DamageObjective objective = new DamageObjective(service, targetAmount, action, type, minAmount, interval);
+        final Argument<DamageAction> action = instruction.enumeration(DamageAction.class).get("action", DamageAction.DEAL);
+        final Argument<List<EntityDamageEvent.DamageCause>> type = instruction.enumeration(EntityDamageEvent.DamageCause.class)
+                .list().get("type", List.of(EntityDamageEvent.DamageCause.ENTITY_ATTACK));
+        final Argument<Number> minAmount = instruction.number().get("min", 0.0);
+        final Argument<Number> interval = instruction.number().get("interval", 0L);
+        final Argument<TimeUnit> timeUnit = instruction.enumeration(TimeUnit.class).get("unit", TimeUnit.SECONDS);
+        final DamageObjective objective = new DamageObjective(service, targetAmount, action, type, minAmount, interval, timeUnit);
         service.request(EntityDamageByEntityEvent.class)
                 .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageDealt)
                 .player(event -> resolveAttackingPlayer(event.getDamager()))

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -1,0 +1,78 @@
+package org.betonquest.betonquest.quest.objective.damage;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.quest.objective.Objective;
+import org.betonquest.betonquest.api.quest.objective.ObjectiveFactory;
+import org.betonquest.betonquest.api.quest.objective.service.ObjectiveService;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Factory for creating {@link DamageObjective} instances from {@link Instruction}s.
+ */
+public class DamageObjectiveFactory implements ObjectiveFactory {
+
+    /**
+     * The name of the parameter that determines whether the player is the one attacking or taking damage.
+     */
+    public static final String ACTION_ARGUMENT = "action";
+
+    /**
+     * The name of the parameter that determines the type of damage to be dealt.
+     */
+    public static final String TYPE_ARGUMENT = "type";
+
+    /**
+     * The name of the parameter that defines the minimum amount of damage.
+     */
+    public static final String MIN_AMOUNT_ARGUMENT = "min";
+
+    /**
+     * The name of the parameter that defines the delay between each attack.
+     */
+    public static final String INTERVAL_ARGUMENT = "interval";
+
+    /**
+     * Creates a new DamageObjectiveFactory instance.
+     */
+    public DamageObjectiveFactory() {
+    }
+
+    @Override
+    public Objective parseInstruction(final Instruction instruction, final ObjectiveService service) throws QuestException {
+        final Argument<Number> targetAmount = instruction.number().get();
+        final Argument<String> action = instruction.string().get(ACTION_ARGUMENT, "deal");
+        final Argument<List<String>> type = instruction.string().list().get(TYPE_ARGUMENT, List.of("entity_attack"));
+        final Argument<Number> minAmount = instruction.number().get(MIN_AMOUNT_ARGUMENT, 0.0);
+        final Argument<Number> interval = instruction.number().get(INTERVAL_ARGUMENT, 0L);
+        final DamageObjective objective = new DamageObjective(service, targetAmount, action, type, minAmount, interval);
+        service.request(EntityDamageByEntityEvent.class)
+                .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageDealt)
+                .player(event -> resolveAttackingPlayer(event.getDamager()))
+                .subscribe(false);
+        service.request(EntityDamageEvent.class)
+                .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageTaken)
+                .player(event -> event.getEntity() instanceof final Player player ? player : null)
+                .subscribe(false);
+        return objective;
+    }
+
+    private @Nullable Player resolveAttackingPlayer(final Entity damager) {
+        if (damager instanceof final Player player) {
+            return player;
+        }
+        if (damager instanceof final Projectile projectile && projectile.getShooter() instanceof final Player shooter) {
+            return shooter;
+        }
+        return null;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -48,12 +48,14 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
         final Argument<TimeUnit> timeUnit = instruction.enumeration(TimeUnit.class).get("unit", TimeUnit.SECONDS);
         final DamageObjective objective = new DamageObjective(service, plugin, targetAmount, action, type, minAmount, interval, timeUnit);
         service.request(EntityDamageByEntityEvent.class)
-                .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageDealt)
+                .priority(EventPriority.HIGHEST)
+                .onlineHandler(objective::onDamageDealt)
                 .player(event -> resolveAttackingPlayer(event.getDamager()))
                 .subscribe(true);
         service.request(EntityDamageEvent.class)
-                .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageTaken)
-                .player(event -> event.getEntity() instanceof final Player player ? player : null)
+                .priority(EventPriority.HIGHEST)
+                .onlineHandler(objective::onDamageTaken)
+                .entity(EntityDamageEvent::getEntity)
                 .subscribe(true);
         return objective;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -31,7 +31,7 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
     @Override
     public Objective parseInstruction(final Instruction instruction, final ObjectiveService service) throws QuestException {
         final Argument<Number> targetAmount = instruction.number().get();
-        final Argument<DamageAction> action = instruction.enumeration(DamageAction.class).get("action", DamageAction.DEAL);
+        final Argument<DamageAction> action = instruction.enumeration(DamageAction.class).get("action", DamageAction.BOTH);
         final Argument<List<EntityDamageEvent.DamageCause>> type = instruction.enumeration(EntityDamageEvent.DamageCause.class)
                 .list().get("type", List.of(EntityDamageEvent.DamageCause.ENTITY_ATTACK));
         final Argument<Number> minAmount = instruction.number().get("min", 0.0);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.plugin.Plugin;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -23,9 +24,17 @@ import java.util.List;
 public class DamageObjectiveFactory implements ObjectiveFactory {
 
     /**
-     * Creates a new DamageObjectiveFactory instance.
+     * The plugin instance.
      */
-    public DamageObjectiveFactory() {
+    private final Plugin plugin;
+
+    /**
+     * Creates a new DamageObjectiveFactory instance.
+     *
+     * @param plugin the plugin instance
+     */
+    public DamageObjectiveFactory(final Plugin plugin) {
+        this.plugin = plugin;
     }
 
     @Override
@@ -37,7 +46,7 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
         final Argument<Number> minAmount = instruction.number().get("min", 0.0);
         final Argument<Number> interval = instruction.number().get("interval", 0L);
         final Argument<TimeUnit> timeUnit = instruction.enumeration(TimeUnit.class).get("unit", TimeUnit.SECONDS);
-        final DamageObjective objective = new DamageObjective(service, targetAmount, action, type, minAmount, interval, timeUnit);
+        final DamageObjective objective = new DamageObjective(service, plugin, targetAmount, action, type, minAmount, interval, timeUnit);
         service.request(EntityDamageByEntityEvent.class)
                 .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageDealt)
                 .player(event -> resolveAttackingPlayer(event.getDamager()))

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -41,11 +41,11 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
         service.request(EntityDamageByEntityEvent.class)
                 .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageDealt)
                 .player(event -> resolveAttackingPlayer(event.getDamager()))
-                .subscribe(false);
+                .subscribe(true);
         service.request(EntityDamageEvent.class)
                 .priority(EventPriority.HIGHEST).onlineHandler(objective::onDamageTaken)
                 .player(event -> event.getEntity() instanceof final Player player ? player : null)
-                .subscribe(false);
+                .subscribe(true);
         return objective;
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/DamageObjectiveFactory.java
@@ -31,7 +31,7 @@ public class DamageObjectiveFactory implements ObjectiveFactory {
     @Override
     public Objective parseInstruction(final Instruction instruction, final ObjectiveService service) throws QuestException {
         final Argument<Number> targetAmount = instruction.number().get();
-        final Argument<DamageAction> action = instruction.enumeration(DamageAction.class).get("action", DamageAction.BOTH);
+        final Argument<DamageAction> action = instruction.enumeration(DamageAction.class).get("action", DamageAction.DEAL);
         final Argument<List<EntityDamageEvent.DamageCause>> type = instruction.enumeration(EntityDamageEvent.DamageCause.class)
                 .list().get("type", List.of(EntityDamageEvent.DamageCause.ENTITY_ATTACK));
         final Argument<Number> minAmount = instruction.number().get("min", 0.0);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/package-info.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/damage/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Damage Objective
+ */
+package org.betonquest.betonquest.quest.objective.damage;

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -285,6 +285,28 @@ objectives:
   preventDying: "die cancel respawn:100;200;300;world;90;0 actions:respawned"
 ```
 
+## `Damage`
+
+__Context__: @snippet:objective-meta:online@  
+__Syntax__: `damage <amount> [action] [type] [min] [interval]`  
+__Description__: The player has to deal or receive damage to progress the objective.
+
+| Parameter   | Syntax                  | Default Value          | Explanation                                                                                                                                           |
+|-------------|-------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _Amount_    | Positive Number         | :octicons-x-circle-16: | Target progress count for the objective.                                                                                                              |
+| _action_    | action:`<deal/take>`    | `deal`                 | Whether the player must deal (`deal`) or receive (`take`) damage.                                                                                     |
+| _type_      | type:`<type1,type2>`    | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated). |
+| _min_       | min:number              | `0.0`                  | Minimum damage required in a single hit for the event to count.                                                                                       |
+| _interval_  | interval:number         | `0`                    | Cooldown in milliseconds between registered damage events per player profile.                                                                         |
+
+```YAML title="Example"
+objectives:
+  basicDamage: "damage 5"
+  elementalDamage: "damage 10 type:fire,lava"
+  combatDamage: "damage 20 action:deal type:entity_attack min:5.0"
+  poisonDamage: "damage 3 type:poison interval:2000"
+```
+
 ## `Enchant`
 
 __Context__: @snippet:objective-meta:online@  

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -235,20 +235,20 @@ objectives:
 
 ## `Damage`
     
-__Context__: @snippet:action-meta:online@  
+__Context__: @snippet:objective-meta:online@  
 __Syntax__: `damage <amount> [action] [type] [min] [interval] [unit]`  
 __Description__: The player has to deal or receive damage (or both) to progress the objective.
 
 The objective tracks the cumulative amount of damage dealt or taken, rather than the number of hits. Each
-damage event that meets the requirements adds its value directly to the objective's progress, maintaining decimal 
-precision to the hundredths place.
+damage event that meets the requirements adds its value directly to the objective's progress, maintaining 
+full decimal precision.
 
 | Parameter                      | Type                          | Explanation                                                                                                                                           |
 |--------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | amount  <br>[Number]           | Required                      | Total accumulated damage                                                                                                                              |
 | action  <br>[DamageAction]     | Optional <br>[deal]           | Whether the player should deal (distribute), receive (take), or do both.                                                                              |
 | type    <br>List[DamageCause]  | Optional <br>[entity_attack]  | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated). |
-| min     <br>[Double]           | Optional <br>[0.0]            | Minimum damage required in a single hit for the event to count                                                                                        |
+| min     <br>[Number]           | Optional <br>[0.0]            | Minimum damage required in a single hit for the event to count                                                                                        |
 | interval<br>[Number]           | Optional <br>[0]              | Cooldown between each damage event recorded for the same player                                                                                       |
 | unit    <br>[TimeUnit]         | Optional <br>[seconds]        | The unit of time (seconds, minutes, hours...)                                                                                                         |
 

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -295,16 +295,17 @@ __Description__: The player has to deal or receive damage to progress the object
 |-------------|-------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | _Amount_    | Positive Number         | :octicons-x-circle-16: | Target progress count for the objective.                                                                                                              |
 | _action_    | action:`<deal/take>`    | `deal`                 | Whether the player must deal (`deal`) or receive (`take`) damage.                                                                                     |
-| _type_      | type:`<type1,type2>`    | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated). |
-| _min_       | min:number              | `0.0`                  | Minimum damage required in a single hit for the event to count.                                                                                       |
-| _interval_  | interval:number         | `0`                    | Cooldown in milliseconds between registered damage events per player profile.                                                                         |
+| _type_      | type:`<type1,type2>`    | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated).                                                                                                 |
+| _min_       | min:`number`            |  0.0                   | Minimum damage required in a single hit for the event to count.                                                                                       |
+| _interval_  | interval:`number`       |  0                     | Cooldown duration between registered damage events per player profile.                                                                                |
+| _unit_      | unit:`<unit>`           | `seconds`              | The unit of time. Either `minutes`, `seconds` or `ticks`.                                                                                             |
 
 ```YAML title="Example"
 objectives:
   basicDamage: "damage 5"
   elementalDamage: "damage 10 type:fire,lava"
   combatDamage: "damage 20 action:deal type:entity_attack min:5.0"
-  poisonDamage: "damage 3 type:poison interval:2000"
+  poisonDamage: "damage 3 type:poison interval:40 unit:ticks"
 ```
 
 ## `Enchant`

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -233,6 +233,37 @@ objectives:
   craftSaddle: "craft saddle 5 actions:reward"
 ```
 
+## `Damage`
+    
+__Context__: @snippet:action-meta:online@  
+__Syntax__: `damage <amount> [action] [type] [min] [interval] [unit]`  
+__Description__: The player has to deal or receive damage (or both) to progress the objective.
+
+The objective tracks the cumulative amount of damage dealt or taken, rather than the number of hits. Each qualifying 
+damage event adds its value directly to the objective's progress.
+    
+| Parameter                      | Type                          | Explanation                                                                                                                                           |
+|--------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| amount  <br>[Number]           | Required                      | Total accumulated damage                                                                                                                              |
+| action  <br>[DamageAction]     | Optional <br>[deal]           | Whether the player should deal (distribute), receive (take), or do both.                                                                              |
+| type    <br>List[DamageCause]  | Optional <br>[entity_attack]  | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated). |
+| min     <br>[Double]           | Optional <br>[0.0]            | Minimum damage required in a single hit for the event to count                                                                                        |
+| interval<br>[Number]           | Optional <br>[0]              | Cooldown between each damage event recorded for the same player                                                                                       |
+| unit    <br>[TimeUnit]         | Optional <br>[seconds]        | The unit of time (seconds, minutes, hours...)                                                                                                         |
+
+```YAML title="Examples"
+objectives:
+  basicDamage: "damage 5"
+  elementalDamage: "damage 10 action:both type:fire,lava"
+  combatDamage: "damage 20 action:deal type:entity_attack min:5.0"
+  poisonDamage: "damage 3 type:poison interval:40 unit:ticks"
+  projectileDamage: "damage 10 action:deal type:projectile min:2.5 interval:80 unit:ticks"
+```
+
+*[DamageAction]: BOTH, DEAL, TAKE
+*[DamageCause]: Click the link below for more information.
+*[TimeUnit]: TICKS, SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS
+
 ## `Delay`
 
 __Context__: @snippet:objective-meta:online@  
@@ -283,30 +314,6 @@ You can also specify the `respawn` location to which the player will be teleport
 objectives:
   respawn: "die respawn:100;200;300;world;90;0 actions:respawned"
   preventDying: "die cancel respawn:100;200;300;world;90;0 actions:respawned"
-```
-
-## `Damage`
-
-__Context__: @snippet:objective-meta:online@  
-__Syntax__: `damage <amount> [action] [type] [min] [interval] [unit]`  
-__Description__: The player has to deal or receive damage (or both) to progress the objective.
-
-| Parameter   | Syntax                   | Default Value          | Explanation                                                                                                                                           |
-|-------------|--------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _Amount_    | Positive Number          | :octicons-x-circle-16: | Target progress count for the objective.                                                                                                              |
-| _action_    | action:`<deal/take/both>`| `both`                 | Whether the player must deal (`deal`) or receive (`take`) damage.                                                                                     |
-| _type_      | type:`<type1,type2>`     | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated).                                                                                                 |
-| _min_       | min:`number`             |  0.0                   | Minimum damage required in a single hit for the event to count.                                                                                       |
-| _interval_  | interval:`number`        |  0                     | Cooldown duration between registered damage events per player profile.                                                                                |
-| _unit_      | unit:`<unit>`            | `seconds`              | The unit of time. Either `minutes`, `seconds` or `ticks`.                                                                                             |
-
-```YAML title="Example"
-objectives:
-  basicDamage: "damage 5"
-  elementalDamage: "damage 10 type:fire,lava"
-  combatDamage: "damage 20 action:deal type:entity_attack min:5.0"
-  poisonDamage: "damage 3 type:poison interval:40 unit:ticks"
-  projectileDamage: "damage 10 action:deal type:projectile min:2.5 interval:80 unit:ticks"
 ```
 
 ## `Enchant`

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -288,17 +288,17 @@ objectives:
 ## `Damage`
 
 __Context__: @snippet:objective-meta:online@  
-__Syntax__: `damage <amount> [action] [type] [min] [interval]`  
-__Description__: The player has to deal or receive damage to progress the objective.
+__Syntax__: `damage <amount> [action] [type] [min] [interval] [unit]`  
+__Description__: The player has to deal or receive damage (or both) to progress the objective.
 
-| Parameter   | Syntax                  | Default Value          | Explanation                                                                                                                                           |
-|-------------|-------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _Amount_    | Positive Number         | :octicons-x-circle-16: | Target progress count for the objective.                                                                                                              |
-| _action_    | action:`<deal/take>`    | `deal`                 | Whether the player must deal (`deal`) or receive (`take`) damage.                                                                                     |
-| _type_      | type:`<type1,type2>`    | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated).                                                                                                 |
-| _min_       | min:`number`            |  0.0                   | Minimum damage required in a single hit for the event to count.                                                                                       |
-| _interval_  | interval:`number`       |  0                     | Cooldown duration between registered damage events per player profile.                                                                                |
-| _unit_      | unit:`<unit>`           | `seconds`              | The unit of time. Either `minutes`, `seconds` or `ticks`.                                                                                             |
+| Parameter   | Syntax                   | Default Value          | Explanation                                                                                                                                           |
+|-------------|--------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _Amount_    | Positive Number          | :octicons-x-circle-16: | Target progress count for the objective.                                                                                                              |
+| _action_    | action:`<deal/take/both>`| `both`                 | Whether the player must deal (`deal`) or receive (`take`) damage.                                                                                     |
+| _type_      | type:`<type1,type2>`     | `entity_attack`        | Allowed [`DamageCause`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) types (comma-separated).                                                                                                 |
+| _min_       | min:`number`             |  0.0                   | Minimum damage required in a single hit for the event to count.                                                                                       |
+| _interval_  | interval:`number`        |  0                     | Cooldown duration between registered damage events per player profile.                                                                                |
+| _unit_      | unit:`<unit>`            | `seconds`              | The unit of time. Either `minutes`, `seconds` or `ticks`.                                                                                             |
 
 ```YAML title="Example"
 objectives:
@@ -306,6 +306,7 @@ objectives:
   elementalDamage: "damage 10 type:fire,lava"
   combatDamage: "damage 20 action:deal type:entity_attack min:5.0"
   poisonDamage: "damage 3 type:poison interval:40 unit:ticks"
+  projectileDamage: "damage 10 action:deal type:projectile min:2.5 interval:80 unit:ticks"
 ```
 
 ## `Enchant`

--- a/docs/Documentation/Reference/Objectives-List.md
+++ b/docs/Documentation/Reference/Objectives-List.md
@@ -239,9 +239,10 @@ __Context__: @snippet:action-meta:online@
 __Syntax__: `damage <amount> [action] [type] [min] [interval] [unit]`  
 __Description__: The player has to deal or receive damage (or both) to progress the objective.
 
-The objective tracks the cumulative amount of damage dealt or taken, rather than the number of hits. Each qualifying 
-damage event adds its value directly to the objective's progress.
-    
+The objective tracks the cumulative amount of damage dealt or taken, rather than the number of hits. Each
+damage event that meets the requirements adds its value directly to the objective's progress, maintaining decimal 
+precision to the hundredths place.
+
 | Parameter                      | Type                          | Explanation                                                                                                                                           |
 |--------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | amount  <br>[Number]           | Required                      | Total accumulated damage                                                                                                                              |
@@ -251,7 +252,7 @@ damage event adds its value directly to the objective's progress.
 | interval<br>[Number]           | Optional <br>[0]              | Cooldown between each damage event recorded for the same player                                                                                       |
 | unit    <br>[TimeUnit]         | Optional <br>[seconds]        | The unit of time (seconds, minutes, hours...)                                                                                                         |
 
-```YAML title="Examples"
+```YAML title="Example"
 objectives:
   basicDamage: "damage 5"
   elementalDamage: "damage 10 action:both type:fire,lava"
@@ -260,9 +261,16 @@ objectives:
   projectileDamage: "damage 10 action:deal type:projectile min:2.5 interval:80 unit:ticks"
 ```
 
-*[DamageAction]: BOTH, DEAL, TAKE
+<h5> Placeholder Properties </h5> 
+
+| Name         | Example Output    | Explanation                                                                     |
+|--------------|-------------------|---------------------------------------------------------------------------------|
+| _amount_     | 14.5              | Displays the total amount of damage the player has already dealt or taken.      |
+| _left_       | 5.5               | Shows the amount of damage that still needs to be dealt to reach the goal.      |
+| _total_      | 20                | Displays the total initial amount of damage required to complete the objective. |
+
+*[DamageAction]: both, deal, take
 *[DamageCause]: Click the link below for more information.
-*[TimeUnit]: TICKS, SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS
 
 ## `Delay`
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Added the `damage` objective allowing quests to track when a player deals or takes damage.
- Supports filtering by damage cause (`type`), minimum damage amount (`min`), and cooldown between events (`interval`).
- Supports projectile attacks (bows, tridents) when checking for dealt damage.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #4067 

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
