### PR TITLE
Add banner pattern handler for simple items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
+- `patterns` argument for adding and matching pattern layers on `simple` banner items
 - `haspoint` and `hasglobalpoint` conditions to check if a point is set
 - counting objective related translations in the lang files can now use all counting objective related placeholders
 - `fallback` argument to point conditions to use a default value when category has no value at all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ${maven.build.timestamp}
 ### Added
-- `patterns` argument for adding and matching pattern layers on `simple` banner items
 - `haspoint` and `hasglobalpoint` conditions to check if a point is set
 - counting objective related translations in the lang files can now use all counting objective related placeholders
 - `fallback` argument to point conditions to use a default value when category has no value at all
 - `section` (and implicit `section`) condition to allow usage of subsections as list of (conjugated) conditions
 - `damage` objective to track dealt and taken damage
 - `updateHologram` action to force updates to (specific) holograms for a player
+- `patterns` argument for adding and matching pattern layers on `simple` banner items
 ### Changed
 - `worldguard` integration version requirement to 7.0.0
 - `worldedit` integration version requirement to 7.3.0

--- a/code/core/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemFactory.java
@@ -13,6 +13,7 @@ import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.TypeFactory;
 import org.betonquest.betonquest.api.service.placeholder.PlaceholderManager;
 import org.betonquest.betonquest.api.text.TextParser;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.CustomModelDataHandler;
