### PR TITLE
Introduce `ConnectionProvider` abstraction for database connections

### DIFF
--- a/code/core/src/main/java/org/betonquest/betonquest/database/ConnectionProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/ConnectionProvider.java
@@ -1,0 +1,28 @@
+package org.betonquest.betonquest.database;
+
+import java.sql.Connection;
+
+/**
+ * Provides a connection to the database.
+ */
+@FunctionalInterface
+public interface ConnectionProvider {
+
+    /**
+     * Creates a new connection.
+     *
+     * @return the new connection
+     */
+    Connection create();
+
+    /**
+     * Returns true if the connection is managed.
+     * Managed connections are opened and closed by the provider and may not be persisted.
+     * Unmanaged connections should be manually managed.
+     *
+     * @return true if the connection is managed, false otherwise
+     */
+    default boolean isManaged() {
+        return false;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/database/Database.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/Database.java
@@ -34,6 +34,11 @@ public abstract class Database {
     protected final String profileInitialName;
 
     /**
+     * The connection provider instance.
+     */
+    protected final ConnectionProvider connectionProvider;
+
+    /**
      * Custom {@link BetonQuestLogger} instance for this class.
      */
     private final BetonQuestLogger log;
@@ -47,13 +52,15 @@ public abstract class Database {
     /**
      * Creates a new Database instance.
      *
-     * @param log    the BetonQuestLogger to use for logging
-     * @param plugin the BetonQuest plugin instance
-     * @param config the plugin configuration file
+     * @param log                the BetonQuestLogger to use for logging
+     * @param connectionProvider the connection provider instance
+     * @param plugin             the BetonQuest plugin instance
+     * @param config             the plugin configuration file
      */
-    protected Database(final BetonQuestLogger log, final Plugin plugin, final ConfigAccessor config) {
+    protected Database(final BetonQuestLogger log, final ConnectionProvider connectionProvider, final Plugin plugin, final ConfigAccessor config) {
         this.log = log;
         this.plugin = plugin;
+        this.connectionProvider = connectionProvider;
         this.prefix = config.getString("mysql.prefix", "");
         this.profileInitialName = config.getString("profile.initial_name", "default");
     }
@@ -66,8 +73,11 @@ public abstract class Database {
      */
     public Connection getConnection() {
         try {
+            if (connectionProvider.isManaged()) {
+                return connectionProvider.create();
+            }
             if (con == null || con.isClosed() || isConnectionBroken(con)) {
-                con = openConnection();
+                con = connectionProvider.create();
             }
         } catch (final SQLException e) {
             log.error("Failed opening database connection!", e);
@@ -86,14 +96,6 @@ public abstract class Database {
             return true;
         }
     }
-
-    /**
-     * Opens a new database connection.
-     *
-     * @return the new database connection
-     * @throws SQLException if the connection could not be opened
-     */
-    protected abstract Connection openConnection() throws SQLException;
 
     /**
      * Closes the database connection if it is open.

--- a/code/core/src/main/java/org/betonquest/betonquest/database/MySQL.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/MySQL.java
@@ -17,7 +17,6 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,71 +42,16 @@ public class MySQL extends Database {
     private final BetonQuestLogger log;
 
     /**
-     * Username for the MySQL user.
-     */
-    private final String user;
-
-    /**
-     * Prefix for the database tables.
-     */
-    private final String database;
-
-    /**
-     * Password for the MySQL user.
-     */
-    private final String password;
-
-    /**
-     * Port number to connect to the MySQL server.
-     */
-    private final String port;
-
-    /**
-     * Name of the host to connect to the MySQL server.
-     */
-    private final String hostname;
-
-    /**
      * Creates a new MySQL instance.
      *
-     * @param log      the logger that will be used for logging
-     * @param plugin   Plugin instance
-     * @param config   the configuration accessor
-     * @param hostname Name of the host
-     * @param port     Port number
-     * @param database Database name
-     * @param username Username
-     * @param password Password
+     * @param log                the logger that will be used for logging
+     * @param connectionProvider the connection provider
+     * @param plugin             Plugin instance
+     * @param config             the configuration accessor
      */
-    public MySQL(final BetonQuestLogger log, final Plugin plugin, final ConfigAccessor config, final String hostname,
-                 final String port, final String database, final String username, final String password) {
-        super(log, plugin, config);
+    public MySQL(final BetonQuestLogger log, final ConnectionProvider connectionProvider, final Plugin plugin, final ConfigAccessor config) {
+        super(log, connectionProvider, plugin, config);
         this.log = log;
-        this.hostname = hostname;
-        this.port = port;
-        this.database = database;
-        this.user = username;
-        this.password = password;
-    }
-
-    @Override
-    public Connection openConnection() {
-        Connection connection = null;
-        try {
-            Class.forName("com.mysql.jdbc.Driver");
-            connection = DriverManager.getConnection(
-                    "jdbc:mysql://" + this.hostname + ":" + this.port + "/" + this.database + "?&useSSL=false", this.user, this.password);
-            final String connectionClassName = connection.getClass().getName();
-            if (!connectionClassName.startsWith("com.mysql.")) {
-                log.warn("External source modified or changed the MySQL connector! We can not guarantee that BetonQuest will work correctly with this connector: " + connectionClassName);
-            }
-        } catch (final ClassNotFoundException | SQLException e) {
-            log.warn("MySQL says: " + e.getMessage(), e);
-        }
-        if (connection == null) {
-            throw new IllegalStateException("Not able to create a database connection!");
-        }
-        return connection;
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/database/MySqlJdbcProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/MySqlJdbcProvider.java
@@ -1,0 +1,82 @@
+package org.betonquest.betonquest.database;
+
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Provides a MySQL JDBC connection.
+ */
+public class MySqlJdbcProvider implements ConnectionProvider {
+
+    /**
+     * The logger instance.
+     */
+    private final BetonQuestLogger log;
+
+    /**
+     * The hostname of the database.
+     */
+    private final String hostname;
+
+    /**
+     * The port of the database.
+     */
+    private final String port;
+
+    /**
+     * The database name.
+     */
+    private final String database;
+
+    /**
+     * The user to connect with.
+     */
+    private final String user;
+
+    /**
+     * The password to connect with.
+     */
+    private final String password;
+
+    /**
+     * Creates a new MySQL JDBC connection provider.
+     *
+     * @param log      the logger instance
+     * @param hostname the hostname of the database
+     * @param port     the port of the database
+     * @param database the database name
+     * @param user     the user to connect with
+     * @param password the password to connect with
+     */
+    public MySqlJdbcProvider(final BetonQuestLogger log, final String hostname, final String port, final String database, final String user, final String password) {
+        this.log = log;
+        this.hostname = hostname;
+        this.port = port;
+        this.database = database;
+        this.user = user;
+        this.password = password;
+    }
+
+    @Override
+    public Connection create() {
+        Connection connection = null;
+        try {
+            Class.forName("com.mysql.jdbc.Driver");
+            connection = DriverManager.getConnection("jdbc:mysql://%s:%s/%s?&useSSL=false"
+                    .formatted(this.hostname, this.port, this.database), this.user, this.password);
+            final String connectionClassName = connection.getClass().getName();
+            if (!connectionClassName.startsWith("com.mysql.")) {
+                log.warn("External source modified or changed the MySQL connector! We can not guarantee that BetonQuest will work correctly with this connector: %s".formatted(connectionClassName));
+            }
+        } catch (final ClassNotFoundException | SQLException e) {
+            log.warn("MySQL says: %s".formatted(e.getMessage()), e);
+        }
+        if (connection == null) {
+            throw new IllegalStateException("Not able to create a database connection!");
+        }
+        return connection;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/database/SQLite.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/SQLite.java
@@ -15,10 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 
-import java.io.File;
-import java.io.IOException;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,7 +32,7 @@ import static org.betonquest.betonquest.item.typehandler.QuestHandler.QUEST_ITEM
 /**
  * Connects to and uses a SQLite database.
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class SQLite extends Database {
 
     /**
@@ -44,51 +41,16 @@ public class SQLite extends Database {
     private final BetonQuestLogger log;
 
     /**
-     * The database file location.
-     */
-    private final String dbLocation;
-
-    /**
      * Creates a new SQLite instance.
      *
-     * @param log        the logger that will be used for logging
-     * @param plugin     Plugin instance
-     * @param config     the accessor for the config
-     * @param dbLocation Location of the Database (Must end in .db)
+     * @param log                the logger that will be used for logging
+     * @param connectionProvider the connection provider that will be used to get a connection to the database
+     * @param plugin             Plugin instance
+     * @param config             the accessor for the config
      */
-    public SQLite(final BetonQuestLogger log, final Plugin plugin, final ConfigAccessor config, final String dbLocation) {
-        super(log, plugin, config);
+    public SQLite(final BetonQuestLogger log, final ConnectionProvider connectionProvider, final Plugin plugin, final ConfigAccessor config) {
+        super(log, connectionProvider, plugin, config);
         this.log = log;
-        this.dbLocation = dbLocation;
-    }
-
-    @Override
-    public Connection openConnection() {
-        if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
-            log.error("Unable to create plugin data folder!");
-        }
-        final File file = new File(plugin.getDataFolder(), dbLocation);
-        if (!file.exists()) {
-            try {
-                if (!file.createNewFile()) {
-                    log.error("Unable to create database file!");
-                }
-            } catch (final IOException e) {
-                log.error("Unable to create database!", e);
-            }
-        }
-        Connection connection = null;
-        try {
-            Class.forName("org.sqlite.JDBC");
-            connection = DriverManager
-                    .getConnection("jdbc:sqlite:" + plugin.getDataFolder().toPath() + "/" + dbLocation);
-        } catch (ClassNotFoundException | SQLException e) {
-            log.error("There was an exception with SQL", e);
-        }
-        if (connection == null) {
-            throw new IllegalStateException("Not able to create a database connection!");
-        }
-        return connection;
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/database/SQliteJdbcProvider.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/SQliteJdbcProvider.java
@@ -1,0 +1,72 @@
+package org.betonquest.betonquest.database;
+
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Provides an SQLite JDBC connection.
+ */
+public class SQliteJdbcProvider implements ConnectionProvider {
+
+    /**
+     * The logger instance.
+     */
+    private final BetonQuestLogger log;
+
+    /**
+     * The plugin instance.
+     */
+    private final Plugin plugin;
+
+    /**
+     * The location of the database file.
+     */
+    private final String dbLocation;
+
+    /**
+     * Creates a new SQLite JDBC provider.
+     *
+     * @param log        the logger instance
+     * @param plugin     the plugin instance
+     * @param dbLocation the location of the database file
+     */
+    public SQliteJdbcProvider(final BetonQuestLogger log, final Plugin plugin, final String dbLocation) {
+        this.log = log;
+        this.plugin = plugin;
+        this.dbLocation = dbLocation;
+    }
+
+    @Override
+    public Connection create() {
+        if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
+            log.error("Unable to create plugin data folder!");
+        }
+        final File file = new File(plugin.getDataFolder(), dbLocation);
+        if (!file.exists()) {
+            try {
+                if (!file.createNewFile()) {
+                    log.error("Unable to create database file '%s'!".formatted(file.getPath()));
+                }
+            } catch (final IOException e) {
+                log.error("Unable to create database!", e);
+            }
+        }
+        Connection connection = null;
+        try {
+            Class.forName("org.sqlite.JDBC");
+            connection = DriverManager.getConnection("jdbc:sqlite:%s/%s".formatted(plugin.getDataFolder().toPath(), dbLocation));
+        } catch (ClassNotFoundException | SQLException e) {
+            log.error("There was an exception with creating the Sqlite connection.", e);
+        }
+        if (connection == null) {
+            throw new IllegalStateException("Not able to create a database connection!");
+        }
+        return connection;
+    }
+}

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/DatabaseComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/DatabaseComponent.java
@@ -7,7 +7,9 @@ import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.database.Connector;
 import org.betonquest.betonquest.database.Database;
 import org.betonquest.betonquest.database.MySQL;
+import org.betonquest.betonquest.database.MySqlJdbcProvider;
 import org.betonquest.betonquest.database.SQLite;
+import org.betonquest.betonquest.database.SQliteJdbcProvider;
 import org.betonquest.betonquest.lib.dependency.component.AbstractCoreComponent;
 import org.bukkit.plugin.Plugin;
 
@@ -52,12 +54,14 @@ public class DatabaseComponent extends AbstractCoreComponent {
         Database database = null;
         if (mySQLEnabled) {
             log.debug("Connecting to MySQL database");
-            final Database mySql = new MySQL(loggerFactory.create(MySQL.class, "Database"), plugin, config,
-                    config.getString("mysql.host"),
-                    config.getString("mysql.port"),
-                    config.getString("mysql.base"),
-                    config.getString("mysql.user"),
-                    config.getString("mysql.pass"));
+            final BetonQuestLogger databaseLogger = loggerFactory.create(MySQL.class, "Database");
+            final MySqlJdbcProvider connectionProvider = new MySqlJdbcProvider(databaseLogger,
+                    config.getString("mysql.host", ""),
+                    config.getString("mysql.port", ""),
+                    config.getString("mysql.base", ""),
+                    config.getString("mysql.user", ""),
+                    config.getString("mysql.pass", ""));
+            final Database mySql = new MySQL(databaseLogger, connectionProvider, plugin, config);
             try {
                 mySql.getConnection();
                 database = mySql;
@@ -68,7 +72,9 @@ public class DatabaseComponent extends AbstractCoreComponent {
             }
         }
         if (database == null) {
-            database = new SQLite(loggerFactory.create(SQLite.class, "Database"), plugin, config, "database.db");
+            final BetonQuestLogger databaseLogger = loggerFactory.create(SQLite.class, "Database");
+            final SQliteJdbcProvider connectionProvider = new SQliteJdbcProvider(databaseLogger, plugin, "database.db");
+            database = new SQLite(databaseLogger, connectionProvider, plugin, config);
             if (mySQLEnabled) {
                 log.warn("No connection to the mySQL Database! Using SQLite for storing data as fallback!");
             } else {


### PR DESCRIPTION
Introduce `ConnectionProvider` abstraction for database connections

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
