### PR TITLE
Prevent `itemdurability` action from setting negative durability values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `null` item in `simple` item is now treated as equal to air
 - MobKillNotifier that handles neutral mob kills for example with skills now work probably when called async
 - item implementations `magic` and `mmoitem` ignoring the given amount for item stacks
+- `itemdurability` action throws exception when the new durability is negative
 ### Security
 
 ## [3.1.0] - 2026-07-19

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/item/ItemDurabilityAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/item/ItemDurabilityAction.java
@@ -118,7 +118,7 @@ public class ItemDurabilityAction implements OnlineAction {
         }
 
         final int actualNewDamage = oldDamage + durabilityModifiedDamage;
-        damageable.setDamage(actualNewDamage);
+        damageable.setDamage(Math.max(0, actualNewDamage));
 
         if (maxDurability - actualNewDamage <= 0) {
             processBreak(profile, player, itemStack, damageable);


### PR DESCRIPTION
<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes https://faststats.dev/project/betonquest/errors/022f6f5d77beea86566875e8fa2b9a578095c49c88017a5db4f850bc3adb373a

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