@@ -125,6 +126,7 @@ public class SimpleQuestItemFactory implements TypeFactory<QuestItemWrapper> {
                 questHandler,
                 new EnchantmentsHandler(),
                 new PotionHandler(),
+                new BannerHandler(),
                 new BookHandler(textParser, bookPageWrapper),
                 new HeadHandler(),
                 new ColorHandler(),

--- a/code/core/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemSerializer.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/SimpleQuestItemSerializer.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.item;
 import org.betonquest.betonquest.api.common.component.BookPageWrapper;
 import org.betonquest.betonquest.api.item.QuestItemSerializer;
 import org.betonquest.betonquest.api.text.TextParser;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.CustomModelDataHandler;
@@ -41,7 +42,7 @@ public class SimpleQuestItemSerializer implements QuestItemSerializer {
     public SimpleQuestItemSerializer(final TextParser textParser, final BookPageWrapper bookPageWrapper) {
         this(List.of(
                 new DurabilityHandler(), new NameHandler(textParser), new LoreHandler(textParser, () -> false), new EnchantmentsHandler(),
-                new BookHandler(textParser, bookPageWrapper), new PotionHandler(), new ColorHandler(), new HeadHandler(),
+                new BookHandler(textParser, bookPageWrapper), new PotionHandler(), new BannerHandler(), new ColorHandler(), new HeadHandler(),
                 new FireworkHandler(), new UnbreakableHandler(), new CustomModelDataHandler(), new FlagHandler(),
                 new QuestHandler(LoreConsumer.EMPTY)
         ));

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BannerHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BannerHandler.java
@@ -56,7 +56,7 @@ public class BannerHandler implements ItemMetaHandler<BannerMeta> {
             return null;
         }
         return "patterns:" + bannerMeta.getPatterns().stream()
-                .map(pattern -> pattern.getColor() + ":" + patternTypeName(pattern.getPattern()))
+                .map(pattern -> pattern.getColor() + ":" + pattern.getPattern().name())
                 .collect(Collectors.joining(","));
     }
 
@@ -66,7 +66,6 @@ public class BannerHandler implements ItemMetaHandler<BannerMeta> {
             throw new QuestException("Invalid banner key: " + key);
         }
         if (Existence.NONE_KEY.equalsIgnoreCase(data)) {
-            patterns = List.of();
             patternsE = Existence.FORBIDDEN;
             return;
         }
@@ -75,7 +74,7 @@ public class BannerHandler implements ItemMetaHandler<BannerMeta> {
         for (final String pattern : patternData) {
             parsedPatterns.add(parsePattern(pattern));
         }
-        patterns = List.copyOf(parsedPatterns);
+        patterns = parsedPatterns;
         patternsE = Existence.REQUIRED;
     }
 
@@ -92,20 +91,11 @@ public class BannerHandler implements ItemMetaHandler<BannerMeta> {
         }
         final PatternType type;
         try {
-            type = (PatternType) PatternType.class.getMethod("valueOf", String.class)
-                    .invoke(null, parts[1].toUpperCase(Locale.ROOT));
-        } catch (final ReflectiveOperationException | IllegalArgumentException e) {
+            type = PatternType.valueOf(parts[1].toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException e) {
             throw new QuestException("Unknown banner pattern type: " + parts[1], e);
         }
         return new Pattern(color, type);
-    }
-
-    private String patternTypeName(final PatternType type) {
-        try {
-            return (String) PatternType.class.getMethod("name").invoke(type);
-        } catch (final ReflectiveOperationException e) {
-            throw new IllegalStateException("Could not serialize banner pattern type", e);
-        }
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BannerHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BannerHandler.java
@@ -1,0 +1,124 @@
+package org.betonquest.betonquest.item.typehandler;
+
+import org.betonquest.betonquest.api.QuestException;
+import org.bukkit.DyeColor;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.inventory.meta.BannerMeta;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Handles de-/serialization of banner patterns.
+ */
+public class BannerHandler implements ItemMetaHandler<BannerMeta> {
+
+    /**
+     * The number of values that describe one pattern layer.
+     */
+    private static final int PATTERN_PARTS = 2;
+
+    /**
+     * The ordered banner patterns.
+     */
+    private List<Pattern> patterns = List.of();
+
+    /**
+     * The required pattern existence.
+     */
+    private Existence patternsE = Existence.WHATEVER;
+
+    /**
+     * The empty default constructor.
+     */
+    public BannerHandler() {
+    }
+
+    @Override
+    public Class<BannerMeta> metaClass() {
+        return BannerMeta.class;
+    }
+
+    @Override
+    public Set<String> keys() {
+        return Set.of("patterns");
+    }
+
+    @Override
+    @Nullable
+    public String serializeToString(final BannerMeta bannerMeta) {
+        if (bannerMeta.getPatterns().isEmpty()) {
+            return null;
+        }
+        return "patterns:" + bannerMeta.getPatterns().stream()
+                .map(pattern -> pattern.getColor() + ":" + patternTypeName(pattern.getPattern()))
+                .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public void set(final String key, final String data) throws QuestException {
+        if (!"patterns".equals(key)) {
+            throw new QuestException("Invalid banner key: " + key);
+        }
+        if (Existence.NONE_KEY.equalsIgnoreCase(data)) {
+            patterns = List.of();
+            patternsE = Existence.FORBIDDEN;
+            return;
+        }
+        final String[] patternData = HandlerUtil.getSplit(data, "Banner patterns are null!", ",");
+        final List<Pattern> parsedPatterns = new ArrayList<>(patternData.length);
+        for (final String pattern : patternData) {
+            parsedPatterns.add(parsePattern(pattern));
+        }
+        patterns = List.copyOf(parsedPatterns);
+        patternsE = Existence.REQUIRED;
+    }
+
+    private Pattern parsePattern(final String data) throws QuestException {
+        final String[] parts = HandlerUtil.getSplit(data, "Banner pattern is null!", ":");
+        if (parts.length != PATTERN_PARTS) {
+            throw new QuestException("Wrong banner pattern format: " + data);
+        }
+        final DyeColor color;
+        try {
+            color = DyeColor.valueOf(parts[0].toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException e) {
+            throw new QuestException("Unknown banner pattern color: " + parts[0], e);
+        }
+        final PatternType type;
+        try {
+            type = (PatternType) PatternType.class.getMethod("valueOf", String.class)
+                    .invoke(null, parts[1].toUpperCase(Locale.ROOT));
+        } catch (final ReflectiveOperationException | IllegalArgumentException e) {
+            throw new QuestException("Unknown banner pattern type: " + parts[1], e);
+        }
+        return new Pattern(color, type);
+    }
+
+    private String patternTypeName(final PatternType type) {
+        try {
+            return (String) PatternType.class.getMethod("name").invoke(type);
+        } catch (final ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not serialize banner pattern type", e);
+        }
+    }
+
+    @Override
+    public void populate(final BannerMeta bannerMeta) {
+        bannerMeta.setPatterns(patterns);
+    }
+
+    @Override
+    public boolean check(final BannerMeta bannerMeta) {
+        return switch (patternsE) {
+            case WHATEVER -> true;
+            case REQUIRED -> patterns.equals(bannerMeta.getPatterns());
+            case FORBIDDEN -> bannerMeta.getPatterns().isEmpty();
+        };
+    }
+}

--- a/code/mc_1_20_6/src/main/java/org/betonquest/betonquest/mc_1_20_6/item/UpdatedSimpleItemFactory.java
+++ b/code/mc_1_20_6/src/main/java/org/betonquest/betonquest/mc_1_20_6/item/UpdatedSimpleItemFactory.java
@@ -12,6 +12,7 @@ import org.betonquest.betonquest.api.text.TextParser;
 import org.betonquest.betonquest.item.LoreConsumer;
 import org.betonquest.betonquest.item.SimpleQuestItem;
 import org.betonquest.betonquest.item.SimpleQuestItemFactory;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.CustomModelDataHandler;
@@ -70,6 +71,7 @@ public class UpdatedSimpleItemFactory extends SimpleQuestItemFactory {
                 questHandler,
                 new EnchantmentsHandler(),
                 new UpdatedPotionHandler(),
+                new BannerHandler(),
                 new BookHandler(textParser, bookPageWrapper),
                 new HeadHandler(),
                 new ColorHandler(),

--- a/code/mc_1_20_6/src/main/java/org/betonquest/betonquest/mc_1_20_6/item/UpdatedSimpleQuestItemSerializer.java
+++ b/code/mc_1_20_6/src/main/java/org/betonquest/betonquest/mc_1_20_6/item/UpdatedSimpleQuestItemSerializer.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.text.TextParser;
 import org.betonquest.betonquest.item.LoreConsumer;
 import org.betonquest.betonquest.item.SimpleQuestItemFactory;
 import org.betonquest.betonquest.item.SimpleQuestItemSerializer;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.CustomModelDataHandler;
@@ -35,7 +36,7 @@ public class UpdatedSimpleQuestItemSerializer extends SimpleQuestItemSerializer 
     public UpdatedSimpleQuestItemSerializer(final TextParser textParser, final BookPageWrapper bookPageWrapper) {
         super(List.of(
                 new DurabilityHandler(), new UpdatedNameHandler(textParser), new LoreHandler(textParser, () -> false), new EnchantmentsHandler(),
-                new BookHandler(textParser, bookPageWrapper), new UpdatedPotionHandler(), new ColorHandler(), new HeadHandler(),
+                new BookHandler(textParser, bookPageWrapper), new UpdatedPotionHandler(), new BannerHandler(), new ColorHandler(), new HeadHandler(),
                 new FireworkHandler(), new UnbreakableHandler(), new CustomModelDataHandler(), new FlagHandler(),
                 new QuestHandler(LoreConsumer.EMPTY)
         ));

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/item/UpdatedSimpleItemFactory.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/item/UpdatedSimpleItemFactory.java
@@ -12,6 +12,7 @@ import org.betonquest.betonquest.api.text.TextParser;
 import org.betonquest.betonquest.item.LoreConsumer;
 import org.betonquest.betonquest.item.SimpleQuestItem;
 import org.betonquest.betonquest.item.SimpleQuestItemFactory;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.DurabilityHandler;
@@ -71,6 +72,7 @@ public class UpdatedSimpleItemFactory extends SimpleQuestItemFactory {
                 questHandler,
                 new EnchantmentsHandler(),
                 new UpdatedPotionHandler(),
+                new BannerHandler(),
                 new BookHandler(textParser, bookPageWrapper),
                 new HeadHandler(),
                 new ColorHandler(),

--- a/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/item/UpdatedSimpleQuestItemSerializer.java
+++ b/code/mc_1_21_4/src/main/java/org/betonquest/betonquest/mc_1_21_4/item/UpdatedSimpleQuestItemSerializer.java
@@ -5,6 +5,7 @@ import org.betonquest.betonquest.api.text.TextParser;
 import org.betonquest.betonquest.item.LoreConsumer;
 import org.betonquest.betonquest.item.SimpleQuestItemFactory;
 import org.betonquest.betonquest.item.SimpleQuestItemSerializer;
+import org.betonquest.betonquest.item.typehandler.BannerHandler;
 import org.betonquest.betonquest.item.typehandler.BookHandler;
 import org.betonquest.betonquest.item.typehandler.ColorHandler;
 import org.betonquest.betonquest.item.typehandler.DurabilityHandler;
@@ -36,7 +37,7 @@ public class UpdatedSimpleQuestItemSerializer extends SimpleQuestItemSerializer 
     public UpdatedSimpleQuestItemSerializer(final TextParser textParser, final BookPageWrapper bookPageWrapper) {
         super(List.of(
                 new DurabilityHandler(), new UpdatedNameHandler(textParser), new LoreHandler(textParser, () -> false), new EnchantmentsHandler(),
-                new BookHandler(textParser, bookPageWrapper), new UpdatedPotionHandler(), new ColorHandler(), new HeadHandler(),
+                new BookHandler(textParser, bookPageWrapper), new UpdatedPotionHandler(), new BannerHandler(), new ColorHandler(), new HeadHandler(),
                 new FireworkHandler(), new UnbreakableHandler(), new UpdatedCustomModelDataHandler(), new FlagHandler(),
                 new QuestHandler(LoreConsumer.EMPTY)
         ));

--- a/docs/Documentation/Advanced/Items.md
+++ b/docs/Documentation/Advanced/Items.md
@@ -263,6 +263,23 @@ color:#ff00ff
 color:none
 ```
 
+### Banners
+
+_This applies to banners._
+
+The banner's base color is selected through its material, for example `RED_BANNER`.
+
+- `patterns` - an ordered, comma-separated list of pattern layers. Each layer consists of a
+  [color](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html) and a
+  [pattern type](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/banner/PatternType.html), separated by a colon.
+  Layers are applied from left to right, starting at the bottom. Use `none` to require a banner without any patterns.
+
+```YAML title="Examples"
+items:
+  heraldicBanner: simple RED_BANNER patterns:yellow:cross,black:border
+  plainBanner: simple WHITE_BANNER patterns:none
+```
+
 ### Fireworks
 
 _This applies to fireworks._


### PR DESCRIPTION
Adds support for ordered pattern layers on `simple` banner items.

- parses and serializes `patterns:<color>:<pattern>[,...]`
- supports `patterns:none` for matching banners without pattern layers
- registers the handler in the core, 1.20.6, and 1.21.4 factories and serializers
- reuses the core handler across supported Minecraft versions; Paper runtime compatibility rewriting handles the `PatternType` enum-to-interface transition
- documents the syntax and adds the required changelog entry

### Testing

- `./mvnw verify`
- parse/populate/check/serialize runtime smoke tests against Paper API 1.18.2 and 1.20.6

---

### Related Issues

Closes #4213

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!