### PR TITLE
Improve `chestgive` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `citizens` returns the stored `location` instead of nothing when not spawned
 - Skript Condition and Effect now handle if no player is present and check like they are independent
 - `deleffect` action no longer accepts an omitted first argument as `any`
+- `chestgive` action no longer drops excess items without newly added `dropExcess` flag
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/core/src/main/java/org/betonquest/betonquest/config/migrator/QuestMigrator.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/config/migrator/QuestMigrator.java
@@ -14,6 +14,7 @@ import org.betonquest.betonquest.config.migrator.from1to2.RideUpdates;
 import org.betonquest.betonquest.config.migrator.from2to3.AddSimpleTypeToQuestItem;
 import org.betonquest.betonquest.config.migrator.from2to3.AutoOnceObjective;
 import org.betonquest.betonquest.config.migrator.from2to3.BurnDurationArgumentName;
+import org.betonquest.betonquest.config.migrator.from2to3.ChestGiveDropFlag;
 import org.betonquest.betonquest.config.migrator.from2to3.DeleteEffectAny;
 import org.betonquest.betonquest.config.migrator.from2to3.DynamicHologramTopLine;
 import org.betonquest.betonquest.config.migrator.from2to3.EventsToActionsRename;
@@ -132,6 +133,7 @@ public class QuestMigrator {
         migrations.put(questVersion("3.0.0", 17), new AutoOnceObjective());
         migrations.put(questVersion("3.1.0", 1), new BurnDurationArgumentName());
         migrations.put(questVersion("3.2.0", 1), new DeleteEffectAny());
+        migrations.put(questVersion("3.2.0", 2), new ChestGiveDropFlag());
         this.fallbackVersion = questVersion(pluginDescription.getVersion(), 0);
     }
 

