### PR TITLE
Fix block selector with regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `lore` of `item` placeholder can now be used without number to get all lines
 - `chat` notify io now only sends messages during a conversation if `bypassInterceptor` is set to `true`
 - `non-positive` (<= 0) update intervals deactivate automatic updating
+- `block selector` no longer uses `matchMaterial` which strips regex characters and resolved to unwanted values
 ### Deprecated
 ### Removed
 ### Fixed

--- a/code/core/src/main/java/org/betonquest/betonquest/util/DefaultBlockSelector.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/util/DefaultBlockSelector.java
@@ -211,10 +211,19 @@ public class DefaultBlockSelector implements BlockSelector {
         return -1;
     }
 
-    @SuppressWarnings("PMD.CyclomaticComplexity")
+    /**
+     * The full material check is explicit for modifications of the {@link Material} with custom namespaces.
+     */
     private List<Material> getMaterials(final String namespaceString, final String keyString) throws QuestException {
         final List<Material> materials = new ArrayList<>();
-        final Material fullMatch = Material.matchMaterial(namespaceString + ":" + keyString);
+        if (NamespacedKey.MINECRAFT_NAMESPACE.equals(namespaceString)) {
+            final Material match = Material.getMaterial(keyString.toUpperCase(Locale.ROOT));
+            if (match != null) {
+                materials.add(match);
+                return materials;
+            }
+        }
+        final Material fullMatch = Material.getMaterial((namespaceString + ":" + keyString).toUpperCase(Locale.ROOT));
         if (fullMatch != null) {
             materials.add(fullMatch);
             return materials;

--- a/code/core/src/main/java/org/betonquest/betonquest/util/DefaultBlockSelector.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/util/DefaultBlockSelector.java
@@ -33,7 +33,7 @@ import java.util.regex.PatternSyntaxException;
  * - state - (optional) The block states can be provided in a comma separated `key=value` list surrounded by square
  * brackets. Regex allowed
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public class DefaultBlockSelector implements BlockSelector {
 
     /**
@@ -160,7 +160,7 @@ public class DefaultBlockSelector implements BlockSelector {
             final String blockState = blockStates.get(singleState);
             final String state = entry.getValue();
             if (!blockState.equals(state)) {
-                final Pattern statePattern = Pattern.compile("^" + state + "$");
+                final Pattern statePattern = Pattern.compile(state);
                 final Matcher stateMatcher = statePattern.matcher(blockState);
                 if (!stateMatcher.find()) {
                     return false;
@@ -230,7 +230,7 @@ public class DefaultBlockSelector implements BlockSelector {
         }
 
         if (keyString.contains(":")) {
-            final String[] groupParts = keyString.split(":");
+            final String[] groupParts = keyString.split(":", 2);
             final NamespacedKey namespacedKey = new NamespacedKey(namespaceString, groupParts[1]);
             final String registry = groupParts[0];
             try {
@@ -244,14 +244,19 @@ public class DefaultBlockSelector implements BlockSelector {
             return materials;
         }
 
+        return getMaterialsByRegex(namespaceString, keyString);
+    }
+
+    private List<Material> getMaterialsByRegex(final String namespaceString, final String keyString) throws QuestException {
         final Pattern namespacePattern;
         final Pattern keyPattern;
         try {
-            namespacePattern = Pattern.compile("^" + namespaceString + "$");
-            keyPattern = Pattern.compile("^" + keyString + "$");
+            namespacePattern = Pattern.compile(namespaceString);
+            keyPattern = Pattern.compile(keyString);
         } catch (final PatternSyntaxException exception) {
             throw new QuestException("Invalid Regex: " + exception.getMessage(), exception);
         }
+        final List<Material> materials = new ArrayList<>();
         for (final Material material : Material.values()) {
             if (material.isLegacy()) {
                 continue;

--- a/docs/Documentation/Reference/Definition-Encyclopedia.md
+++ b/docs/Documentation/Reference/Definition-Encyclopedia.md
@@ -76,6 +76,7 @@ A list of all data types that require a special and more elaborate explanation.
       - `redstone_wire[power=5,facing=1]` - Matches all blocks of type REDSTONE_WIRE and which have both a power of 5 and are facing 1
       - `.*_LOG` - Matches all LOGS
       - `.*` - Matches everything, including air
+      - `^(?!air$).*` - Matches everything, excluding air
       - `.*[waterlogged=true]` - Matches all waterlogged blocks
       - `minecraft:blocks:flowers` - Matches all flowers
       - `:blocks:crops[age=0]` - Matches all crops with an age of 0 meaning, not grown / just planted


### PR DESCRIPTION
<!-- Please describe your changes here. -->
Both the `Material#matchMaterial` method and manual adding of regex control characters break commonly used regexes like `^(?!air$).*` which made not matching a specific material not possible.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
