### PR TITLE
Changed Skript Condition and Effect now handle if no player is present an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `worldedit` integration version requirement to 7.3.0
 - counting objective related translations in the lang files were moved in an own `objective` section and use `{absoluteleft}` instead of `{amount}`
 - `citizens` returns the stored `location` instead of nothing when not spawned
+- Skript Condition and Effect now handle if no player is present and check like they are independent
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptConditionBQ.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptConditionBQ.java
@@ -62,7 +62,8 @@ public class SkriptConditionBQ extends Condition {
     @Override
     @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public String toString(@Nullable final Event event, final boolean debug) {
-        return player.getSingle(event).getName() + " meets " + condition;
+        final Player single = player.getSingle(event);
+        return "%s meets %s".formatted(single == null ? "null" : single.getName(), condition);
     }
 
     @Override
@@ -72,7 +73,8 @@ public class SkriptConditionBQ extends Condition {
             final ProfileProvider profileProvider = betonQuestApi.profiles();
             final IdentifierFactory<ConditionIdentifier> conditionIdentifierFactory =
                     betonQuestApi.identifiers().getFactory(ConditionIdentifier.class);
-            return betonQuestApi.conditions().manager().test(profileProvider.getProfile(player.getSingle(event)),
+            final Player single = player.getSingle(event);
+            return betonQuestApi.conditions().manager().test(single == null ? null : profileProvider.getProfile(single),
                     conditionIdentifierFactory.parseIdentifier(null, conditionID));
         } catch (final QuestException e) {
             log.warn("Error while checking Skript condition - could not load condition with ID '" + conditionID + "': " + e.getMessage(), e);

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptEffectBQ.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/skript/SkriptEffectBQ.java
@@ -63,7 +63,8 @@ public class SkriptEffectBQ extends Effect {
     @Override
     @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public String toString(@Nullable final Event event, final boolean debug) {
-        return "fire " + this.action + " for " + player.getSingle(event).getName();
+        final Player single = player.getSingle(event);
+        return "fire %s for %s".formatted(this.action, single == null ? "null" : single.getName());
     }
 
     @Override
@@ -76,7 +77,8 @@ public class SkriptEffectBQ extends Effect {
                     final ProfileProvider profileProvider = betonQuestApi.profiles();
                     final IdentifierFactory<ActionIdentifier> actionIdentifierFactory =
                             betonQuestApi.identifiers().getFactory(ActionIdentifier.class);
-                    betonQuestApi.actions().manager().run(profileProvider.getProfile(player.getSingle(event)),
+                    final Player single = player.getSingle(event);
+                    betonQuestApi.actions().manager().run(single == null ? null : profileProvider.getProfile(single),
                             actionIdentifierFactory.parseIdentifier(null, actionID));
                 } catch (final QuestException e) {
                     log.warn("Error when running Skript event - could not load '" + actionID + "' action: " + e.getMessage(), e);


### PR DESCRIPTION
…d check like they are independent

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes https://faststats.dev/project/betonquest/errors/114c8033043c4a4f14c309814d33fb10dfa93e36a35c7cc68adcfd0755216b34

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
