### PR TITLE
Add `bypassInterceptor` flag to `chat` io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `drop` objective to track players dropping items
 ### Changed
 - `lore` of `item` placeholder can now be used without number to get all lines
+- `chat` notify io now only sends messages during a conversation if `bypassInterceptor` is set to `true`
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/core/src/main/java/org/betonquest/betonquest/notify/io/ChatNotifyIO.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/notify/io/ChatNotifyIO.java
@@ -3,6 +3,7 @@ package org.betonquest.betonquest.notify.io;
 import net.kyori.adventure.text.Component;
 import org.betonquest.betonquest.api.QuestException;
 import org.betonquest.betonquest.api.config.quest.QuestPackage;
+import org.betonquest.betonquest.api.instruction.argument.parser.BooleanParser;
 import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.service.conversation.Conversations;
 import org.betonquest.betonquest.api.service.placeholder.PlaceholderManager;
@@ -22,6 +23,11 @@ public class ChatNotifyIO extends NotifyIO {
     private final Conversations conversations;
 
     /**
+     * If the conversation interceptor should be bypassed and messages directly displayed in the conversation.
+     */
+    private final boolean bypassInterceptor;
+
+    /**
      * Create a new Chat Notify IO.
      *
      * @param placeholders  the {@link PlaceholderManager} to create and resolve placeholders
@@ -32,11 +38,17 @@ public class ChatNotifyIO extends NotifyIO {
      */
     public ChatNotifyIO(final PlaceholderManager placeholders, @Nullable final QuestPackage pack, final Map<String, String> data, final Conversations conversations) throws QuestException {
         super(placeholders, pack, data);
+        final String raw = data.get("bypassinterceptor");
+        this.bypassInterceptor = raw != null && new BooleanParser().apply(raw);
         this.conversations = conversations;
     }
 
     @Override
     protected void notifyPlayer(final Component message, final OnlineProfile onlineProfile) {
-        conversations.sendBypassMessage(onlineProfile, message);
+        if (bypassInterceptor) {
+            conversations.sendBypassMessage(onlineProfile, message);
+        } else {
+            onlineProfile.getPlayer().sendMessage(message);
+        }
     }
 }

--- a/docs/Documentation/Advanced/Notification-IO's-&-Categories.md
+++ b/docs/Documentation/Advanced/Notification-IO's-&-Categories.md
@@ -41,9 +41,10 @@ Writes the notification in the player's chat.
 ??? info "Preview"
     ![chat image](../../_media/content/Documentation/Notifications/chat.png)
 
-| Option          | Description                            |
-|-----------------|----------------------------------------|
-| [Sound](#sound) | Any option from the [SoundIO](#sound). |
+| Option            | Description                                                                                  |
+|-------------------|----------------------------------------------------------------------------------------------|
+| [Sound](#sound)   | Any option from the [SoundIO](#sound).                                                       |
+| bypassInterceptor | If the messages should ignore any set interceptor and be sent into the running conversation. |
 
 ### Advancement
 Shows the notification using an achievement popup.


### PR DESCRIPTION
<!-- Please describe your changes here. -->
and change the default to send messages during conversations to `false`. That is the more common use case and thus disabling that is not useful here, even when it breaks existing behavior.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
