### PR TITLE
 Fix build module dependency resolving

### DIFF
--- a/code/build/pom.xml
+++ b/code/build/pom.xml
@@ -91,6 +91,16 @@
       <id>betonquest-papermc-repo</id>
       <url>https://repo.papermc.io/repository/maven-public/</url>
     </repository>
+
+    <!-- Transitive compile dependencies -->
+    <repository>
+      <id>betonquest-minebench-repo</id>
+      <url>https://repo.minebench.de/</url>
+    </repository>
+    <repository>
+      <id>faststats-releases</id>
+      <url>https://repo.faststats.dev/releases</url>
+    </repository>
   </repositories>
 
   <build>

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -26,6 +26,7 @@
     <betonquest.lib.version>3.3.0${changelist}</betonquest.lib.version>
 
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
+    <minedown-adventure.version>1.7.4-SNAPSHOT</minedown-adventure.version>
     <bstats-bukkit.version>3.0.2</bstats-bukkit.version>
     <faststats-bukkit.version>0.27.1</faststats-bukkit.version>
     <log4j-api.version>3.0.0-beta2</log4j-api.version>
@@ -54,6 +55,13 @@
           <artifactId>junit</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- from minebench repository -->
+    <dependency>
+      <groupId>de.themoep</groupId>
+      <artifactId>minedown-adventure</artifactId>
+      <version>${minedown-adventure.version}</version>
     </dependency>
 
     <!-- only dependencies from maven central that are MC Plugins -->
@@ -103,6 +111,10 @@
     <repository>
       <id>betonquest-papermc-repo</id>
       <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>betonquest-minebench-repo</id>
+      <url>https://repo.minebench.de/</url>
     </repository>
     <repository>
       <id>maven_central</id>

--- a/code/lib/pom.xml
+++ b/code/lib/pom.xml
@@ -24,7 +24,6 @@
 
     <!-- dependency versions -->
     <paper-api.version>1.18.2-R0.1-SNAPSHOT</paper-api.version>
-    <minedown-adventure.version>1.7.4-SNAPSHOT</minedown-adventure.version>
     <log4j-api.version>3.0.0-beta2</log4j-api.version>
     <log4j-core.version>3.0.0-beta2</log4j-core.version>
     <maven-artifact.version>4.0.0-beta-3</maven-artifact.version>
@@ -53,13 +52,6 @@
           <artifactId>junit</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- from minebench repository -->
-    <dependency>
-      <groupId>de.themoep</groupId>
-      <artifactId>minedown-adventure</artifactId>
-      <version>${minedown-adventure.version}</version>
     </dependency>
 
     <!-- only dependencies from maven central that are no MC Plugins -->
@@ -111,10 +103,6 @@
     <repository>
       <id>betonquest-papermc-repo</id>
       <url>https://repo.papermc.io/repository/maven-public/</url>
-    </repository>
-    <repository>
-      <id>betonquest-minebench-repo</id>
-      <url>https://repo.minebench.de/</url>
     </repository>
     <repository>
       <id>maven_central</id>


### PR DESCRIPTION
<!-- Please describe your changes here. -->
The build module supplies transitive the compile dependency from core, but without the repositories. Without that you need to manually add the repositories in your own project or exclude the relevant dependencies from the build dependency.

---

### Related Issues

<!-- Issue number if existing. -->
Closes #XXXX

### Requirements
- [x] I made sure my contribution fulfills the [requirements](https://betonquest.org/DEV/Participate/Process/Submitting-Changes/#checklist).

### Reviewer's checklist

<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers and will be checked by them! -->
Did the contributor...
- [x]  ... test their changes?
- [x]  ... increment the [Version](https://betonquest.org/DEV/Participate/Misc/Versioning-and-Releasing/#versioning)?
- [x]  ... update the [Changelog](https://betonquest.org/DEV/Participate/Process/Maintaining-the-Changelog/)?
- [x]  ... update the [Documentation](https://betonquest.org/DEV/Participate/Process/Docs/Workflow/)?
- [x]  ... write a migration?
- [x]  ... clean the commit history?

Check if the build pipeline succeeded for this PR!
