### PR TITLE
Add section condition as well as implicit section conjunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `haspoint` and `hasglobalpoint` conditions to check if a point is set
 - counting objective related translations in the lang files can now use all counting objective related placeholders
 - `fallback` argument to point conditions to use a default value when category has no value at all
+- `section` (and implicit `section`) condition to allow usage of subsections as list of (conjugated) conditions
 ### Changed
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0

--- a/code/core/src/main/java/org/betonquest/betonquest/api/identifier/DefaultReadableIdentifier.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/identifier/DefaultReadableIdentifier.java
@@ -34,7 +34,11 @@ public abstract class DefaultReadableIdentifier extends DefaultIdentifier implem
     @Override
     public String readRawInstruction() throws QuestException {
         final MultiConfiguration config = getPackage().getConfig();
-        final String rawInstruction = config.getString(section + config.options().pathSeparator() + get());
+        final String path = section + config.options().pathSeparator() + get();
+        if (config.isConfigurationSection(path)) {
+            return "section %s (implicit)".formatted(getFull());
+        }
+        final String rawInstruction = config.getString(path);
         if (rawInstruction == null) {
             throw new QuestException("'%s' is not defined in section '%s'".formatted(getFull(), section));
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/identifier/factory/DefaultIdentifierFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/identifier/factory/DefaultIdentifierFactory.java
@@ -22,6 +22,7 @@ import static org.betonquest.betonquest.api.identifier.Identifier.SEPARATOR_PATT
  *
  * @param <I> the type of identifier to create
  */
+@SuppressWarnings("PMD.GodClass")
 public abstract class DefaultIdentifierFactory<I extends Identifier> implements IdentifierFactory<I> {
 
     /**
@@ -82,6 +83,23 @@ public abstract class DefaultIdentifierFactory<I extends Identifier> implements 
         }
         if (!config.isString(path)) {
             throw new QuestException("%s '%s' does not define a string in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
+        }
+        return resolvedIdentifier;
+    }
+
+    /**
+     * Ensures the specified section has any value for the identifier.
+     *
+     * @param resolvedIdentifier the identifier to check
+     * @param section            the section to check for
+     * @return the given identifier
+     * @throws QuestException if the section does not have any value
+     */
+    protected I requireValue(final I resolvedIdentifier, final String section) throws QuestException {
+        final MultiConfiguration config = resolvedIdentifier.getPackage().getConfig();
+        final String path = section + config.options().pathSeparator() + resolvedIdentifier.get();
+        if (!config.contains(path)) {
+            throw new QuestException("%s '%s' is not defined in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
         }
         return resolvedIdentifier;
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/api/identifier/factory/DefaultIdentifierFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/identifier/factory/DefaultIdentifierFactory.java
@@ -22,7 +22,7 @@ import static org.betonquest.betonquest.api.identifier.Identifier.SEPARATOR_PATT
  *
  * @param <I> the type of identifier to create
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public abstract class DefaultIdentifierFactory<I extends Identifier> implements IdentifierFactory<I> {
 
     /**
@@ -47,6 +47,21 @@ public abstract class DefaultIdentifierFactory<I extends Identifier> implements 
         this.readableTypeName = readableTypeName;
     }
 
+    private I require(final I resolvedIdentifier, final String section, final boolean needsSection, final boolean needsString) throws QuestException {
+        final MultiConfiguration config = resolvedIdentifier.getPackage().getConfig();
+        final String path = section + config.options().pathSeparator() + resolvedIdentifier.get();
+        if (!config.contains(path)) {
+            throw new QuestException("%s '%s' is not defined in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
+        }
+        if (needsSection && !config.isConfigurationSection(path)) {
+            throw new QuestException("%s '%s' does not define a section under section '%s'".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
+        }
+        if (needsString && !config.isString(path)) {
+            throw new QuestException("%s '%s' does not define a string in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
+        }
+        return resolvedIdentifier;
+    }
+
     /**
      * Ensures the specified section is defined for the identifier.
      *
@@ -56,15 +71,7 @@ public abstract class DefaultIdentifierFactory<I extends Identifier> implements 
      * @throws QuestException if the section is not defined
      */
     protected I requireSection(final I resolvedIdentifier, final String section) throws QuestException {
-        final MultiConfiguration config = resolvedIdentifier.getPackage().getConfig();
-        final String path = section + config.options().pathSeparator() + resolvedIdentifier.get();
-        if (!config.contains(path)) {
-            throw new QuestException("%s '%s' is not defined in section '%s'".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
-        }
-        if (!config.isConfigurationSection(path)) {
-            throw new QuestException("%s '%s' does not define a section under section '%s'".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
-        }
-        return resolvedIdentifier;
+        return require(resolvedIdentifier, section, true, false);
     }
 
     /**
@@ -76,15 +83,7 @@ public abstract class DefaultIdentifierFactory<I extends Identifier> implements 
      * @throws QuestException if the section does not contain a string instruction
      */
     protected I requireInstruction(final I resolvedIdentifier, final String section) throws QuestException {
-        final MultiConfiguration config = resolvedIdentifier.getPackage().getConfig();
-        final String path = section + config.options().pathSeparator() + resolvedIdentifier.get();
-        if (!config.contains(path)) {
-            throw new QuestException("%s '%s' is not defined in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
-        }
-        if (!config.isString(path)) {
-            throw new QuestException("%s '%s' does not define a string in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
-        }
-        return resolvedIdentifier;
+        return require(resolvedIdentifier, section, false, true);
     }
 
     /**
@@ -96,12 +95,7 @@ public abstract class DefaultIdentifierFactory<I extends Identifier> implements 
      * @throws QuestException if the section does not have any value
      */
     protected I requireValue(final I resolvedIdentifier, final String section) throws QuestException {
-        final MultiConfiguration config = resolvedIdentifier.getPackage().getConfig();
-        final String path = section + config.options().pathSeparator() + resolvedIdentifier.get();
-        if (!config.contains(path)) {
-            throw new QuestException("%s '%s' is not defined in section '%s'!".formatted(readableTypeName, resolvedIdentifier.getFull(), section));
-        }
-        return resolvedIdentifier;
+        return require(resolvedIdentifier, section, false, false);
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
@@ -488,7 +488,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         final List<String> completions = new ArrayList<>();
         if (configuration != null) {
             for (final String key : configuration.getKeys(type.allowNested)) {
-                if (type.allowNested && configuration.isConfigurationSection(key)) {
+                if (type.allowNested && !type.allowSection && configuration.isConfigurationSection(key)) {
                     continue;
                 }
                 completions.add(pack + Identifier.SEPARATOR + key);
@@ -2036,7 +2036,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         /**
          * ConditionID.
          */
-        CONDITIONS(true),
+        CONDITIONS(true, true),
         /**
          * ObjectiveID.
          */
@@ -2055,8 +2055,18 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
          */
         private final boolean allowNested;
 
+        /**
+         * If section nodes also are identifiers.
+         */
+        private final boolean allowSection;
+
         AccessorType(final boolean allowNested) {
+            this(allowNested, false);
+        }
+
+        AccessorType(final boolean allowNested, final boolean allowSection) {
             this.allowNested = allowNested;
+            this.allowSection = allowSection;
         }
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/id/IdentifierUtil.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/id/IdentifierUtil.java
@@ -1,0 +1,52 @@
+package org.betonquest.betonquest.id;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.identifier.ReadableIdentifier;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Util class for common identifier methods.
+ */
+public final class IdentifierUtil {
+
+    private IdentifierUtil() {
+    }
+
+    /**
+     * Get from an identifier all "leaf" identifiers inside its {@link ConfigurationSection}.
+     *
+     * @param identifierFactory the factory to create new identifiers for the subsections
+     * @param identifier        the identifier pointing to the wanted subsection
+     * @param <I>               the identifier type
+     * @return list of identifiers that are
+     * @throws QuestException when there are no subsection for the given identifier
+     */
+    public static <I extends ReadableIdentifier> List<I> subsectionIdentifiers(
+            final IdentifierFactory<I> identifierFactory, final I identifier) throws QuestException {
+        final QuestPackage pack = identifier.getPackage();
+        final String identifierSection = identifier.getSection();
+        final ConfigurationSection section = pack.getConfig().getConfigurationSection(identifierSection);
+        if (section == null) {
+            throw new QuestException("There is no base section '%s' in pack '%s'".formatted(identifierSection, identifier.getPackage()));
+        }
+        final ConfigurationSection targetSection = section.getConfigurationSection(identifier.get());
+        if (targetSection == null) {
+            throw new QuestException("Target section '%s' does not exist (in base section '%s' in pack '%s')"
+                    .formatted(identifier.get(), identifierSection, identifier.getPackage()));
+        }
+        final List<I> identifiers = new ArrayList<>();
+        for (final Map.Entry<String, Object> entry : targetSection.getValues(true).entrySet()) {
+            if (entry.getValue() instanceof ConfigurationSection) {
+                continue;
+            }
+            identifiers.add(identifierFactory.parseIdentifier(pack, identifier.get() + "." + entry.getKey()));
+        }
+        return identifiers;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/id/condition/ConditionIdentifierFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/id/condition/ConditionIdentifierFactory.java
@@ -28,6 +28,6 @@ public class ConditionIdentifierFactory extends DefaultIdentifierFactory<Conditi
         final boolean isInverted = !input.isEmpty() && input.charAt(0) == '!';
         final Map.Entry<QuestPackage, String> entry = parse(source, isInverted ? input.substring(1) : input);
         final DefaultConditionIdentifier identifier = new DefaultConditionIdentifier(entry.getKey(), entry.getValue(), isInverted);
-        return requireInstruction(identifier, DefaultConditionIdentifier.CONDITION_SECTION);
+        return requireValue(identifier, DefaultConditionIdentifier.CONDITION_SECTION);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ConditionTypesComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ConditionTypesComponent.java
@@ -13,6 +13,7 @@ import org.betonquest.betonquest.api.service.npc.NpcManager;
 import org.betonquest.betonquest.api.service.objective.ObjectiveManager;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.GlobalData;
+import org.betonquest.betonquest.id.condition.ConditionIdentifierFactory;
 import org.betonquest.betonquest.kernel.registry.quest.ConditionTypeRegistry;
 import org.betonquest.betonquest.lib.dependency.component.AbstractCoreComponent;
 import org.betonquest.betonquest.quest.condition.advancement.AdvancementConditionFactory;
@@ -60,6 +61,7 @@ import org.betonquest.betonquest.quest.condition.random.RandomConditionFactory;
 import org.betonquest.betonquest.quest.condition.ride.RideConditionFactory;
 import org.betonquest.betonquest.quest.condition.scoreboard.ScoreboardObjectiveConditionFactory;
 import org.betonquest.betonquest.quest.condition.scoreboard.ScoreboardTagConditionFactory;
+import org.betonquest.betonquest.quest.condition.section.SectionConditionFactory;
 import org.betonquest.betonquest.quest.condition.slots.EmptySlotsConditionFactory;
 import org.betonquest.betonquest.quest.condition.sneak.SneakConditionFactory;
 import org.betonquest.betonquest.quest.condition.stage.StageConditionFactory;
@@ -96,7 +98,7 @@ public class ConditionTypesComponent extends AbstractCoreComponent {
                 BetonQuestLoggerFactory.class, ProfileProvider.class, GlobalData.class, PlayerDataStorage.class,
                 Localizations.class, LanguageProvider.class, Instructions.class,
                 ConditionTypeRegistry.class, Conversations.class, ConditionManager.class, ObjectiveManager.class,
-                NpcManager.class, Functions.class);
+                NpcManager.class, Functions.class, ConditionIdentifierFactory.class);
     }
 
     @Override
@@ -116,6 +118,7 @@ public class ConditionTypesComponent extends AbstractCoreComponent {
         final ObjectiveManager objectiveManager = getDependency(ObjectiveManager.class);
         final NpcManager npcManager = getDependency(NpcManager.class);
         final Functions functions = getDependency(Functions.class);
+        final ConditionIdentifierFactory conditionIdentifierFactory = getDependency(ConditionIdentifierFactory.class);
 
         conditionTypes.register("advancement", new AdvancementConditionFactory(server));
         conditionTypes.registerCombined("and", new ConjunctionConditionFactory(conditionManager));
@@ -164,6 +167,7 @@ public class ConditionTypesComponent extends AbstractCoreComponent {
         conditionTypes.register("rating", new ArmorRatingConditionFactory());
         conditionTypes.register("realtime", new RealTimeConditionFactory());
         conditionTypes.register("ride", new RideConditionFactory());
+        conditionTypes.registerCombined("section", new SectionConditionFactory(conditionManager, conditionIdentifierFactory));
         conditionTypes.register("score", new ScoreboardObjectiveConditionFactory());
         conditionTypes.register("scoretag", new ScoreboardTagConditionFactory());
         conditionTypes.register("sneak", new SneakConditionFactory());

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/TypedQuestProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/TypedQuestProcessor.java
@@ -15,6 +15,8 @@ import org.betonquest.betonquest.bstats.MetricsHolder;
 import org.betonquest.betonquest.kernel.registry.FactoryTypeRegistry;
 import org.betonquest.betonquest.util.MetricsUtils;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -76,15 +78,16 @@ public abstract class TypedQuestProcessor<I extends ReadableIdentifier, T> exten
             return;
         }
         for (final String key : section.getKeys(true)) {
-            if (section.isConfigurationSection(key)) {
-                continue;
-            }
             if (key.contains(" ")) {
                 log.warn(pack, readable + " name cannot contain spaces: '" + key + "' in pack '" + pack.getQuestPath() + "'");
                 continue;
             }
             try {
-                loadKey(key, pack);
+                if (section.isConfigurationSection(key)) {
+                    loadSectionKey(key, pack);
+                } else {
+                    loadKey(key, pack);
+                }
             } catch (final QuestException e) {
                 log.warn(pack, "Error while loading " + readable + " '" + key + "' in pack '" + pack.getQuestPath() + "': " + e.getMessage(), e);
             }
@@ -106,6 +109,36 @@ public abstract class TypedQuestProcessor<I extends ReadableIdentifier, T> exten
         }
     }
 
+    private void loadSectionKey(final String key, final QuestPackage pack) throws QuestException {
+        final SectionFactory<I, T> sectionFactory = getSectionFactory();
+        if (sectionFactory == null) {
+            return;
+        }
+        final I identifier = getIdentifier(pack, key);
+        try {
+            final T parsed = sectionFactory.fromSection(identifier);
+            values.put(identifier, parsed);
+            postCreation(identifier, parsed);
+            log.debug(pack, "  " + readable + " '" + identifier + "' loaded");
+        } catch (final QuestException e) {
+            throw new QuestException("Error in '%s' %s (implicit section): %s".formatted(identifier, readable, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Get the factory for creating {@link T} for sections.
+     * <p>
+     * Only implement that method if the {@link T} should have default implementations
+     * for {@link ConfigurationSection} nodes.
+     *
+     * @return the factory, if section nodes should get implementations
+     */
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    @Nullable
+    protected SectionFactory<I, T> getSectionFactory() {
+        return null;
+    }
+
     /**
      * Allows for using the {@link T} after successful creation.
      *
@@ -115,5 +148,25 @@ public abstract class TypedQuestProcessor<I extends ReadableIdentifier, T> exten
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     protected void postCreation(final I identifier, final T value) {
         // Empty
+    }
+
+    /**
+     * Factory to create implementation that works on sections instead instruction strings.
+     *
+     * @param <I> the {@link ReadableIdentifier} identifying the type
+     * @param <T> the type
+     */
+    @FunctionalInterface
+    protected interface SectionFactory<I, T> {
+
+        /**
+         * Create a new {@link T} from an {@link Instruction}.
+         *
+         * @param sectionIdentifier the section to create for
+         * @return the newly created {@link T}
+         * @throws QuestException if the section cannot be parsed
+         */
+        @Contract(pure = true)
+        T fromSection(I sectionIdentifier) throws QuestException;
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ConditionProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ConditionProcessor.java
@@ -5,11 +5,14 @@ import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
 import org.betonquest.betonquest.api.identifier.IdentifierFactory;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.profile.Profile;
+import org.betonquest.betonquest.api.quest.condition.NullableConditionAdapter;
 import org.betonquest.betonquest.api.service.condition.ConditionManager;
 import org.betonquest.betonquest.api.service.instruction.Instructions;
+import org.betonquest.betonquest.id.IdentifierUtil;
 import org.betonquest.betonquest.kernel.processor.TypedQuestProcessor;
 import org.betonquest.betonquest.kernel.processor.adapter.ConditionAdapter;
 import org.betonquest.betonquest.kernel.registry.quest.ConditionTypeRegistry;
+import org.betonquest.betonquest.quest.condition.logik.ConjunctionCondition;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -40,6 +43,11 @@ public class ConditionProcessor extends TypedQuestProcessor<ConditionIdentifier,
     private final Plugin plugin;
 
     /**
+     * Factory to create section conditions for configuration sections.
+     */
+    private final SectionFactory<ConditionIdentifier, ConditionAdapter> sectionFactory;
+
+    /**
      * Create a new Condition Processor to store Conditions and checks them.
      *
      * @param log                        the custom logger for this class
@@ -56,6 +64,17 @@ public class ConditionProcessor extends TypedQuestProcessor<ConditionIdentifier,
         super(log, conditionTypes, conditionIdentifierFactory, instructionApi, "Condition", "conditions");
         this.scheduler = scheduler;
         this.plugin = plugin;
+        this.sectionFactory = identifier -> {
+            final List<ConditionIdentifier> identifiers = IdentifierUtil.subsectionIdentifiers(identifierFactory, identifier);
+            final NullableConditionAdapter adapter = new NullableConditionAdapter(new ConjunctionCondition(profile -> identifiers, this));
+            return new ConditionAdapter(identifier.getPackage(), adapter, adapter);
+        };
+    }
+
+    @Override
+    @Nullable
+    protected SectionFactory<ConditionIdentifier, ConditionAdapter> getSectionFactory() {
+        return sectionFactory;
     }
 
     /**

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/section/SectionConditionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/section/SectionConditionFactory.java
@@ -1,0 +1,63 @@
+package org.betonquest.betonquest.quest.condition.section;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.identifier.ConditionIdentifier;
+import org.betonquest.betonquest.api.identifier.IdentifierFactory;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.quest.condition.NullableConditionAdapter;
+import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
+import org.betonquest.betonquest.api.quest.condition.PlayerlessCondition;
+import org.betonquest.betonquest.api.quest.condition.PlayerlessConditionFactory;
+import org.betonquest.betonquest.api.service.condition.ConditionManager;
+import org.betonquest.betonquest.id.IdentifierUtil;
+import org.betonquest.betonquest.quest.condition.logik.ConjunctionCondition;
+
+import java.util.List;
+
+/**
+ * Factory to create section grouped conditions from {@link Instruction}s.
+ */
+public class SectionConditionFactory implements PlayerConditionFactory, PlayerlessConditionFactory {
+
+    /**
+     * The condition manager.
+     */
+    private final ConditionManager conditionManager;
+
+    /**
+     * Factory to create identifier from section keys.
+     */
+    private final IdentifierFactory<ConditionIdentifier> identifierFactory;
+
+    /**
+     * Create the section condition factory.
+     *
+     * @param conditionManager  the condition manager
+     * @param identifierFactory the factory to create identifier from section keys
+     */
+    public SectionConditionFactory(final ConditionManager conditionManager, final IdentifierFactory<ConditionIdentifier> identifierFactory) {
+        this.conditionManager = conditionManager;
+        this.identifierFactory = identifierFactory;
+    }
+
+    @Override
+    public PlayerCondition parsePlayer(final Instruction instruction) throws QuestException {
+        return parseInstruction(instruction);
+    }
+
+    @Override
+    public PlayerlessCondition parsePlayerless(final Instruction instruction) throws QuestException {
+        return parseInstruction(instruction);
+    }
+
+    private NullableConditionAdapter parseInstruction(final Instruction instruction) throws QuestException {
+        final Argument<List<ConditionIdentifier>> conditionIDs = instruction.identifier(ConditionIdentifier.class).map(this::map).get();
+        return new NullableConditionAdapter(new ConjunctionCondition(conditionIDs, conditionManager));
+    }
+
+    private List<ConditionIdentifier> map(final ConditionIdentifier identifier) throws QuestException {
+        return IdentifierUtil.subsectionIdentifiers(identifierFactory, identifier);
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/section/package-info.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/section/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@link org.betonquest.betonquest.api.quest.condition Condition} implementation that allows using section nodes.
+ */
+package org.betonquest.betonquest.quest.condition.section;

--- a/docs/Documentation/Reference/Conditions-List.md
+++ b/docs/Documentation/Reference/Conditions-List.md
@@ -30,7 +30,9 @@ __Context__: @snippet:condition-meta:independent@
 __Syntax__: `and <conditions>`  
 __Description__: The conjunction of the specified conditions.
 
-This means that every condition has to be met in order for conjunction to be true. Used only in complex alternatives, because conditions generally work as conjunction. Instruction string is exactly the same as in `alternative`.
+This means that every condition has to be met in order for conjunction to be true.
+Used only in complex alternatives, because conditions generally work as conjunction.
+Instruction string is exactly the same as in `alternative`.
 
 ```YAML title="Example"
 conditions:
@@ -729,6 +731,33 @@ The kind of tags that are used by vanilla Minecraft and not the [betonquest tags
 conditions:
   hasVanillaTag: "scoretag vanilla_tag"
 ```
+
+## `Section`
+
+__Context__: @snippet:condition-meta:independent@  
+__Syntax__: `section <section>`  
+__Description__: The conjunction of the conditions inside the specified section.
+
+| Parameter                                                            | Type     | Explanation                             |
+|----------------------------------------------------------------------|----------|-----------------------------------------|
+| section <br>[[Identifier]](./Definition-Encyclopedia.md#identifiers) | Required | The target section with the conditions. |
+
+You can also use directly any node as condition, which works the same as [`and`](#and) of every condition in the subsections.
+
+```YAML title="Examples"
+conditions:
+  section: "section nested"
+  nested:
+    one: …
+    deep:
+      two: …
+      three: …
+  conjunction: "and nested.one,nested.deep.two,nested.deep.three" #(1)!
+  implicit: "and nested" #(2)!
+```
+
+1. Is equivalent to the "section" condition.
+2. Is equivalent to the "section" condition.
 
 ## `Sneak`
 


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Trying to implement the section condition without also implementing the implicit one results in the need of a slightly different identifier instead of just allowing to pointing to a configuration section.

For that reason the section condition is minimalistic to none existent, the non-standard implementation with flags and other arguments follows in a different PR.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
