### PR TITLE
[DOCS] Fix documentation for `effect` action

### DIFF
--- a/docs/Documentation/Reference/Actions-List.md
+++ b/docs/Documentation/Reference/Actions-List.md
@@ -285,7 +285,7 @@ actions:
 ## `Effect`
 
 __Context__: @snippet:action-meta:online@  
-__Syntax__: `effect <effect> <duration> <level> [ambient] [icon] [hidden]`  
+__Syntax__: `effect <effect> <duration> <level> [ambient] [noicon] [hidden]`  
 __Description__: Apply the specified potion effect to the player.
 
 First argument is potion type. You can find all available types [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html).
@@ -296,7 +296,7 @@ To hide particles add a parameter `hidden`. To hide the icon for the effect add 
 
 ```YAML title="Example"
 actions:
-  effectBlindness: "effect BLINDNESS 30 1 ambient icon"
+  effectBlindness: "effect BLINDNESS 30 1 ambient noicon"
 ```
 
 ## `Eval`


### PR DESCRIPTION
Update `Actions-List` to replace `icon` with `noicon` in `effect` syntax and example to match the actual implementation correctly

---


### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
