### PR TITLE
Refactor PlayerDataStorage to have one `get` method handle all online offline cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
 - JobsReborn integration missed some null checks resulting in not working actions and conditions
+- concurrency issue when loading player data on join causing multiple profiles to get created with a database exception
 ### Security
 
 ## [3.2.0] - 2026-08-17

--- a/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultObjectiveService.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/api/quest/objective/service/DefaultObjectiveService.java
@@ -164,9 +164,8 @@ public class DefaultObjectiveService implements ObjectiveService {
         saver.add(new Saver.Record(UpdateType.ADD_OBJECTIVES, profile.getProfileUUID().toString(), objectiveID.getFull(), freshData));
         final QuestDataUpdateEvent event = new QuestDataUpdateEvent(profile, objectiveID, freshData);
         plugin.getServer().getScheduler().runTask(plugin, event::callEvent);
-        if (profile.getOnlineProfile().isPresent()) {
-            plugin.getPlayerDataStorage().get(profile).getJournal().update();
-        }
+        profile.getOnlineProfile()
+                .ifPresent(onlineProfile -> plugin.getPlayerDataStorage().get(onlineProfile).getJournal().update());
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/command/QuestCommand.java
@@ -45,7 +45,6 @@ import org.betonquest.betonquest.database.Backup;
 import org.betonquest.betonquest.database.Connector;
 import org.betonquest.betonquest.database.GlobalData;
 import org.betonquest.betonquest.database.PlayerData;
-import org.betonquest.betonquest.database.PlayerDataFactory;
 import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.database.Saver.Record;
 import org.betonquest.betonquest.database.UpdateType;
@@ -132,11 +131,6 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
      * Provider for Player Profiles.
      */
     private final ProfileProvider profileProvider;
-
-    /**
-     * Factory to create new Player Data.
-     */
-    private final PlayerDataFactory playerDataFactory;
 
     /**
      * The {@link Localizations} instance.
@@ -247,7 +241,6 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         this.configAccessorFactory = constructorParams.configAccessorFactory();
         this.logWatcher = constructorParams.playerLogWatcher();
         this.debuggingController = constructorParams.logPublishingController();
-        this.playerDataFactory = constructorParams.playerDataFactory();
         this.playerDataStorage = constructorParams.playerDataStorage();
         this.profileProvider = constructorParams.profileProvider();
         this.localizations = constructorParams.localizations();
@@ -588,11 +581,10 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         if (profile == null) {
             return null;
         }
-        if (profile.getOnlineProfile().isPresent()) {
-            return playerDataStorage.get(profile);
+        if (profile.getOnlineProfile().isEmpty()) {
+            log.debug("Profile is offline, loading his data");
         }
-        log.debug("Profile is offline, loading his data");
-        return playerDataFactory.createPlayerData(profile);
+        return playerDataStorage.get(profile);
     }
 
     /**
@@ -1145,13 +1137,10 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
             return;
         }
         final boolean isOnline = profile.getOnlineProfile().isPresent();
-        final PlayerData playerData;
-        if (isOnline) {
-            playerData = playerDataStorage.get(profile);
-        } else {
+        if (!isOnline) {
             log.debug("Profile is offline, loading his data");
-            playerData = playerDataFactory.createPlayerData(profile);
         }
+        final PlayerData playerData = playerDataStorage.get(profile);
         // if there are no arguments then list player's objectives
         if (args.length < 3 || "list".equalsIgnoreCase(args[2]) || "l".equalsIgnoreCase(args[2])) {
             // display objectives
@@ -1857,7 +1846,7 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
         if (isOnline) {
             data = null;
         } else {
-            final PlayerData offline = playerDataStorage.getOffline(profile);
+            final PlayerData offline = playerDataStorage.get(profile);
             final String instruction = offline.getRawObjectives().get(variableObjective.getObjectiveID().getFull());
             if (instruction == null) {
                 log.debug("There is no data for that objective for that player!");
@@ -2075,7 +2064,6 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
      *
      * @param loggerFactory           the logger factory
      * @param configAccessorFactory   the config accessor factory
-     * @param playerDataFactory       the player data factory
      * @param playerDataStorage       the player data storage
      * @param profileProvider         the profile provider
      * @param localizations           the Localizations
@@ -2098,12 +2086,11 @@ public class QuestCommand implements CommandExecutor, SimpleTabCompleter {
      * @param reloader                the plugin reloading runnable
      */
     public record ConstructorParams(BetonQuestLoggerFactory loggerFactory, ConfigAccessorFactory configAccessorFactory,
-                                    PlayerDataFactory playerDataFactory, PlayerDataStorage playerDataStorage,
-                                    ProfileProvider profileProvider, Localizations localizations, Updater updater,
-                                    Compatibility compatibility, Connector connector, Saver saver,
-                                    QuestPackageManager questPackageManager, ConfigAccessor configAccessor,
-                                    LogPublishingController logPublishingController, PlayerLogWatcher playerLogWatcher,
-                                    Identifiers identifiers, GlobalData globalData,
+                                    PlayerDataStorage playerDataStorage, ProfileProvider profileProvider,
+                                    Localizations localizations, Updater updater, Compatibility compatibility,
+                                    Connector connector, Saver saver, QuestPackageManager questPackageManager,
+                                    ConfigAccessor configAccessor, LogPublishingController logPublishingController,
+                                    PlayerLogWatcher playerLogWatcher, Identifiers identifiers, GlobalData globalData,
                                     JournalEntryProcessor journalEntryProcessor,
                                     ItemTypeRegistry itemTypeRegistry, ActionManager actionManager,
                                     ConditionManager conditionManager,

--- a/code/core/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/data/PlayerDataStorage.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 
 /**
  * Stores loaded {@link PlayerData}.
@@ -48,7 +50,7 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
     /**
      * Stored player data for online players.
      */
-    private final Map<Profile, PlayerData> playerDataMap;
+    private final Map<Profile, FutureTask<PlayerData>> playerDataMap;
 
     /**
      * Create a new Storage for Player Data.
@@ -77,7 +79,7 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
      */
     public void initProfiles(final Collection<OnlineProfile> onlineProfiles, final Conversations conversations) {
         for (final OnlineProfile onlineProfile : onlineProfiles) {
-            final PlayerData playerData = init(onlineProfile);
+            final PlayerData playerData = get(onlineProfile);
             playerData.startObjectives();
             playerData.getJournal().update();
             if (playerData.getActiveConversation() != null) {
@@ -87,16 +89,7 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
     }
 
     /**
-     * Start the objectives for all stored player data.
-     */
-    public void startObjectives() {
-        for (final PlayerData playerData : playerDataMap.values()) {
-            playerData.startObjectives();
-        }
-    }
-
-    /**
-     * Start auto-once objectives and update journals.
+     * Start objectives, auto-once objectives and update journals.
      *
      * @param onlineProfiles the profiles to update
      */
@@ -110,74 +103,48 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
     }
 
     /**
-     * Creates new PlayerData and {@link #put(Profile, PlayerData) puts} it into this storage.
+     * Creates new PlayerData and stores it.
      *
      * @param profile the {@link Profile} of the player
      * @return the created PlayerData
      */
     public PlayerData init(final Profile profile) {
-        log.debug("Creating new data for " + profile);
-        final PlayerData playerData = playerDataFactory.createPlayerData(profile);
-        put(profile, playerData);
-        return playerData;
+        final FutureTask<PlayerData> playerDataFutureTask = playerDataMap.compute(profile, (key, task) -> {
+            if (task == null || task.isDone()) {
+                final FutureTask<PlayerData> newTask = new FutureTask<>(() -> playerDataFactory.createPlayerData(key));
+                newTask.run();
+                return newTask;
+            }
+            return task;
+        });
+        return saveGet(playerDataFutureTask);
     }
 
     /**
-     * Stores the PlayerData in a map, so it can be retrieved using
-     * {@link #get(Profile profile)}.
-     *
-     * @param profile    the {@link Profile} of the player
-     * @param playerData PlayerData object to store
-     */
-    public void put(final Profile profile, final PlayerData playerData) {
-        log.debug("Inserting data for " + profile);
-        playerDataMap.put(profile, playerData);
-    }
-
-    /**
-     * Retrieves PlayerData object for specified profile. If the playerData does
-     * not exist it will create new playerData and store it.
-     *
-     * @param profile the {@link OnlineProfile} of the player
-     * @return PlayerData object for the player
-     */
-    public PlayerData get(final OnlineProfile profile) {
-        return get((Profile) profile);
-    }
-
-    /**
-     * Retrieves PlayerData object for specified profile. If the playerData does
-     * not exist but the profile is online, it will create new playerData and store it.
+     * Retrieves PlayerData object for the specified profile. If the playerData does
+     * not exist, it will create a new playerData.
+     * If the player is online, it will be stored as well.
      *
      * @param profile the {@link Profile} of the player
      * @return PlayerData object for the player
-     * @throws IllegalArgumentException when there is no data and the player is offline
      */
     public PlayerData get(final Profile profile) {
-        PlayerData playerData = playerDataMap.get(profile);
-        if (playerData == null) {
-            if (profile.getOnlineProfile().isPresent()) {
-                playerData = init(profile);
-            } else {
-                throw new IllegalArgumentException("The profile has no online player!");
-            }
+        final FutureTask<PlayerData> playerData = playerDataMap.get(profile);
+        if (playerData != null) {
+            return saveGet(playerData);
         }
-        return playerData;
-    }
-
-    /**
-     * Retrieves PlayerData object for specified profile. If the playerData does
-     * not exist it will create new playerData but won't store it.
-     *
-     * @param profile the {@link Profile} of the player
-     * @return PlayerData object for the player
-     * @throws IllegalArgumentException when there is no data and the player is offline
-     */
-    public PlayerData getOffline(final Profile profile) {
         if (profile.getOnlineProfile().isPresent()) {
-            return get(profile);
+            return init(profile);
         }
         return playerDataFactory.createPlayerData(profile);
+    }
+
+    private PlayerData saveGet(final FutureTask<PlayerData> playerData) {
+        try {
+            return playerData.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException("Failed to load profile data!", e);
+        }
     }
 
     /**
@@ -193,9 +160,25 @@ public class PlayerDataStorage implements FastStatsMetricsProvider {
     public Set<Metric<?>> getMetrics() {
         return Set.of(
                 Metric.number("profiles_personal_lang_count", () -> playerDataMap.values().stream()
+                        .map(future -> {
+                            try {
+                                return future.get();
+                            } catch (InterruptedException | ExecutionException e) {
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
                         .filter(data -> data.getLanguage().isPresent()
                                 && !"default".equalsIgnoreCase(data.getLanguage().get())).count()),
                 Metric.stringArray("profiles_personal_lang", () -> playerDataMap.values().stream()
+                        .map(future -> {
+                            try {
+                                return future.get();
+                            } catch (InterruptedException | ExecutionException e) {
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
                         .map(data -> data.getLanguage().orElse(null)).filter(Objects::nonNull)
                         .filter(lang -> !"default".equalsIgnoreCase(lang))
                         .toList().toArray(new String[0]))

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/CommandsComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/CommandsComponent.java
@@ -25,7 +25,6 @@ import org.betonquest.betonquest.compatibility.Compatibility;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.Connector;
 import org.betonquest.betonquest.database.GlobalData;
-import org.betonquest.betonquest.database.PlayerDataFactory;
 import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.feature.BackpackFactory;
 import org.betonquest.betonquest.kernel.processor.feature.CancelerProcessor;
@@ -57,10 +56,9 @@ public class CommandsComponent extends AbstractCoreComponent {
     @Override
     public Set<Class<?>> requires() {
         return Set.of(JavaPlugin.class, BetonQuestLoggerFactory.class, ConfigAccessorFactory.class,
-                ProfileProvider.class, PlayerDataFactory.class, PlayerDataStorage.class,
-                GlobalData.class, ConfigAccessor.class, Localizations.class, Updater.class,
-                Compatibility.class, QuestPackageManager.class, Connector.class, Saver.class,
-                ItemTypeRegistry.class, JournalEntryProcessor.class, CompassManager.class,
+                ProfileProvider.class, PlayerDataStorage.class, GlobalData.class, ConfigAccessor.class,
+                Localizations.class, Updater.class, Compatibility.class, QuestPackageManager.class, Connector.class,
+                Saver.class, ItemTypeRegistry.class, JournalEntryProcessor.class, CompassManager.class,
                 CancelerProcessor.class, Identifiers.class, ItemManager.class, ActionManager.class,
                 ConditionManager.class, ObjectiveManager.class, LanguageProvider.class,
                 AccumulatingReceiverSelector.class, HistoryHandler.class, Reloader.class);
@@ -72,7 +70,6 @@ public class CommandsComponent extends AbstractCoreComponent {
         final BetonQuestLoggerFactory loggerFactory = getDependency(BetonQuestLoggerFactory.class);
         final ConfigAccessorFactory configAccessorFactory = getDependency(ConfigAccessorFactory.class);
         final ProfileProvider profileProvider = getDependency(ProfileProvider.class);
-        final PlayerDataFactory playerDataFactory = getDependency(PlayerDataFactory.class);
         final GlobalData globalData = getDependency(GlobalData.class);
         final ConfigAccessor config = getDependency(ConfigAccessor.class);
         final PlayerDataStorage playerDataStorage = getDependency(PlayerDataStorage.class);
@@ -98,7 +95,7 @@ public class CommandsComponent extends AbstractCoreComponent {
 
         final PlayerLogWatcher playerLogWatcher = new PlayerLogWatcher(receiverSelector);
         final QuestCommand.ConstructorParams questCommandParams = new QuestCommand.ConstructorParams(loggerFactory,
-                configAccessorFactory, playerDataFactory, playerDataStorage, profileProvider, localizations, updater,
+                configAccessorFactory, playerDataStorage, profileProvider, localizations, updater,
                 compatibility, connector, saver, questPackageManager, config, debugHistoryHandler,
                 playerLogWatcher, identifiers, globalData, journalEntryProcessor,
                 itemRegistry, actionManager, conditionManager, objectiveManager, itemManager, reloader);

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PersistenceComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PersistenceComponent.java
@@ -59,7 +59,7 @@ public class PersistenceComponent extends AbstractCoreComponent {
         @Override
         @SuppressWarnings("PMD.ShortMethodName")
         public PersistentDataHolder of(final Profile profile) {
-            return playerDataStorage.getOffline(profile);
+            return playerDataStorage.get(profile);
         }
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PlayerDataStorageComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PlayerDataStorageComponent.java
@@ -67,7 +67,6 @@ public class PlayerDataStorageComponent extends AbstractCoreComponent {
         dependencyProvider.take(PlayerDataFactory.class, playerDataFactory);
         dependencyProvider.take(PlayerDataStorage.class, playerDataStorage);
         reloader.register(ReloadPhase.PROFILES, () -> {
-            playerDataStorage.startObjectives();
             playerDataStorage.reloadProfiles(profileProvider.getOnlineProfiles());
         });
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PostEnableComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/PostEnableComponent.java
@@ -60,7 +60,6 @@ public class PostEnableComponent extends AbstractCoreComponent {
             integrationManager.postEnable(betonQuestApiService);
             compatibility.logAndInitHologramProvider();
             processorDataLoader.loadData(packageManager.getPackages().values());
-            dataStorage.startObjectives();
             menu.syncCommands();
             dataStorage.initProfiles(profileProvider.getOnlineProfiles(), conversations);
             playerHider.load(packageManager, instructions);

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ActionTypesComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/types/ActionTypesComponent.java
@@ -17,7 +17,6 @@ import org.betonquest.betonquest.api.service.objective.ObjectiveManager;
 import org.betonquest.betonquest.api.text.TextParser;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.GlobalData;
-import org.betonquest.betonquest.database.PlayerDataFactory;
 import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.kernel.processor.feature.CancelerProcessor;
 import org.betonquest.betonquest.kernel.registry.quest.ActionTypeRegistry;
@@ -110,19 +109,17 @@ public class ActionTypesComponent extends AbstractCoreComponent {
     @Override
     public Set<Class<?>> requires() {
         return Set.of(Plugin.class, PluginManager.class, Server.class, BukkitScheduler.class,
-                BetonQuestLoggerFactory.class, ProfileProvider.class, PlayerDataFactory.class,
-                PlayerDataStorage.class, GlobalData.class, Localizations.class, LanguageProvider.class,
-                Saver.class, TextParser.class, Instructions.class, Persistence.class,
-                ActionTypeRegistry.class, Conversations.class, ActionManager.class, ConditionManager.class,
-                ObjectiveManager.class, NpcManager.class, CompassManager.class, CancelerProcessor.class,
-                DefaultNpcHider.class, PlayerHider.class);
+                BetonQuestLoggerFactory.class, ProfileProvider.class, PlayerDataStorage.class, GlobalData.class,
+                Localizations.class, LanguageProvider.class, Saver.class, TextParser.class, Instructions.class,
+                Persistence.class, ActionTypeRegistry.class, Conversations.class, ActionManager.class,
+                ConditionManager.class, ObjectiveManager.class, NpcManager.class, CompassManager.class,
+                CancelerProcessor.class, DefaultNpcHider.class, PlayerHider.class);
     }
 
     @Override
     protected void load(final DependencyProvider dependencyProvider) {
         final BetonQuestLoggerFactory loggerFactory = getDependency(BetonQuestLoggerFactory.class);
         final ProfileProvider profileProvider = getDependency(ProfileProvider.class);
-        final PlayerDataFactory playerDataFactory = getDependency(PlayerDataFactory.class);
         final GlobalData globalData = getDependency(GlobalData.class);
         final PlayerDataStorage playerDataStorage = getDependency(PlayerDataStorage.class);
         final Persistence persistence = getDependency(Persistence.class);
@@ -189,7 +186,7 @@ public class ActionTypesComponent extends AbstractCoreComponent {
         actionTypes.registerCombined("notifyall", new NotifyAllActionFactory(textParser, playerDataStorage, profileProvider, languageProvider));
         actionTypes.registerCombined("npcteleport", new NpcTeleportActionFactory(npcManager));
         actionTypes.registerCombined("objective", new ObjectiveActionFactory(plugin, loggerFactory, profileProvider, saver,
-                objectiveManager, playerDataStorage, playerDataFactory));
+                objectiveManager, playerDataStorage));
         actionTypes.register("opsudo", new OpSudoActionFactory(server));
         actionTypes.register("party", new PartyActionFactory(profileProvider, actionManager, conditionManager));
         actionTypes.registerCombined("pickrandom", new PickRandomActionFactory(actionManager));

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ObjectiveProcessor.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/processor/quest/ObjectiveProcessor.java
@@ -9,6 +9,7 @@ import org.betonquest.betonquest.api.identifier.ObjectiveIdentifier;
 import org.betonquest.betonquest.api.instruction.Instruction;
 import org.betonquest.betonquest.api.instruction.argument.parser.PackageIdentifierParser;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
 import org.betonquest.betonquest.api.profile.Profile;
 import org.betonquest.betonquest.api.quest.objective.Objective;
 import org.betonquest.betonquest.api.quest.objective.ObjectiveFactory;
@@ -322,8 +323,9 @@ public class ObjectiveProcessor extends QuestProcessor<ObjectiveIdentifier, Obje
      * @param profile     the {@link Profile} of the player
      * @param dataStorage the storage providing player data
      */
-    public void startAll(final Profile profile, final PlayerDataStorage dataStorage) {
+    public void startAll(final OnlineProfile profile, final PlayerDataStorage dataStorage) {
         final PlayerData data = dataStorage.get(profile);
+        data.startObjectives();
         final TagHolder tagHolder = data.tags();
         for (final ObjectiveIdentifier id : autoOnceObjectiveIds) {
             final Objective objective = values.get(id);

--- a/code/core/src/main/java/org/betonquest/betonquest/listener/JoinQuitListener.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/listener/JoinQuitListener.java
@@ -104,7 +104,6 @@ public class JoinQuitListener implements Listener {
         final Player player = event.getPlayer();
         final OnlineProfile onlineProfile = profileProvider.getProfile(player);
         final PlayerData playerData = playerDataStorage.get(onlineProfile);
-        playerData.startObjectives();
         questTypeApi.startAll(onlineProfile, playerDataStorage);
         checkResourcepack(player, onlineProfile);
 

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/journal/DeleteJournalPlayerlessAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/journal/DeleteJournalPlayerlessAction.java
@@ -57,7 +57,7 @@ public class DeleteJournalPlayerlessAction implements PlayerlessAction {
     public void execute() throws QuestException {
         final JournalEntryIdentifier resolved = this.entryID.getValue(null);
         for (final OnlineProfile profile : profileProvider.getOnlineProfiles()) {
-            final PlayerData playerData = dataStorage.getOffline(profile);
+            final PlayerData playerData = dataStorage.get(profile);
             final Journal journal = playerData.getJournal();
             journal.removePointer(resolved);
             journal.update();

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/journal/JournalAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/journal/JournalAction.java
@@ -43,7 +43,7 @@ public class JournalAction implements PlayerAction {
 
     @Override
     public void execute(final Profile profile) throws QuestException {
-        final PlayerData playerData = dataStorage.getOffline(profile);
+        final PlayerData playerData = dataStorage.get(profile);
         final Journal journal = playerData.getJournal();
         journalChanger.changeJournal(journal, profile);
         journal.update();

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/language/LanguageAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/language/LanguageAction.java
@@ -35,6 +35,6 @@ public class LanguageAction implements PlayerAction {
     @Override
     public void execute(final Profile profile) throws QuestException {
         final String lang = language.getValue(profile);
-        dataStorage.getOffline(profile).setLanguage("default".equalsIgnoreCase(lang) ? null : lang);
+        dataStorage.get(profile).setLanguage("default".equalsIgnoreCase(lang) ? null : lang);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/objective/ObjectiveAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/objective/ObjectiveAction.java
@@ -12,7 +12,6 @@ import org.betonquest.betonquest.api.quest.objective.Objective;
 import org.betonquest.betonquest.api.service.objective.ObjectiveManager;
 import org.betonquest.betonquest.data.PlayerDataStorage;
 import org.betonquest.betonquest.database.PlayerData;
-import org.betonquest.betonquest.database.PlayerDataFactory;
 import org.betonquest.betonquest.database.Saver;
 import org.betonquest.betonquest.database.UpdateType;
 import org.bukkit.Bukkit;
@@ -69,11 +68,6 @@ public class ObjectiveAction implements NullableAction {
     private final Argument<List<ObjectiveIdentifier>> objectives;
 
     /**
-     * Factory to create new Player Data.
-     */
-    private final PlayerDataFactory playerDataFactory;
-
-    /**
      * The action to do with the objectives.
      */
     private final String action;
@@ -89,15 +83,13 @@ public class ObjectiveAction implements NullableAction {
      * @param playerDataStorage the player data storage
      * @param questPackage      the quest package of the instruction
      * @param objectives        the objectives to affect
-     * @param playerDataFactory the factory to create player data
      * @param action            the action to do with the objectives
      * @throws QuestException if the action is invalid
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     public ObjectiveAction(final Plugin plugin, final BetonQuestLogger log, final ProfileProvider profileProvider, final Saver saver,
                            final ObjectiveManager objectiveManager, final PlayerDataStorage playerDataStorage,
                            final QuestPackage questPackage, final Argument<List<ObjectiveIdentifier>> objectives,
-                           final PlayerDataFactory playerDataFactory, final String action) throws QuestException {
+                           final String action) throws QuestException {
         this.plugin = plugin;
         this.profileProvider = profileProvider;
         this.saver = saver;
@@ -106,7 +98,6 @@ public class ObjectiveAction implements NullableAction {
         this.playerDataStorage = playerDataStorage;
         this.questPackage = questPackage;
         this.objectives = objectives;
-        this.playerDataFactory = playerDataFactory;
         if (!Arrays.asList("start", "add", "delete", "remove", "complete", "finish").contains(action)) {
             throw new QuestException("Invalid action: " + action);
         }
@@ -147,7 +138,7 @@ public class ObjectiveAction implements NullableAction {
 
     private void handleForOfflinePlayer(final Profile profile, final ObjectiveIdentifier objectiveID) {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            final PlayerData playerData = playerDataFactory.createPlayerData(profile);
+            final PlayerData playerData = playerDataStorage.get(profile);
             switch (action.toLowerCase(Locale.ROOT)) {
                 case "start", "add" -> playerData.addNewRawObjective(objectiveID);
                 case "complete", "finish" ->

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/objective/ObjectiveActionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/objective/ObjectiveActionFactory.java
@@ -13,7 +13,6 @@ import org.betonquest.betonquest.api.quest.action.PlayerlessAction;
 import org.betonquest.betonquest.api.quest.action.PlayerlessActionFactory;
 import org.betonquest.betonquest.api.service.objective.ObjectiveManager;
 import org.betonquest.betonquest.data.PlayerDataStorage;
-import org.betonquest.betonquest.database.PlayerDataFactory;
 import org.betonquest.betonquest.database.Saver;
 import org.bukkit.plugin.Plugin;
 
@@ -34,11 +33,6 @@ public class ObjectiveActionFactory implements PlayerActionFactory, PlayerlessAc
      * Logger factory to create a logger for the actions.
      */
     private final BetonQuestLoggerFactory loggerFactory;
-
-    /**
-     * Factory to create new Player Data.
-     */
-    private final PlayerDataFactory playerDataFactory;
 
     /**
      * The objective manager.
@@ -69,18 +63,16 @@ public class ObjectiveActionFactory implements PlayerActionFactory, PlayerlessAc
      * @param saver             the database saver
      * @param objectiveManager  the objective manager
      * @param playerDataStorage the player data storage
-     * @param playerDataFactory the factory to create player data
      */
     public ObjectiveActionFactory(final Plugin plugin, final BetonQuestLoggerFactory loggerFactory,
                                   final ProfileProvider profileProvider, final Saver saver, final ObjectiveManager objectiveManager,
-                                  final PlayerDataStorage playerDataStorage, final PlayerDataFactory playerDataFactory) {
+                                  final PlayerDataStorage playerDataStorage) {
         this.plugin = plugin;
         this.profileProvider = profileProvider;
         this.saver = saver;
         this.objectiveManager = objectiveManager;
         this.playerDataStorage = playerDataStorage;
         this.loggerFactory = loggerFactory;
-        this.playerDataFactory = playerDataFactory;
     }
 
     @Override
@@ -97,6 +89,6 @@ public class ObjectiveActionFactory implements PlayerActionFactory, PlayerlessAc
         final String action = instruction.string().map(s -> s.toLowerCase(Locale.ROOT)).get().getValue(null);
         final Argument<List<ObjectiveIdentifier>> objectives = instruction.identifier(ObjectiveIdentifier.class).list().get();
         return new NullableActionAdapter(new ObjectiveAction(plugin, loggerFactory.create(ObjectiveAction.class), profileProvider, saver,
-                objectiveManager, playerDataStorage, instruction.getPackage(), objectives, playerDataFactory, action));
+                objectiveManager, playerDataStorage, instruction.getPackage(), objectives, action));
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/point/DeletePointActionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/point/DeletePointActionFactory.java
@@ -46,7 +46,7 @@ public class DeletePointActionFactory implements PlayerActionFactory, Playerless
 
     @Override
     public PlayerAction parsePlayer(final Instruction instruction) throws QuestException {
-        return new DeletePointAction(dataStorage::getOffline, instruction.packageIdentifier().get());
+        return new DeletePointAction(dataStorage::get, instruction.packageIdentifier().get());
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/action/point/PointAction.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/action/point/PointAction.java
@@ -60,7 +60,7 @@ public class PointAction implements PlayerAction {
 
     @Override
     public void execute(final Profile profile) throws QuestException {
-        final PlayerData playerData = dataStorage.getOffline(profile);
+        final PlayerData playerData = dataStorage.get(profile);
         final double countDouble = count.getValue(profile).doubleValue();
         final String category = this.category.getValue(profile);
         playerData.points().set(category, pointType.modify(playerData.points().get(category).orElse(0), countDouble));

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/language/LanguageCondition.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/language/LanguageCondition.java
@@ -45,7 +45,7 @@ public class LanguageCondition implements PlayerCondition {
 
     @Override
     public boolean check(final Profile profile) throws QuestException {
-        final String playerLanguage = dataStorage.getOffline(profile).getLanguage().orElseGet(languageProvider::getDefaultLanguage);
+        final String playerLanguage = dataStorage.get(profile).getLanguage().orElseGet(languageProvider::getDefaultLanguage);
         return expectedLanguages.getValue(profile).contains(playerLanguage);
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/point/HasPointCondition.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/point/HasPointCondition.java
@@ -34,6 +34,6 @@ public class HasPointCondition implements PlayerCondition {
 
     @Override
     public boolean check(final Profile profile) throws QuestException {
-        return dataStorage.getOffline(profile).points().get(category.getValue(profile)).isPresent();
+        return dataStorage.get(profile).points().get(category.getValue(profile)).isPresent();
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/point/PointConditionFactory.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/point/PointConditionFactory.java
@@ -17,7 +17,7 @@ public class PointConditionFactory extends DefaultPointConditionFactory implemen
      * @param dataStorage the storage providing player data
      */
     public PointConditionFactory(final PlayerDataStorage dataStorage) {
-        super(profile -> dataStorage.getOffline(profile).points());
+        super(profile -> dataStorage.get(profile).points());
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/condition/tag/TagCondition.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/condition/tag/TagCondition.java
@@ -34,6 +34,6 @@ public class TagCondition implements PlayerCondition {
 
     @Override
     public boolean check(final Profile profile) throws QuestException {
-        return dataStorage.getOffline(profile).tags().has(tag.getValue(profile));
+        return dataStorage.get(profile).tags().has(tag.getValue(profile));
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/PointObjective.java
@@ -77,7 +77,7 @@ public class PointObjective extends DefaultObjective {
         if (value == CountingMode.TOTAL) {
             return String.valueOf(targetValue);
         }
-        final Optional<Integer> points = playerDataStorage.getOffline(profile).points().get(category.getValue(profile));
+        final Optional<Integer> points = playerDataStorage.get(profile).points().get(category.getValue(profile));
         return String.valueOf(targetValue + points.orElse(0));
     }
 
@@ -105,7 +105,7 @@ public class PointObjective extends DefaultObjective {
         if (event.getState() != ObjectiveState.ACTIVE) {
             return;
         }
-        final PlayerData playerData = playerDataStorage.getOffline(profile);
+        final PlayerData playerData = playerDataStorage.get(profile);
         final Optional<Integer> points = playerData.points().get(category.getValue(profile));
         if (points.isPresent()) {
             checkProgress(profile, points.get());
@@ -119,7 +119,7 @@ public class PointObjective extends DefaultObjective {
     }
 
     private int getRemainingPoints(final Profile profile) throws QuestException {
-        return getPoints(profile) - playerDataStorage.getOffline(profile)
+        return getPoints(profile) - playerDataStorage.get(profile)
                 .points()
                 .get(category.getValue(profile))
                 .orElse(0);

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/objective/data/TagObjective.java
@@ -64,7 +64,7 @@ public class TagObjective extends DefaultObjective {
         if (event.getState() != ObjectiveState.ACTIVE) {
             return;
         }
-        if (playerDataStorage.getOffline(profile).tags().has(tag.getValue(profile))) {
+        if (playerDataStorage.get(profile).tags().has(tag.getValue(profile))) {
             getService().complete(profile);
         }
     }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/point/PointPlaceholder.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/point/PointPlaceholder.java
@@ -24,6 +24,6 @@ public class PointPlaceholder extends AbstractPointPlaceholder<PlayerDataStorage
 
     @Override
     public String getValue(final Profile profile) {
-        return getValueFor(data.getOffline(profile).points().get(category).orElse(0));
+        return getValueFor(data.get(profile).points().get(category).orElse(0));
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/tag/TagPlaceholder.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/quest/placeholder/tag/TagPlaceholder.java
@@ -30,6 +30,6 @@ public class TagPlaceholder extends AbstractTagPlaceholder<PlayerDataStorage> im
 
     @Override
     public String getValue(final Profile profile) throws QuestException {
-        return getValueFor(profile, data.getOffline(profile).tags().get());
+        return getValueFor(profile, data.get(profile).tags().get());
     }
 }

--- a/code/core/src/test/java/org/betonquest/betonquest/quest/action/journal/JournalActionTest.java
+++ b/code/core/src/test/java/org/betonquest/betonquest/quest/action/journal/JournalActionTest.java
@@ -30,7 +30,7 @@ class JournalActionTest {
             @Mock final JournalChanger changer, @Mock final NotificationSender sender) throws QuestException {
         final ProfileProvider profileProvider = mock(ProfileProvider.class);
         final OnlineProfile onlineProfile = profileProvider.getProfile(mock(Player.class));
-        when(dataStorage.getOffline(onlineProfile)).thenReturn(data);
+        when(dataStorage.get(onlineProfile)).thenReturn(data);
         when(data.getJournal()).thenReturn(journal);
 
         final JournalAction action = new JournalAction(dataStorage, changer, sender);


### PR DESCRIPTION
Replace `getOffline` method with `get` for player data access and refactor related code

<!-- Please describe your changes here. -->


---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
