### PR TITLE
Add `count` flag to section placeholder for element counting

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/section/SectionPlaceholder.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/section/SectionPlaceholder.java
@@ -50,24 +50,31 @@ public class SectionPlaceholder implements NullablePlaceholder {
     private final FlagArgument<Boolean> shuffle;
 
     /**
+     * Whether the number of elements in the section should be counted instead of listed.
+     */
+    private final FlagArgument<Boolean> count;
+
+    /**
      * Create a new section placeholder.
      *
      * @param questPackage  the quest package to be relative to
      * @param section       the parent section to select from, e.g., actions, conditions, etc
-     * @param identifier    the identifier in the section to select subsection from
+     * @param identifier    the identifier in the section to select subsections from
      * @param selectionMode how the elements in the section should be selected
      * @param limit         the limit for how many elements in the section should be selected at max
      * @param shuffle       whether the elements should be shuffled after selection
+     * @param count         whether the number of elements in the section should be counted instead of listed
      */
     public SectionPlaceholder(final QuestPackage questPackage, final Argument<String> section, final Argument<String> identifier,
                               final Argument<SectionSelectionMode> selectionMode, final Argument<Number> limit,
-                              final FlagArgument<Boolean> shuffle) {
+                              final FlagArgument<Boolean> shuffle, final FlagArgument<Boolean> count) {
         this.questPackage = questPackage;
         this.section = section;
         this.identifier = identifier;
         this.selectionMode = selectionMode;
         this.limit = limit;
         this.shuffle = shuffle;
+        this.count = count;
     }
 
     @Override
@@ -86,6 +93,10 @@ public class SectionPlaceholder implements NullablePlaceholder {
         }
         final List<String> keys = new ArrayList<>(configSection.getKeys(true));
         keys.removeIf(configSection::isConfigurationSection);
+
+        if (count.getValue(profile).orElse(false)) {
+            return String.valueOf(Math.min(keys.size(), limit));
+        }
 
         if (mode == SectionSelectionMode.LAST) {
             Collections.reverse(keys);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/section/SectionPlaceholderFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/section/SectionPlaceholderFactory.java
@@ -38,6 +38,7 @@ public class SectionPlaceholderFactory implements PlayerPlaceholderFactory, Play
                 .get("select", SectionSelectionMode.FIRST);
         final Argument<Number> limit = instruction.number().get("limit", Integer.MAX_VALUE);
         final FlagArgument<Boolean> shuffle = instruction.bool().getFlag("shuffle", true);
-        return new NullablePlaceholderAdapter(new SectionPlaceholder(instruction.getPackage(), section, identifier, selectionMode, limit, shuffle));
+        final FlagArgument<Boolean> count = instruction.bool().getFlag("count", true);
+        return new NullablePlaceholderAdapter(new SectionPlaceholder(instruction.getPackage(), section, identifier, selectionMode, limit, shuffle, count));
     }
 }

--- a/docs/Documentation/Reference/Placeholders-List.md
+++ b/docs/Documentation/Reference/Placeholders-List.md
@@ -325,6 +325,7 @@ __Description__: Represents a section as a list of all its elements as identifie
 | select<br>[SectionMode] | Optional<br>[first]   | Decides how subsections will be selected to list them. `last` starts with the last element and `random` selects them randomly. |
 | limit<br>[Number]       | Optional<br>[NoLimit] | How many elements should be selected at max. Don't use it if you want to have all elements.                                    |
 | shuffle<br>[Boolean]    | Flag<br>[false, true] | If the resulting list of elements should be shuffled. This won't be necessary if `select:random` is set.                       |
+| count<br>[Boolean]      | Flag<br>[false, true] | If the result should be counted and represented as number instead. Will ignore `shuffle` and `select` if set to `true`.        |
 
 *[SectionMode]: first, last, random
 *[NoLimit]: Internally the maximum value for an integer is used, so there effectively is no limit.


### PR DESCRIPTION
Add `count` flag to section placeholder for element counting
* Introduced a new `count` flag to SectionPlaceholder to return the number of elements in the section instead of listing them
* Updated related documentation and factory logic

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
