### PR TITLE
Add block condition as shorter alias for testforblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `section` (and implicit `section`) condition to allow usage of subsections as list of (conjugated) conditions
 - `damage` objective to track dealt and taken damage
 - `updateHologram` action to force updates to (specific) holograms for a player
+- `block` condition as a shorter alias for `testforblock`
 ### Changed
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ConditionTypesComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ConditionTypesComponent.java
@@ -124,6 +124,7 @@ public class ConditionTypesComponent extends AbstractCoreComponent {
         conditionTypes.registerCombined("and", new ConjunctionConditionFactory(conditionManager));
         conditionTypes.register("armor", new ArmorConditionFactory());
         conditionTypes.register("biome", new BiomeConditionFactory());
+        conditionTypes.registerCombined("block", new BlockConditionFactory());
         conditionTypes.register("burning", new BurningConditionFactory());
         conditionTypes.registerCombined("check", new CheckConditionFactory(instructions, conditionTypes));
         conditionTypes.registerCombined("chestitem", new ChestItemConditionFactory());

--- a/docs/Documentation/Reference/Conditions-List.md
+++ b/docs/Documentation/Reference/Conditions-List.md
@@ -63,6 +63,21 @@ conditions:
   inSavannaRock: "biome savanna_rock"
 ```
 
+## `Block`
+
+__Context__: @snippet:condition-meta:independent@  
+__Syntax__: `block <location> <selector>`  
+__Description__: Whether the block at the specified location matches the specified block selector.
+
+The first argument is a location in the [unified location format](Definition-Encyclopedia.md#unified-location-format), and the second is a [block selector](Definition-Encyclopedia.md#block-selectors). The block is checked even if its chunk isn't currently loaded.
+
+This is the same condition as [`TestForBlock`](#testforblock), just under a shorter name.
+
+```YAML title="Example"
+conditions:
+  stoneSet: "block 100;200;300;world STONE"
+```
+
 ## `Burning`
 
 __Context__: @snippet:condition-meta:online@  
@@ -812,7 +827,7 @@ __Context__: @snippet:condition-meta:independent@
 __Syntax__: `testforblock <location> <selector>`  
 __Description__: Whether the block at specified location matches the specified material.
 
-First argument is a location, and the second one is a `block selector`.
+First argument is a location, and the second one is a `block selector`. Also available under the shorter name [`Block`](#block).
 
 ```YAML title="Example"
 conditions:


### PR DESCRIPTION
Adds a `block` condition that checks the block at a location against a block selector, as requested.

### Note

While implementing this I found that `testforblock` already does exactly this (`BlockCondition`/`BlockConditionFactory`, registered under `testforblock`). Rather than duplicating that logic, this PR registers the existing factory under the shorter name `block` as well, and documents `block` as the preferred name while keeping `testforblock` working for backwards compatibility. Happy to change the approach (e.g. deprecate/remove `testforblock` instead) if you'd rather go that route.

---

### Related Issues

Closes #4206

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [ ]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... write a migration?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!

## Testing

`mvn verify` on the `core` module (Java 21): 754 tests passed, checkstyle/spotbugs clean, BUILD SUCCESS.