### PR TITLE
Keep the dialog conversation IO open between answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `extends` in `conversations` sometimes crashing with IllegalStateException
 - `section` placeholder did not include target path to subsections
 - async database handling by using default java executor service implementation instead of manual thread handling
+- `dialog` conversation IO closed and reopened the screen on every answer, briefly freeing the camera and recentering the cursor
 ### Security
 
 ## [3.2.0] - 2026-08-17

--- a/code/mc_1_21_8/src/main/java/org/betonquest/betonquest/mc_1_21_8/conversation/io/DialogConvIO.java
+++ b/code/mc_1_21_8/src/main/java/org/betonquest/betonquest/mc_1_21_8/conversation/io/DialogConvIO.java
@@ -158,6 +158,7 @@ public class DialogConvIO implements ConversationIO {
 
         return DialogBase.builder(title)
                 .canCloseWithEscape(settings.closeButtonEnabled() && settings.closeWithEscape() && !conv.isMovementBlock())
+                .pause(false)
                 .afterAction(DialogBase.DialogAfterAction.NONE)
                 .body(bodies)
                 .build();

--- a/code/mc_1_21_8/src/main/java/org/betonquest/betonquest/mc_1_21_8/conversation/io/DialogConvIO.java
+++ b/code/mc_1_21_8/src/main/java/org/betonquest/betonquest/mc_1_21_8/conversation/io/DialogConvIO.java
@@ -158,6 +158,7 @@ public class DialogConvIO implements ConversationIO {
 
         return DialogBase.builder(title)
                 .canCloseWithEscape(settings.closeButtonEnabled() && settings.closeWithEscape() && !conv.isMovementBlock())
+                .afterAction(DialogBase.DialogAfterAction.NONE)
                 .body(bodies)
                 .build();
     }
@@ -287,6 +288,7 @@ public class DialogConvIO implements ConversationIO {
 
     @Override
     public void end(final Runnable callback) {
+        onlineProfile.getPlayer().closeDialog();
         callback.run();
     }
 }


### PR DESCRIPTION
The `dialog` conversation IO never sets an after-action on its `DialogBase`, so Paper applies the default `CLOSE`. Every button click therefore closes the screen on the client before the next page arrives. The player sees the camera freed for a frame, then the next dialog opens with the cursor recentred. It feels like the conversation closes and reopens on every answer.

This sets `DialogAfterAction.NONE` so the next `showDialog` replaces the current screen in place, and closes the dialog explicitly in `end()` since the client no longer does that on its own (otherwise the last page and the close button would stay open after the conversation ends). It also sets `pause(false)`: Paper's `DialogBaseImpl` rejects `NONE` on a dialog that pauses the game ("Dialogs that pause the game must use after_action values that unpause it after user action"), and the pause flag only has meaning in singleplayer anyway. The first revision of this branch lacked that and threw on every conversation open; fixed in the second commit.

Three lines of code plus a changelog entry. `mvn verify` passes for `code/mc_1_21_8` and its dependencies. Draft until I have run it in-game on our Paper 1.21.11 server with 3.2.0 plus this patch; I will update here once that is done.

**AI disclosure** (per [AI Usage](https://betonquest.org/DEV/Participate/Process/AI-Usage/)): the root cause analysis and this patch were produced with an AI assistant (Claude) and reviewed by me.

---

### Related Issues

None filed; happy to open one if you prefer tracking it that way.

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [ ]  ... test their changes?
- [ ]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [ ]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [ ]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [ ]  ... write a migration?
- [ ]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
