### PR TITLE
No longer show square brackets for `mythic` item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Skript Condition and Effect now handle if no player is present and check like they are independent
 - `deleffect` action no longer accepts an omitted first argument as `any`
 - `chestgive` action no longer drops excess items without newly added `dropExcess` flag
+- `mythic` item no longer shows square brackets
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/item/MythicItemWrapper.java
+++ b/code/compatibility/src/main/java/org/betonquest/betonquest/compatibility/mythicmobs/item/MythicItemWrapper.java
@@ -57,7 +57,7 @@ public record MythicItemWrapper(ItemManager itemManager, Argument<String> itemNa
 
         @Override
         public Component getName() {
-            return stack.displayName();
+            return Objects.requireNonNullElseGet(stack.getItemMeta().displayName(), () -> Component.translatable(stack));
         }
 
         @Override


### PR DESCRIPTION
<!-- Please describe your changes here. -->
use meta name to avoid square brackets for MythicItem even when loosing stuff like Potion names

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
