### PR TITLE
Implement equip action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `section` (and implicit `section`) condition to allow usage of subsections as list of (conjugated) conditions
 - `damage` objective to track dealt and taken damage
 - `updateHologram` action to force updates to (specific) holograms for a player
+- `equip` action to put items into players' equipment slots
 ### Changed
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ActionTypesComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ActionTypesComponent.java
@@ -40,6 +40,7 @@ import org.betonquest.betonquest.quest.action.drop.DropActionFactory;
 import org.betonquest.betonquest.quest.action.effect.DeleteEffectActionFactory;
 import org.betonquest.betonquest.quest.action.effect.EffectActionFactory;
 import org.betonquest.betonquest.quest.action.entity.RemoveEntityActionFactory;
+import org.betonquest.betonquest.quest.action.equip.EquipActionFactory;
 import org.betonquest.betonquest.quest.action.eval.EvalActionFactory;
 import org.betonquest.betonquest.quest.action.experience.ExperienceActionFactory;
 import org.betonquest.betonquest.quest.action.explosion.ExplosionActionFactory;
@@ -160,6 +161,7 @@ public class ActionTypesComponent extends AbstractCoreComponent {
         actionTypes.registerCombined("door", new DoorActionFactory());
         actionTypes.registerCombined("drop", new DropActionFactory(profileProvider));
         actionTypes.register("effect", new EffectActionFactory());
+        actionTypes.register("equip", new EquipActionFactory());
         actionTypes.registerCombined("eval", new EvalActionFactory(instructions, actionTypes, scheduler, plugin));
         actionTypes.register("experience", new ExperienceActionFactory());
         actionTypes.registerCombined("explosion", new ExplosionActionFactory());

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipAction.java
@@ -62,28 +62,24 @@ public class EquipAction implements OnlineAction {
         final ItemStack equippedItem = equipment.getItem(resolvedSlot);
         final boolean shouldDrop = drop.getValue(profile).orElse(false);
         final boolean shouldForce = force.getValue(profile).orElse(false);
+        final ItemStack newItem = item.getValue(profile).generate(profile);
 
         if (InventoryUtils.isEmptySlot(equippedItem)) {
-            equipment.setItem(resolvedSlot, generateItem(profile));
+            equipment.setItem(resolvedSlot, newItem);
             return;
         }
 
         if (!shouldForce) {
             if (shouldDrop) {
-                dropItem(player, generateItem(profile));
+                dropItem(player, newItem);
             }
             return;
         }
 
-        final ItemStack newItem = generateItem(profile);
         if (shouldDrop) {
             dropItem(player, equippedItem);
         }
         equipment.setItem(resolvedSlot, newItem);
-    }
-
-    private ItemStack generateItem(final OnlineProfile profile) throws QuestException {
-        return item.getValue(profile).generate(profile);
     }
 
     private void dropItem(final Player player, final ItemStack item) {

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipAction.java
@@ -1,0 +1,98 @@
+package org.betonquest.betonquest.quest.action.equip;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.action.OnlineAction;
+import org.betonquest.betonquest.util.InventoryUtils;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Equips an item in a player's equipment slot.
+ */
+public class EquipAction implements OnlineAction {
+
+    /**
+     * The item to equip.
+     */
+    private final Argument<ItemWrapper> item;
+
+    /**
+     * The equipment slot to target.
+     */
+    private final Argument<EquipmentSlot> slot;
+
+    /**
+     * Whether to drop an item that cannot remain in the slot.
+     */
+    private final FlagArgument<Boolean> drop;
+
+    /**
+     * Whether to replace an item already in the slot.
+     */
+    private final FlagArgument<Boolean> force;
+
+    /**
+     * Creates the equip action.
+     *
+     * @param item  the item to equip
+     * @param slot  the equipment slot to target
+     * @param drop  whether to drop an item that cannot remain in the slot
+     * @param force whether to replace an item already in the slot
+     */
+    public EquipAction(final Argument<ItemWrapper> item, final Argument<EquipmentSlot> slot,
+                       final FlagArgument<Boolean> drop, final FlagArgument<Boolean> force) {
+        this.item = item;
+        this.slot = slot;
+        this.drop = drop;
+        this.force = force;
+    }
+
+    @Override
+    public void execute(final OnlineProfile profile) throws QuestException {
+        final Player player = profile.getPlayer();
+        final EntityEquipment equipment = player.getEquipment();
+        final EquipmentSlot resolvedSlot = slot.getValue(profile);
+        final ItemStack equippedItem = equipment.getItem(resolvedSlot);
+        final boolean shouldDrop = drop.getValue(profile).orElse(false);
+        final boolean shouldForce = force.getValue(profile).orElse(false);
+
+        if (InventoryUtils.isEmptySlot(equippedItem)) {
+            equipment.setItem(resolvedSlot, generateItem(profile));
+            return;
+        }
+
+        if (!shouldForce) {
+            if (shouldDrop) {
+                dropItem(player, generateItem(profile));
+            }
+            return;
+        }
+
+        final ItemStack newItem = generateItem(profile);
+        if (shouldDrop) {
+            dropItem(player, equippedItem);
+        }
+        equipment.setItem(resolvedSlot, newItem);
+    }
+
+    private ItemStack generateItem(final OnlineProfile profile) throws QuestException {
+        return item.getValue(profile).generate(profile);
+    }
+
+    private void dropItem(final Player player, final ItemStack item) {
+        final Location location = player.getLocation();
+        location.getWorld().dropItem(location, item);
+    }
+
+    @Override
+    public boolean isPrimaryThreadEnforced() {
+        return true;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipActionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipActionFactory.java
@@ -10,10 +10,19 @@ import org.betonquest.betonquest.api.quest.action.PlayerAction;
 import org.betonquest.betonquest.api.quest.action.PlayerActionFactory;
 import org.bukkit.inventory.EquipmentSlot;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * Factory for {@link EquipAction}.
  */
 public class EquipActionFactory implements PlayerActionFactory {
+
+    /**
+     * Equipment slots available to players.
+     */
+    private static final Set<EquipmentSlot> PLAYER_SLOTS = EnumSet.of(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND,
+            EquipmentSlot.FEET, EquipmentSlot.LEGS, EquipmentSlot.CHEST, EquipmentSlot.HEAD);
 
     /**
      * Creates the equip action factory.
@@ -25,16 +34,10 @@ public class EquipActionFactory implements PlayerActionFactory {
     public PlayerAction parsePlayer(final Instruction instruction) throws QuestException {
         final Argument<ItemWrapper> item = instruction.item().get();
         final Argument<EquipmentSlot> slot = instruction.enumeration(EquipmentSlot.class)
-                .validate(EquipActionFactory::isPlayerSlot, "Invalid player equipment slot: '%s'")
+                .validate(PLAYER_SLOTS::contains, "Invalid player equipment slot: '%s'")
                 .get();
         final FlagArgument<Boolean> drop = instruction.bool().getFlag("drop", true);
         final FlagArgument<Boolean> force = instruction.bool().getFlag("force", true);
         return new OnlineActionAdapter(new EquipAction(item, slot, drop, force));
-    }
-
-    private static boolean isPlayerSlot(final EquipmentSlot slot) {
-        return slot == EquipmentSlot.HAND || slot == EquipmentSlot.OFF_HAND
-                || slot == EquipmentSlot.FEET || slot == EquipmentSlot.LEGS
-                || slot == EquipmentSlot.CHEST || slot == EquipmentSlot.HEAD;
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipActionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/EquipActionFactory.java
@@ -1,0 +1,40 @@
+package org.betonquest.betonquest.quest.action.equip;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.Argument;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.instruction.Instruction;
+import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
+import org.betonquest.betonquest.api.quest.action.OnlineActionAdapter;
+import org.betonquest.betonquest.api.quest.action.PlayerAction;
+import org.betonquest.betonquest.api.quest.action.PlayerActionFactory;
+import org.bukkit.inventory.EquipmentSlot;
+
+/**
+ * Factory for {@link EquipAction}.
+ */
+public class EquipActionFactory implements PlayerActionFactory {
+
+    /**
+     * Creates the equip action factory.
+     */
+    public EquipActionFactory() {
+    }
+
+    @Override
+    public PlayerAction parsePlayer(final Instruction instruction) throws QuestException {
+        final Argument<ItemWrapper> item = instruction.item().get();
+        final Argument<EquipmentSlot> slot = instruction.enumeration(EquipmentSlot.class)
+                .validate(EquipActionFactory::isPlayerSlot, "Invalid player equipment slot: '%s'")
+                .get();
+        final FlagArgument<Boolean> drop = instruction.bool().getFlag("drop", true);
+        final FlagArgument<Boolean> force = instruction.bool().getFlag("force", true);
+        return new OnlineActionAdapter(new EquipAction(item, slot, drop, force));
+    }
+
+    private static boolean isPlayerSlot(final EquipmentSlot slot) {
+        return slot == EquipmentSlot.HAND || slot == EquipmentSlot.OFF_HAND
+                || slot == EquipmentSlot.FEET || slot == EquipmentSlot.LEGS
+                || slot == EquipmentSlot.CHEST || slot == EquipmentSlot.HEAD;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/package-info.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/equip/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@link org.betonquest.betonquest.api.quest.action Action} implementation to equip a player with an item.
+ */
+package org.betonquest.betonquest.quest.action.equip;

--- a/code/core/src/test/java/org/betonquest/betonquest/quest/action/equip/EquipActionTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/quest/action/equip/EquipActionTest.java
@@ -60,7 +60,6 @@ class EquipActionTest {
         createAction(item, false, false).execute(profile);
 
         verify(equipment, never()).setItem(any(), any());
-        verify(item, never()).generate(any());
     }
 
     @Test

--- a/code/core/src/test/java/org/betonquest/betonquest/quest/action/equip/EquipActionTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/quest/action/equip/EquipActionTest.java
@@ -1,0 +1,145 @@
+package org.betonquest.betonquest.quest.action.equip;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.betonquest.betonquest.api.instruction.FlagArgument;
+import org.betonquest.betonquest.api.instruction.type.ItemWrapper;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link EquipAction}.
+ */
+@ExtendWith(MockitoExtension.class)
+class EquipActionTest {
+
+    private static final EquipmentSlot SLOT = EquipmentSlot.HEAD;
+
+    @Test
+    void equips_item_when_slot_is_empty(
+            @Mock final OnlineProfile profile,
+            @Mock final Player player,
+            @Mock final EntityEquipment equipment,
+            @Mock final ItemWrapper item,
+            @Mock final ItemStack newItem
+    ) throws QuestException {
+        final ItemStack emptyItem = mock(ItemStack.class);
+        when(emptyItem.getType()).thenReturn(Material.AIR);
+        setupProfile(profile, player, equipment, emptyItem);
+        when(item.generate(profile)).thenReturn(newItem);
+
+        createAction(item, false, false).execute(profile);
+
+        verify(equipment).setItem(SLOT, newItem);
+    }
+
+    @Test
+    void keeps_existing_item_without_flags(
+            @Mock final OnlineProfile profile,
+            @Mock final Player player,
+            @Mock final EntityEquipment equipment,
+            @Mock final ItemWrapper item,
+            @Mock final ItemStack equippedItem
+    ) throws QuestException {
+        setupProfile(profile, player, equipment, equippedItem);
+        when(equippedItem.getType()).thenReturn(Material.DIAMOND_HELMET);
+
+        createAction(item, false, false).execute(profile);
+
+        verify(equipment, never()).setItem(any(), any());
+        verify(item, never()).generate(any());
+    }
+
+    @Test
+    void drops_new_item_when_slot_is_occupied_and_drop_is_set(
+            @Mock final OnlineProfile profile,
+            @Mock final Player player,
+            @Mock final EntityEquipment equipment,
+            @Mock final ItemWrapper item,
+            @Mock final ItemStack equippedItem,
+            @Mock final ItemStack newItem,
+            @Mock final Location location,
+            @Mock final World world
+    ) throws QuestException {
+        setupProfile(profile, player, equipment, equippedItem);
+        setupDrop(player, location, world);
+        when(equippedItem.getType()).thenReturn(Material.DIAMOND_HELMET);
+        when(item.generate(profile)).thenReturn(newItem);
+
+        createAction(item, true, false).execute(profile);
+
+        verify(world).dropItem(location, newItem);
+        verify(equipment, never()).setItem(any(), any());
+    }
+
+    @Test
+    void replaces_existing_item_when_force_is_set(
+            @Mock final OnlineProfile profile,
+            @Mock final Player player,
+            @Mock final EntityEquipment equipment,
+            @Mock final ItemWrapper item,
+            @Mock final ItemStack equippedItem,
+            @Mock final ItemStack newItem
+    ) throws QuestException {
+        setupProfile(profile, player, equipment, equippedItem);
+        when(equippedItem.getType()).thenReturn(Material.DIAMOND_HELMET);
+        when(item.generate(profile)).thenReturn(newItem);
+
+        createAction(item, false, true).execute(profile);
+
+        verify(equipment).setItem(SLOT, newItem);
+    }
+
+    @Test
+    void drops_existing_item_when_drop_and_force_are_set(
+            @Mock final OnlineProfile profile,
+            @Mock final Player player,
+            @Mock final EntityEquipment equipment,
+            @Mock final ItemWrapper item,
+            @Mock final ItemStack equippedItem,
+            @Mock final ItemStack newItem,
+            @Mock final Location location,
+            @Mock final World world
+    ) throws QuestException {
+        setupProfile(profile, player, equipment, equippedItem);
+        setupDrop(player, location, world);
+        when(equippedItem.getType()).thenReturn(Material.DIAMOND_HELMET);
+        when(item.generate(profile)).thenReturn(newItem);
+
+        createAction(item, true, true).execute(profile);
+
+        verify(world).dropItem(location, equippedItem);
+        verify(equipment).setItem(SLOT, newItem);
+    }
+
+    private void setupProfile(final OnlineProfile profile, final Player player,
+                              final EntityEquipment equipment, final ItemStack equippedItem) {
+        when(profile.getPlayer()).thenReturn(player);
+        when(player.getEquipment()).thenReturn(equipment);
+        when(equipment.getItem(SLOT)).thenReturn(equippedItem);
+    }
+
+    private void setupDrop(final Player player, final Location location, final World world) {
+        when(player.getLocation()).thenReturn(location);
+        when(location.getWorld()).thenReturn(world);
+    }
+
+    private EquipAction createAction(final ItemWrapper item, final boolean drop, final boolean force) {
+        final FlagArgument<Boolean> dropFlag = profile -> Optional.of(drop);
+        final FlagArgument<Boolean> forceFlag = profile -> Optional.of(force);
+        return new EquipAction(profile -> item, profile -> SLOT, dropFlag, forceFlag);
+    }
+}

--- a/docs/Documentation/Reference/Actions-List.md
+++ b/docs/Documentation/Reference/Actions-List.md
@@ -302,6 +302,30 @@ actions:
   effectBlindness: "effect BLINDNESS 30 1 ambient noicon"
 ```
 
+## `Equip`
+
+__Context__: @snippet:action-meta:online@  
+__Syntax__: `equip <item> <slot> {drop} {force}`  
+__Description__: Put the specified item into the player's equipment slot.
+
+By default, the item is only equipped if the slot is empty. The `drop` flag drops the new item when the slot is occupied.
+The `force` flag replaces an existing item, and combining it with `drop` drops the replaced item.
+
+| Parameter               | Type                  | Explanation                                                                            |
+|-------------------------|-----------------------|----------------------------------------------------------------------------------------|
+| item<br>[Item]          | Required              | The item to equip.                                                                     |
+| slot<br>[EquipmentSlot] | Required              | The equipment slot in which the item should be placed.                                 |
+| drop<br>[Boolean]       | Flag<br>[false, true] | Whether an item that cannot remain in the equipment slot should be dropped.            |
+| force<br>[Boolean]      | Flag<br>[false, true] | Whether an item already in the equipment slot should be replaced by the specified one. |
+
+```YAML title="Example"
+actions:
+  equipHelmet: "equip diamond_helmet HEAD"
+  replaceHelmet: "equip quest_helmet HEAD drop force"
+```
+
+*[EquipmentSlot]: HAND, OFF_HAND, FEET, LEGS, CHEST, HEAD
+
 ## `Eval`
 
 __Context__: @snippet:action-meta:independent@  


### PR DESCRIPTION
Adds the online `equip` action requested in #4207.

- equips generated items into one of the six player equipment slots
- implements the documented default, `drop`, `force`, and combined flag behavior
- validates player-only slots and registers the action factory
- adds focused tests, reference documentation, and a changelog entry

Validation:
- `EquipActionTest`: 5 tests passed
- core unit suite: 673 tests passed
- core integration suite: 67 tests passed before the final parser-only guard
- core packaging, Javadoc, EditorConfig, Checkstyle, PMD, and SpotBugs passed

Full-reactor limitation: the unchanged compatibility module currently fails to compile against its resolved TheBrewingProject dependency because that dependency API has changed. The changed core module and both supported Minecraft modules passed their applicable checks.

---

### Related Issues

Closes #4207

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