--- a/code/core/src/main/java/org/betonquest/betonquest/config/migrator/from2to3/ChestGiveDropFlag.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/config/migrator/from2to3/ChestGiveDropFlag.java
@@ -1,0 +1,24 @@
+package org.betonquest.betonquest.config.migrator.from2to3;
+
+import org.betonquest.betonquest.lib.config.patcher.migration.QuestMigration;
+import org.betonquest.betonquest.lib.config.quest.Quest;
+import org.bukkit.configuration.InvalidConfigurationException;
+
+/**
+ * Add the new `dropExcess` flag to the chest-give action.
+ */
+public class ChestGiveDropFlag implements QuestMigration {
+
+    /**
+     * Creates a new chest-give drop flag migration.
+     */
+    public ChestGiveDropFlag() {
+    }
+
+    @Override
+    public void migrate(final Quest quest) throws InvalidConfigurationException {
+        replace(quest.getQuestConfig(), "actions",
+                value -> value.startsWith("chestgive"),
+                value -> value.trim() + " dropExcess");
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/config/migrator/from2to3/ChestGiveDropFlag.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/config/migrator/from2to3/ChestGiveDropFlag.java
@@ -5,7 +5,7 @@ import org.betonquest.betonquest.lib.config.quest.Quest;
 import org.bukkit.configuration.InvalidConfigurationException;
 
 /**
- * Add the new `dropExcess` flag to the chest-give action.
+ * Add the new {@code dropExcess} flag to the chest-give action.
  */
 public class ChestGiveDropFlag implements QuestMigration {
 
@@ -18,7 +18,7 @@ public class ChestGiveDropFlag implements QuestMigration {
     @Override
     public void migrate(final Quest quest) throws InvalidConfigurationException {
         replace(quest.getQuestConfig(), "actions",
-                value -> value.startsWith("chestgive"),
-                value -> value.trim() + " dropExcess");
+                value -> value.startsWith("chestgive "),
+                value -> value + " dropExcess");
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveAction.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.quest.action.chest;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.item.QuestItem;
 import org.betonquest.betonquest.api.profile.Profile;
@@ -22,7 +23,7 @@ import java.util.Map;
 public class ChestGiveAction implements NullableAction {
 
     /**
-     * The items to put in the blocks inventory.
+     * The items to put in the block's inventory.
      */
     private final Argument<List<ItemWrapper>> questItems;
 
@@ -32,14 +33,22 @@ public class ChestGiveAction implements NullableAction {
     private final Argument<Location> location;
 
     /**
+     * Whether to drop excess items.
+     */
+    private final FlagArgument<Boolean> dropExcess;
+
+    /**
      * Create the chest give action.
      *
-     * @param questItems the items to put in the blocks inventory
+     * @param questItems the items to put in the block's inventory
      * @param location   the location of the block
+     * @param dropExcess whether to drop excess items
      */
-    public ChestGiveAction(final Argument<Location> location, final Argument<List<ItemWrapper>> questItems) {
+    public ChestGiveAction(final Argument<Location> location, final Argument<List<ItemWrapper>> questItems,
+                           final FlagArgument<Boolean> dropExcess) {
         this.questItems = questItems;
         this.location = location;
+        this.dropExcess = dropExcess;
     }
 
     @Override
@@ -53,6 +62,9 @@ public class ChestGiveAction implements NullableAction {
                     + block.getX() + " Y" + block.getY() + " Z" + block.getZ(), e);
         }
         final Map<Integer, ItemStack> left = chest.getInventory().addItem(getItemStacks(profile));
+        if (!dropExcess.getValue(profile).orElse(false)) {
+            return;
+        }
         for (final ItemStack itemStack : left.values()) {
             block.getWorld().dropItem(block.getLocation(), itemStack);
         }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveActionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/chest/ChestGiveActionFactory.java
@@ -2,6 +2,7 @@ package org.betonquest.betonquest.quest.action.chest;
 
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
 import org.betonquest.betonquest.api.quest.action.NullableActionAdapter;
@@ -37,7 +38,8 @@ public class ChestGiveActionFactory implements PlayerActionFactory, PlayerlessAc
     private NullableActionAdapter createChestGiveAction(final Instruction instruction) throws QuestException {
         final Argument<Location> location = instruction.location().get();
         final Argument<List<ItemWrapper>> items = instruction.item().list().get();
-        return new NullableActionAdapter(new ChestGiveAction(location, items)
+        final FlagArgument<Boolean> dropExcess = instruction.bool().getFlag("dropExcess", true);
+        return new NullableActionAdapter(new ChestGiveAction(location, items, dropExcess)
         );
     }
 }

--- a/docs/Documentation/Reference/Actions-List.md
+++ b/docs/Documentation/Reference/Actions-List.md
@@ -93,18 +93,23 @@ actions:
 ## `ChestGive`
 
 __Context__: @snippet:action-meta:independent@  
-__Syntax__: `chestgive <location> <items>`  
+__Syntax__: `chestgive <location> <items> {dropExcess}`  
 __Description__: Put items into the chest at the specified location.
 
-This works the same as `give` action, but it puts the items in a chest at specified location.
-The first argument is a location, the second argument is a list of items, like in `give` action.
-If the chest is full, the items will be dropped on the ground.
-The chest can be any other block with inventory, i.e. a hopper or a dispenser.
-BetonQuest will log an error to the console when this action is fired but there is no chest at a specified location.
+This works the same as [`give` action](#give), but it puts the items in a block with an inventory at the specified location.  
+At the location may be any block with an inventory, i.e., a hopper or a dispenser.  
+If the chest is full, the items will be dropped on the ground if the `dropExcess` flag is present or set to `true`.
+
+| Parameter                                                                      | Type                  | Explanation                                                                                                                            |
+|--------------------------------------------------------------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| location<br>[[Location]](./Definition-Encyclopedia.md#unified-location-format) | Required              | The location of the block of which the inventory should be filled. In case there is no chest at the given location an error is thrown. |
+| items<br>List[Item]                                                            | Required              | The items with their optional amounts.                                                                                                 |
+| dropExcess<br>[Boolean]                                                        | Flag<br>[false, true] | If the excess amount of items that won't fit into the chest should be dropped on the ground.                                           |
 
 ```YAML title="Example"
 actions:
-  chestgive: "chestgive 100;200;300;world emerald:5,sword"
+  chestgive: "chestgive 100;200;300;world emerald:5,sword dropExcess"
+  nodrop: "chestgive 100;200;300;world emerald:5,sword"
 ```
 
 ## `ChestTake`

--- a/docs/_glossary/instruction-datatypes.md
+++ b/docs/_glossary/instruction-datatypes.md
@@ -8,3 +8,4 @@
 *[Additionals]: Additional values are prefixed with a + symbol and allow for key-value pairs to be added to the element.
 *[Null]: A null value has no value.
 *[TimeUnit]: ticks, seconds, minutes, hours, days, weeks, months, years
+*[Item]: An item refers to elements defined in the items section of a quest package. It may be specified with an amount after a colon.


### PR DESCRIPTION
Improve `chestgive` action.
- Add `dropExcess` flag to specify whether to drop items if the chest is full
- Add fully automated migration for it, since the old behavior requires it to be present by default
- Apply new documentation format

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
