### PR TITLE
`citizens` npcs now return stored location when not spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0
 - counting objective related translations in the lang files were moved in an own `objective` section and use `{absoluteleft}` instead of `{amount}`
+- `citizens` returns the stored `location` instead of nothing when not spawned
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/CitizensAdapter.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/npc/citizens/CitizensAdapter.java
@@ -50,7 +50,7 @@ public class CitizensAdapter implements Npc<NPC> {
     public Optional<Location> getLocation() {
         final Entity entity = npc.getEntity();
         if (entity == null) {
-            return Optional.empty();
+            return Optional.ofNullable(npc.getStoredLocation());
         }
         return Optional.of(entity.getLocation());
     }


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Getting their location via placeholder is very useful, even when nobody is nearby.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
