### PR TITLE
Remove unused database connection validation logic in AsyncSaver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `block selector` no longer uses `matchMaterial` which strips regex characters and resolved to unwanted values
 ### Deprecated
 ### Removed
+- `mysql.reconnect_interval` config option since it is no longer used
 ### Fixed
 - JobsReborn integration missed some null checks resulting in not working actions and conditions
 - concurrency issue when loading player data on join causing multiple profiles to get created with a database exception
 - `extends` in `conversations` sometimes crashing with IllegalStateException
 - `section` placeholder did not include target path to subsections
+- async database handling by using default java executor service implementation instead of manual thread handling
 ### Security
 
 ## [3.2.0] - 2026-08-17

--- a/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
@@ -1,10 +1,7 @@
 package org.betonquest.betonquest.database;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -12,8 +9,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * Saves the data to the database asynchronously.
  */
-@SuppressWarnings({"PMD.DoNotUseThreads", "PMD.AvoidSynchronizedStatement"})
-@SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 public class AsyncSaver implements Runnable, Saver {
 
     /**
@@ -32,11 +28,6 @@ public class AsyncSaver implements Runnable, Saver {
     private final Queue<Record> queue;
 
     /**
-     * The amount of time until the AsyncSaver tries to reconnect if there was a connection loss.
-     */
-    private final long reconnectInterval;
-
-    /**
      * Whether the saver is currently running or not.
      */
     private boolean running;
@@ -44,68 +35,45 @@ public class AsyncSaver implements Runnable, Saver {
     /**
      * Creates a new database saver thread.
      *
-     * @param log               the logger that will be used for logging
-     * @param reconnectInterval the interval for trying reconnecting to the database
-     * @param connector         the connector for database access
+     * @param log       the logger that will be used for logging
+     * @param connector the connector for database access
      */
-    public AsyncSaver(final BetonQuestLogger log, final long reconnectInterval, final Connector connector) {
+    public AsyncSaver(final BetonQuestLogger log, final Connector connector) {
         this.log = log;
-        this.reconnectInterval = reconnectInterval;
         this.con = connector;
         this.queue = new ConcurrentLinkedQueue<>();
         this.running = true;
     }
 
     @Override
-    @SuppressFBWarnings("UW_UNCOND_WAIT")
     public void run() {
         log.debug("Thread started.");
-        boolean active = false;
         while (true) {
-            while (queue.isEmpty()) {
-                if (!running) {
-                    log.debug("Thread terminating.");
-                    return;
-                }
-                synchronized (this) {
+            synchronized (this) {
+                while (queue.isEmpty()) {
+                    if (!running) {
+                        log.debug("Thread terminating.");
+                        return;
+                    }
                     try {
-                        active = false;
                         wait();
                     } catch (final InterruptedException e) {
                         log.warn("Got interrupted!");
                     }
                 }
+                consumeQueue();
             }
-            if (!(active || ensureActive())) {
-                return;
-            }
-            active = true;
+        }
+    }
+
+    private void consumeQueue() {
+        while (!queue.isEmpty()) {
             final Record rec = queue.poll();
             if (rec != null) {
                 log.debug("Processing queued record: '%s' with arguments '%s'".formatted(rec.type(), Arrays.toString(rec.args())));
                 con.updateSQL(rec.type(), new Arguments(rec.args()));
             }
         }
-    }
-
-    private boolean ensureActive() {
-        try (Connection connection = con.getDatabase().getConnection()) {
-            log.debug("Validating database connection...");
-            if (connection.isValid(5000)) {
-                log.debug("Database connection validated.");
-                return true;
-            }
-        } catch (final IllegalStateException | SQLException illegalStateException) {
-            log.warn("Failed to re-establish connection with the database! Trying again in %s second(s)..."
-                    .formatted(reconnectInterval / 1000), illegalStateException);
-            try {
-                Thread.sleep(reconnectInterval);
-            } catch (final InterruptedException interruptedException) {
-                log.warn("Got interrupted!", interruptedException);
-                return false;
-            }
-        }
-        return ensureActive();
     }
 
     @Override

--- a/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/database/AsyncSaver.java
@@ -3,14 +3,15 @@ package org.betonquest.betonquest.database;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 
 import java.util.Arrays;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Saves the data to the database asynchronously.
  */
-@SuppressWarnings("PMD.AvoidSynchronizedStatement")
-public class AsyncSaver implements Runnable, Saver {
+@SuppressWarnings("PMD.DoNotUseThreads")
+public class AsyncSaver implements Saver {
 
     /**
      * Custom {@link BetonQuestLogger} instance for this class.
@@ -23,14 +24,9 @@ public class AsyncSaver implements Runnable, Saver {
     private final Connector con;
 
     /**
-     * The queue of records to be saved to the database.
+     * The executor service that will run the saver.
      */
-    private final Queue<Record> queue;
-
-    /**
-     * Whether the saver is currently running or not.
-     */
-    private boolean running;
+    private final ExecutorService executor;
 
     /**
      * Creates a new database saver thread.
@@ -41,56 +37,32 @@ public class AsyncSaver implements Runnable, Saver {
     public AsyncSaver(final BetonQuestLogger log, final Connector connector) {
         this.log = log;
         this.con = connector;
-        this.queue = new ConcurrentLinkedQueue<>();
-        this.running = true;
+        this.executor = Executors.newSingleThreadExecutor();
     }
 
-    @Override
-    public void run() {
-        log.debug("Thread started.");
-        while (true) {
-            synchronized (this) {
-                while (queue.isEmpty()) {
-                    if (!running) {
-                        log.debug("Thread terminating.");
-                        return;
-                    }
-                    try {
-                        wait();
-                    } catch (final InterruptedException e) {
-                        log.warn("Got interrupted!");
-                    }
-                }
-                consumeQueue();
-            }
-        }
-    }
-
-    private void consumeQueue() {
-        while (!queue.isEmpty()) {
-            final Record rec = queue.poll();
-            if (rec != null) {
-                log.debug("Processing queued record: '%s' with arguments '%s'".formatted(rec.type(), Arrays.toString(rec.args())));
-                con.updateSQL(rec.type(), new Arguments(rec.args()));
-            }
-        }
+    private void process(final Record rec) {
+        log.debug("Processing record: '%s' with arguments '%s'".formatted(rec.type(), Arrays.toString(rec.args())));
+        con.updateSQL(rec.type(), new Arguments(rec.args()));
+        log.debug("Processing record done: '%s' with arguments '%s'".formatted(rec.type(), Arrays.toString(rec.args())));
     }
 
     @Override
     public void add(final Record rec) {
-        synchronized (this) {
-            log.debug("Queued record: '%s' with arguments '%s' (queued: %d)".formatted(rec.type(), Arrays.toString(rec.args()), queue.size() + 1));
-            queue.add(rec);
-            notifyAll();
-        }
+        executor.execute(() -> process(rec));
     }
 
     @Override
     public void end() {
-        synchronized (this) {
-            log.debug("Terminating with %d pending records in queue.".formatted(queue.size()));
-            running = false;
-            notifyAll();
+        log.debug("Terminating executor service.");
+        try {
+            executor.shutdown();
+            if (executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                log.debug("Executor service terminated.");
+            } else {
+                log.error("Executor service did not terminate correctly!");
+            }
+        } catch (final InterruptedException e) {
+            log.error("Interrupted while waiting for executor service to terminate.", e);
         }
     }
 }

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
@@ -14,7 +14,6 @@ import java.util.Set;
 /**
  * The implementation of {@link AbstractCoreComponent} for {@link AsyncSaver}.
  */
-@SuppressWarnings("PMD.DoNotUseThreads")
 public class AsyncSaverComponent extends AbstractCoreComponent {
 
     /**
@@ -42,7 +41,6 @@ public class AsyncSaverComponent extends AbstractCoreComponent {
         final Connector connector = getDependency(Connector.class);
 
         final AsyncSaver saver = new AsyncSaver(loggerFactory.create(AsyncSaver.class, "AsyncSaver"), connector);
-        new Thread(saver).start();
         new Backup(loggerFactory, loggerFactory.create(Backup.class), configAccessorFactory, plugin.getDataFolder(), connector)
                 .loadDatabaseFromBackup();
 

--- a/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
+++ b/code/core/src/main/java/org/betonquest/betonquest/kernel/component/AsyncSaverComponent.java
@@ -1,6 +1,5 @@
 package org.betonquest.betonquest.kernel.component;
 
-import org.betonquest.betonquest.api.config.ConfigAccessor;
 import org.betonquest.betonquest.api.config.ConfigAccessorFactory;
 import org.betonquest.betonquest.api.dependency.DependencyProvider;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -27,7 +26,7 @@ public class AsyncSaverComponent extends AbstractCoreComponent {
 
     @Override
     public Set<Class<?>> requires() {
-        return Set.of(Plugin.class, BetonQuestLoggerFactory.class, ConfigAccessorFactory.class, ConfigAccessor.class, Connector.class);
+        return Set.of(Plugin.class, BetonQuestLoggerFactory.class, ConfigAccessorFactory.class, Connector.class);
     }
 
     @Override
@@ -40,10 +39,9 @@ public class AsyncSaverComponent extends AbstractCoreComponent {
         final Plugin plugin = getDependency(Plugin.class);
         final BetonQuestLoggerFactory loggerFactory = getDependency(BetonQuestLoggerFactory.class);
         final ConfigAccessorFactory configAccessorFactory = getDependency(ConfigAccessorFactory.class);
-        final ConfigAccessor config = getDependency(ConfigAccessor.class);
         final Connector connector = getDependency(Connector.class);
 
-        final AsyncSaver saver = new AsyncSaver(loggerFactory.create(AsyncSaver.class, "AsyncSaver"), config.getLong("mysql.reconnect_interval"), connector);
+        final AsyncSaver saver = new AsyncSaver(loggerFactory.create(AsyncSaver.class, "AsyncSaver"), connector);
         new Thread(saver).start();
         new Backup(loggerFactory, loggerFactory.create(Backup.class), configAccessorFactory, plugin.getDataFolder(), connector)
                 .loadDatabaseFromBackup();

--- a/code/core/src/main/resources/config.patch.yml
+++ b/code/core/src/main/resources/config.patch.yml
@@ -1,4 +1,7 @@
 # Put patches for BetonQuest's config here. The syntax is documented in the docs/API/Configuration-Files.md
+3.3.0.3:
+  - type: REMOVE
+    key: mysql.reconnect_interval
 3.3.0.2:
   - type: SET
     key: hook.discordsrv

--- a/code/core/src/main/resources/config.yml
+++ b/code/core/src/main/resources/config.yml
@@ -23,7 +23,6 @@ mysql:
   pass: ''
   base: ''
   prefix: betonquest_
-  reconnect_interval: 1000
 profile:
   initial_name: 'default'
 language:

--- a/docs/Documentation/Reference/Plugin-Config.md
+++ b/docs/Documentation/Reference/Plugin-Config.md
@@ -74,7 +74,6 @@ mysql:
   pass: ''                   #(6)!
   base: ''                   #(7)!
   prefix: betonquest_        #(8)!
-  reconnect_interval: 1000   #(9)!
 ```
 
 1. Set this to true.
@@ -85,7 +84,6 @@ mysql:
 6. The password of that user.
 7. The database that BetonQuest will write to. You need to create it in your database server.
 8. The table prefix of BetonQuest's data in the database.
-9. The time interval the database tries to reconnect if the connection gets lost
 
 ### Migrating a database from SQLite to MySQL or back
 Follow these few steps to migrate your database easily:


### PR DESCRIPTION
Remove unused database connection validation logic in AsyncSaver.
This should also fix issues with records not being processed correctly, getting stuck or the saver unable to handle the connection in general.

---

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
