### PR TITLE
Use different method to add pages to books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Deprecated
 ### Removed
 ### Fixed
-- `freeze` action and `packetevents` conversation io on MC 26.2+
+- `freeze` action and `packetevents` conversation io as well as `Journal` and `simple` books on MC 26.2+
 - NPE in PacketEvents Interceptor when resending messages to offline players
 - `mmoskill` objective trigger are not parsed correctly
 - error handling for items when the amount is less than 1

--- a/code/core/src/main/java/org/betonquest/betonquest/feature/journal/Journal.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/feature/journal/Journal.java
@@ -212,7 +212,7 @@ public class Journal {
         pointers.add(pointer);
         final String date = betonQuest.isMySQLUsed()
                 ? DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT)
-                  .format(Instant.ofEpochMilli(pointer.timestamp()).atZone(ZoneId.systemDefault()))
+                .format(Instant.ofEpochMilli(pointer.timestamp()).atZone(ZoneId.systemDefault()))
                 : Long.toString(pointer.timestamp());
         betonQuest.getSaver().add(new Record(UpdateType.ADD_JOURNAL, profile.getProfileUUID().toString(),
                 pointer.pointer().getFull(), date));
@@ -230,7 +230,7 @@ public class Journal {
                 new PlayerJournalDeleteEvent(profile, !betonQuest.getServer().isPrimaryThread(), this, pointer).callEvent();
                 final String date = betonQuest.isMySQLUsed()
                         ? DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT)
-                          .format(Instant.ofEpochMilli(pointer.timestamp()).atZone(ZoneId.systemDefault()))
+                        .format(Instant.ofEpochMilli(pointer.timestamp()).atZone(ZoneId.systemDefault()))
                         : Long.toString(pointer.timestamp());
                 betonQuest.getSaver().add(new Record(UpdateType.REMOVE_JOURNAL, profile.getProfileUUID().toString(),
                         pointer.pointer().getFull(), date));
@@ -442,9 +442,9 @@ public class Journal {
             finalList.addAll(bookWrapper.splitPages(stringBuilder.asComponent()));
         }
         if (finalList.isEmpty()) {
-            meta.pages(Component.empty());
+            meta.addPages(Component.empty());
         } else {
-            meta.pages(finalList);
+            meta.addPages(finalList.toArray(new Component[0]));
         }
         item.setItemMeta(meta);
         return item;

--- a/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BookHandler.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/item/typehandler/BookHandler.java
@@ -129,7 +129,7 @@ public class BookHandler implements ItemMetaHandler<BookMeta> {
 
     @Override
     public void populate(final BookMeta bookMeta) {
-        bookMeta.title(title).author(author).pages(text);
+        bookMeta.title(title).author(author).addPages(text.toArray(new Component[0]));
     }
 
     @Override


### PR DESCRIPTION
<!-- Please describe your changes here. -->
because the BookMeta no longer has the pages method which returns an adventure Book but rather itself.

I actually made a fix #PaperMC/Paper#14081 but it is not merged until today and with the new 26.3 dev cycle it looks like it won't so fast. Since we made other 26.2 fixes in this release I will now just add this here too.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
